### PR TITLE
Update Rhodonite v0.18.1 to v0.19.2

### DIFF
--- a/examples/rhodonite/oimo/balls/index.html
+++ b/examples/rhodonite/oimo/balls/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/box/index.html
+++ b/examples/rhodonite/oimo/box/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/domino/index.html
+++ b/examples/rhodonite/oimo/domino/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/football/index.html
+++ b/examples/rhodonite/oimo/football/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/football/index.js
+++ b/examples/rhodonite/oimo/football/index.js
@@ -3,6 +3,7 @@ import Rn from 'rhodonite';
 let entities = [];
 const PHYSICS_SCALE = 1/10;
 const BALL_SIZE = 15;
+let engine;
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
@@ -57,12 +58,9 @@ function getRgbColor( c )
 }
 
 const load = async function() {
-    await Rn.ModuleManager.getInstance().loadModule('webgl');
-    await Rn.ModuleManager.getInstance().loadModule('pbr');
-
     const c = document.getElementById('world');
 
-    await Rn.System.init({
+    engine = await Rn.Engine.init({
       approach: Rn.ProcessApproach.DataTexture,
       canvas: c,
     });
@@ -74,23 +72,20 @@ const load = async function() {
     });
 
     function resizeCanvas() {
-        Rn.System.resizeCanvas(window.innerWidth, window.innerHeight);
+        engine.resizeCanvas(window.innerWidth, window.innerHeight);
     }
 
-    const assets = await Rn.defaultAssetLoader.load({
-        grass: Rn.Texture.loadFromUrl('../../../../assets/textures/grass.jpg'),
-        football: Rn.Texture.loadFromUrl('../../../../assets/textures/football.png')
-    });
+    const grassTexture = await Rn.Texture.loadFromUrl(engine, '../../../../assets/textures/grass.jpg');
+    const footballTexture = await Rn.Texture.loadFromUrl(engine, '../../../../assets/textures/football.png');
 
-    const sampler = new Rn.Sampler({
+    const sampler = new Rn.Sampler(engine, {
       magFilter: Rn.TextureParameter.Linear,
       minFilter: Rn.TextureParameter.Linear,
       wrapS: Rn.TextureParameter.Repeat,
       wrapT: Rn.TextureParameter.Repeat,
     });
-    sampler.create();
     
-    const entity1 = Rn.MeshHelper.createCube({
+    const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
             move: false,
@@ -105,13 +100,13 @@ const load = async function() {
     });
     entity1.scale = Rn.Vector3.fromCopyArray([400 * PHYSICS_SCALE, 0.4 * PHYSICS_SCALE, 400 * PHYSICS_SCALE]);
     entity1.position = Rn.Vector3.fromCopyArray([0, -20 * PHYSICS_SCALE, 0]);
-    entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', assets.grass, sampler);
+    entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', grassTexture, sampler);
     entities.push(entity1);
 
-    populate(assets.football, sampler);
+    populate(footballTexture, sampler);
 
     // camera
-    const cameraEntity = Rn.createCameraControllerEntity();
+    const cameraEntity = Rn.createCameraControllerEntity(engine);
     cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 100.0 * PHYSICS_SCALE, 400 * PHYSICS_SCALE]);
     cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([0.0, 0.0, 0.0]);
     const cameraComponent = cameraEntity.getCamera();
@@ -121,20 +116,31 @@ const load = async function() {
     cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
     // Lights
-    const lightEntity1 = Rn.createLightEntity();
+    const lightEntity1 = Rn.createLightEntity(engine);
     const lightComponent1 = lightEntity1.getLight();
     lightComponent1.type = Rn.LightType.Directional;
     lightComponent1.intensity = 1.5;
     lightEntity1.localEulerAngles = Rn.Vector3.fromCopyArray([-Math.PI / 2, -Math.PI / 4, Math.PI / 4]);
 
-    const lightEntity2 = Rn.createLightEntity();
+    const lightEntity2 = Rn.createLightEntity(engine);
     const lightComponent2 = lightEntity2.getLight();
     lightComponent2.type = Rn.LightType.Directional;
     lightComponent2.intensity = 1.5;
     lightEntity2.localEulerAngles = Rn.Vector3.fromCopyArray([Math.PI / 2, Math.PI / 4, -Math.PI / 4]);
 
+    // renderPass
+    const renderPass = new Rn.RenderPass(engine);
+    renderPass.cameraComponent = cameraComponent;
+    renderPass.toClearColorBuffer = true;
+    renderPass.clearColor = Rn.Vector4.fromCopyArray4([0, 0, 0, 1]);
+    renderPass.addEntities(entities);
+
+    // expression
+    const expression = new Rn.Expression();
+    expression.addRenderPasses([renderPass]);
+
     const draw = function(time) {
-        Rn.System.processAuto();
+        engine.process([expression]);
 
         requestAnimationFrame(draw);
     }
@@ -153,7 +159,7 @@ function populate(texture, sampler) {
             const y1 = (30 + y * BALL_SIZE * 1.2) * PHYSICS_SCALE;
             const z1 = (1.0 * Math.random()) * PHYSICS_SCALE;
 
-            let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial({
+            let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
                 isLighting: true
             });
             modelMaterial.setParameter(
@@ -162,7 +168,7 @@ function populate(texture, sampler) {
             );
             modelMaterial.setTextureParameter('baseColorTexture', texture, sampler);
 
-            const entity = Rn.MeshHelper.createSphere({
+            const entity = Rn.MeshHelper.createSphere(engine, {
                 radius: BALL_SIZE / 2 * PHYSICS_SCALE,
                 widthSegments: 16,
                 heightSegments: 16,

--- a/examples/rhodonite/oimo/marbles/index.html
+++ b/examples/rhodonite/oimo/marbles/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/minimum/index.html
+++ b/examples/rhodonite/oimo/minimum/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/minimum/index.js
+++ b/examples/rhodonite/oimo/minimum/index.js
@@ -2,12 +2,12 @@ import Rn from 'rhodonite';
 
 const PHYSICS_SCALE = 1/10;
 
+let engine;
+
 const load = async function() {
-    await Rn.ModuleManager.getInstance().loadModule('webgl');
-    await Rn.ModuleManager.getInstance().loadModule('pbr');
     const c = document.getElementById('world');
 
-    await Rn.System.init({
+    engine = await Rn.Engine.init({
       approach: Rn.ProcessApproach.DataTexture,
       canvas: c,
     });
@@ -19,28 +19,25 @@ const load = async function() {
     });
 
     function resizeCanvas() {
-        Rn.System.resizeCanvas(window.innerWidth, window.innerHeight);
+        engine.resizeCanvas(window.innerWidth, window.innerHeight);
     }
     
     const entities = [];
 
-    const assets = await Rn.defaultAssetLoader.load({
-        texture: Rn.Texture.loadFromUrl('../../../../assets/textures/frog.jpg')
-    });
+    const texture = await Rn.Texture.loadFromUrl(engine, '../../../../assets/textures/frog.jpg');
 
-    const sampler = new Rn.Sampler({
+    const sampler = new Rn.Sampler(engine, {
       magFilter: Rn.TextureParameter.Linear,
       minFilter: Rn.TextureParameter.Linear,
       wrapS: Rn.TextureParameter.ClampToEdge,
       wrapT: Rn.TextureParameter.ClampToEdge,
     });
-    sampler.create();
     
-    const material = Rn.MaterialHelper.createClassicUberMaterial();
-    material.setTextureParameter('diffuseColorTexture', assets.texture, sampler)
+    const material = Rn.MaterialHelper.createClassicUberMaterial(engine);
+    material.setTextureParameter('diffuseColorTexture', texture, sampler)
 
     // Ground
-    const entity1 = Rn.MeshHelper.createCube({
+    const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
             move: false,
@@ -58,7 +55,7 @@ const load = async function() {
     entities.push(entity1);
 
     // Cube
-    const entity2 = Rn.MeshHelper.createCube({
+    const entity2 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
             move: true,
@@ -79,7 +76,7 @@ const load = async function() {
     const startTime = Date.now();
 
     // camera
-    const cameraEntity = Rn.createCameraControllerEntity();
+    const cameraEntity = Rn.createCameraControllerEntity(engine);
     cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 50 * PHYSICS_SCALE, 200 * PHYSICS_SCALE]);
     const cameraComponent = cameraEntity.getCamera();
     cameraComponent.zNear = 0.1;
@@ -88,7 +85,7 @@ const load = async function() {
     cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
     // renderPass
-    const renderPass = new Rn.RenderPass();
+    const renderPass = new Rn.RenderPass(engine);
     renderPass.cameraComponent = cameraComponent;
     renderPass.toClearColorBuffer = true;
     renderPass.clearColor = Rn.Vector4.fromCopyArray4([0, 0, 0, 1]);
@@ -99,7 +96,7 @@ const load = async function() {
     expression.addRenderPasses([renderPass]);
 
     const draw = function(time) {
-        Rn.System.process([expression]);
+        engine.process([expression]);
 
         requestAnimationFrame(draw);
     }

--- a/examples/rhodonite/oimo/shogi/index.html
+++ b/examples/rhodonite/oimo/shogi/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.18.1/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.2/esm/index.js"
     }
 }
 </script>


### PR DESCRIPTION
This pull request updates all Rhodonite physics demo examples (`balls`, `box`, `domino`, `football`) to use the new `Rn.Engine` API, replacing the older `Rn.System` and related static methods. The changes improve code consistency with the latest Rhodonite version, streamline initialization and resource creation, and modernize the rendering pipeline setup. It also updates the Rhodonite library version in HTML import maps.

**Upgrade to Rhodonite v0.19.2:**

* Updated the import map in all HTML files to use Rhodonite v0.19.2 instead of v0.18.1. [[1]](diffhunk://#diff-4b142243a9484aee26482736ee84f80b202329da1c76f4c8100f6de345668ff4L12-R12) [[2]](diffhunk://#diff-b93abcd3844c9eb33b08ba6cb4363bbae1399f844b6533d745f8c3b4014bc655L12-R12) [[3]](diffhunk://#diff-d876845de6c1ea438caa5bd90d120090af204c962769543b1701720aa4b2f265L12-R12) [[4]](diffhunk://#diff-57d06d1654f97bed36e7aaa2e9918ccd7345b53e8fa99dc6eed1112502946724L12-R12)

**Migration to `Rn.Engine` API:**

* Replaced `Rn.System.init` and `Rn.System.resizeCanvas` with `Rn.Engine.init` and instance methods like `engine.resizeCanvas` in all demos. [[1]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L15-R18) [[2]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L32-R55) [[3]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L60-R63) [[4]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L77-R87) [[5]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L60-R63) [[6]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L77-R87) [[7]](diffhunk://#diff-47b2f602ba5939d20aa73a5da1017ec93d4c66015239ed26b0096a553dfddf9aL60-R63)
* Updated resource creation and loading (textures, samplers, materials, meshes) to pass the `engine` instance as the first argument, ensuring compatibility with the new API. [[1]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L32-R55) [[2]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L155-R168) [[3]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L77-R87) [[4]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L155-R169) [[5]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L77-R87) [[6]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L158-R172) [[7]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L195-R209)
* Changed entity creation functions (`createCameraControllerEntity`, `createLightEntity`, mesh helpers) to use the new engine-based signatures. [[1]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L110-R107) [[2]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L120-R141) [[3]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L107-R108) [[4]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L123-R142) [[5]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L106-R109) [[6]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L124-R141)

**Rendering pipeline modernization:**

* Replaced the old `Rn.System.processAuto()` frame loop with the new `engine.process([expression])` approach, using `RenderPass` and `Expression` objects for rendering. [[1]](diffhunk://#diff-b138f156d605d3cdfec405ac3638b1383964c6684a8f9002c147b9793e865638L120-R141) [[2]](diffhunk://#diff-e6b096a9c7871dd6d8ef523c7c5241e0d42ed086fd96c5fa33ad17997ac8ac57L123-R142) [[3]](diffhunk://#diff-e6640b5fa523dcce8159716ebdc2a9fc227169e505fd0ef29fc73845d71ea0f7L124-R141)

These updates ensure the demos are aligned with current Rhodonite best practices and will be easier to maintain going forward.