### PR TITLE
Add WebGL2 and WebGPU domino examples with Oimo.js

### DIFF
--- a/examples/webgl2/oimo/domino/index.html
+++ b/examples/webgl2/oimo/domino/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGL 2.0 + Oimo.js Domino Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/oimo/1.0.9/oimo.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+#version 300 es
+#define PI 3.14159265359
+
+mat4 lookAt(in vec3 eye, in vec3 center, in vec3 up) {
+    vec3 w = normalize(eye - center);
+    vec3 u = normalize(cross(up, w));
+    vec3 v = normalize(cross(w, u));
+    return mat4(
+        u.x, v.x, w.x, 0.0,
+        u.y, v.y, w.y, 0.0,
+        u.z, v.z, w.z, 0.0,
+        -dot(u, eye), -dot(u, eye), -dot(w, eye), 1.0);
+}
+
+vec3 qtransform(in vec4 q, in vec3 p) {
+    return p + 2.0 * cross(cross(p, q.xyz) - q.w * p, q.xyz);
+}
+
+in vec3 position;
+in vec3 normal;
+in vec3 offset;
+in vec4 quat;
+in vec3 col;
+uniform mat4 pMatrix;
+out vec3 vColor;
+
+void main() {
+    mat4 vMatrix = lookAt(vec3(60.0, 50.0, 0.0), vec3(0.0), vec3(0.0, 1.0, 0.0));
+    vec3 nor = qtransform(quat, normal);
+    vec3 light = normalize(vec3(1.0));
+    vColor = col * max(dot(light, nor), 0.4);
+    vec3 pos = qtransform(quat, position);
+    pos += offset;
+    gl_Position = pMatrix * vMatrix * vec4(pos, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+#version 300 es
+precision mediump float;
+
+in vec3 vColor;
+out vec4 fragColor;
+
+void main() {
+    float fog = min(1.0, pow(gl_FragCoord.w, 2.0) * 5000.0);
+    vec3 col = pow(vColor * fog, vec3(0.8));
+    fragColor = vec4(col, 1.0);
+}
+</script>
+
+<canvas id="c" width="465" height="465"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgl2/oimo/domino/index.js
+++ b/examples/webgl2/oimo/domino/index.js
@@ -1,0 +1,265 @@
+// forked from gaziya's "Domino (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
+
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
+// ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
+// ‥‥‥‥‥■■■□□■□‥■■■
+// ‥‥‥‥■□■□□□■□□■■■
+// ‥‥‥‥■□■■□□□■□□□■
+// ‥‥‥‥■■□□□□■■■■■‥
+// ‥‥‥‥‥‥□□□□□□□■‥‥
+// ‥‥■■■■■〓■■■〓■‥‥‥
+// ‥■■■■■■■〓■■■〓‥‥■
+// □□■■■■■■〓〓〓〓〓‥‥■
+// □□□‥〓〓■〓〓□〓〓□〓■■
+// ‥□‥■〓〓〓〓〓〓〓〓〓〓■■
+// ‥‥■■■〓〓〓〓〓〓〓〓〓■■
+// ‥■■■〓〓〓〓〓〓〓‥‥‥‥‥
+// ‥■‥‥〓〓〓〓‥‥‥‥‥‥‥‥
+let dataSet = [
+    "無","無","無","無","無","無","無","無","無","無","無","無","無","肌","肌","肌",
+    "無","無","無","無","無","無","赤","赤","赤","赤","赤","無","無","肌","肌","肌",
+    "無","無","無","無","無","赤","赤","赤","赤","赤","赤","赤","赤","赤","肌","肌",
+    "無","無","無","無","無","茶","茶","茶","肌","肌","茶","肌","無","赤","赤","赤",
+    "無","無","無","無","茶","肌","茶","肌","肌","肌","茶","肌","肌","赤","赤","赤",
+    "無","無","無","無","茶","肌","茶","茶","肌","肌","肌","茶","肌","肌","肌","赤",
+    "無","無","無","無","茶","茶","肌","肌","肌","肌","茶","茶","茶","茶","赤","無",
+    "無","無","無","無","無","無","肌","肌","肌","肌","肌","肌","肌","赤","無","無",
+    "無","無","赤","赤","赤","赤","赤","青","赤","赤","赤","青","赤","無","無","無",
+    "無","赤","赤","赤","赤","赤","赤","赤","青","赤","赤","赤","青","無","無","茶",
+    "肌","肌","赤","赤","赤","赤","赤","赤","青","青","青","青","青","無","無","茶",
+    "肌","肌","肌","無","青","青","赤","青","青","黄","青","青","黄","青","茶","茶",
+    "無","肌","無","茶","青","青","青","青","青","青","青","青","青","青","茶","茶",
+    "無","無","茶","茶","茶","青","青","青","青","青","青","青","青","青","茶","茶",
+    "無","茶","茶","茶","青","青","青","青","青","青","青","無","無","無","無","無",
+    "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
+];
+
+function getRgbColor(c) {
+    let colorHash = {
+        "無": [0xDC/0xFF, 0xAA/0xFF, 0x6B/0xFF],
+        "白": [0xFF/0xFF, 0xFF/0xFF, 0xFF/0xFF],
+        "肌": [0xFF/0xFF, 0xCC/0xFF, 0xCC/0xFF],
+        "茶": [0x80/0xFF, 0x00/0xFF, 0x00/0xFF],
+        "赤": [0xFF/0xFF, 0x00/0xFF, 0x00/0xFF],
+        "黄": [0xFF/0xFF, 0xFF/0xFF, 0x00/0xFF],
+        "緑": [0x00/0xFF, 0xFF/0xFF, 0x00/0xFF],
+        "水": [0x00/0xFF, 0xFF/0xFF, 0xFF/0xFF],
+        "青": [0x00/0xFF, 0x00/0xFF, 0xFF/0xFF],
+        "紫": [0x80/0xFF, 0x00/0xFF, 0x80/0xFF]
+    };
+    return colorHash[c];
+}
+
+let canvas = document.getElementById("c");
+let gl = canvas.getContext("webgl2");
+gl.clearColor(0.05, 0.05, 0.1, 1.0);
+gl.enable(gl.DEPTH_TEST);
+gl.depthFunc(gl.LEQUAL);
+
+resizeCanvas();
+window.addEventListener("resize", resizeCanvas);
+
+function resizeCanvas() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+// --- Shader program ---
+let program = gl.createProgram();
+for (let i = 0; i < 2; i++) {
+    let shader = gl.createShader([gl.VERTEX_SHADER, gl.FRAGMENT_SHADER][i]);
+    gl.shaderSource(shader, [
+        document.getElementById('vs').textContent.trim(),
+        document.getElementById('fs').textContent.trim()
+    ][i]);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        alert(gl.getShaderInfoLog(shader));
+    }
+    gl.attachShader(program, shader);
+    gl.deleteShader(shader);
+}
+gl.linkProgram(program);
+gl.useProgram(program);
+
+let perspective = function (fovy, aspect, near, far) {
+    let v = 1 / Math.tan(fovy * Math.PI / 360.0);
+    let u = v / aspect;
+    let w = near - far;
+    return new Float32Array([
+        u, 0, 0, 0,
+        0, v, 0, 0,
+        0, 0, (near + far) / w, -1,
+        0, 0, near * far * 2 / w, 0
+    ]);
+};
+gl.uniformMatrix4fv(
+    gl.getUniformLocation(program, "pMatrix"),
+    false,
+    perspective(45, canvas.width / canvas.height, 0.1, 200)
+);
+
+// --- Geometry (box) ---
+let bw = 1, bh = 2, bd = 0.3;
+let position = new Float32Array([
+    -bw, -bh, -bd, -bw, -bh,  bd,  bw, -bh,  bd,  bw, -bh, -bd,
+    -bw,  bh, -bd, -bw,  bh,  bd,  bw,  bh,  bd,  bw,  bh, -bd,
+    -bw, -bh, -bd, -bw,  bh, -bd,  bw,  bh, -bd,  bw, -bh, -bd,
+    -bw, -bh,  bd, -bw,  bh,  bd,  bw,  bh,  bd,  bw, -bh,  bd,
+    -bw, -bh, -bd, -bw, -bh,  bd, -bw,  bh,  bd, -bw,  bh, -bd,
+     bw, -bh, -bd,  bw, -bh,  bd,  bw,  bh,  bd,  bw,  bh, -bd]);
+let normal = new Float32Array([
+     0, -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,  0,
+     0,  1,  0,  0,  1,  0,  0,  1,  0,  0,  1,  0,
+     0,  0, -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,
+     0,  0,  1,  0,  0,  1,  0,  0,  1,  0,  0,  1,
+    -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,  0,  0,
+     1,  0,  0,  1,  0,  0,  1,  0,  0,  1,  0,  0]);
+let indices = new Int16Array([
+     0,  2,  1,  0,  3,  2,
+     4,  5,  6,  4,  6,  7,
+     8,  9, 10,  8, 10, 11,
+    12, 15, 14, 12, 14, 13,
+    16, 17, 18, 16, 18, 19,
+    20, 23, 22, 20, 22, 21]);
+let indexBuffer = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+let indexCount = indices.length;
+
+// --- Vertex attribute locations ---
+let aPosition = gl.getAttribLocation(program, 'position');
+let aNormal   = gl.getAttribLocation(program, 'normal');
+let aOffset   = gl.getAttribLocation(program, 'offset');
+let aQuat     = gl.getAttribLocation(program, 'quat');
+let aCol      = gl.getAttribLocation(program, 'col');
+
+// Per-vertex buffers
+for (let i = 0; i < 2; i++) {
+    let buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, [position, normal][i], gl.STATIC_DRAW);
+    let loc = [aPosition, aNormal][i];
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 3, gl.FLOAT, false, 0, 0);
+}
+
+// Per-instance buffers
+let number = 256;
+let posArray  = new Float32Array(number * 3);
+let quatArray = new Float32Array(number * 4);
+let colArray  = new Float32Array(number * 3);
+
+let posBuffer  = gl.createBuffer();
+let quatBuffer = gl.createBuffer();
+let colBuffer  = gl.createBuffer();
+
+for (let i = 0; i < 3; i++) {
+    let buf  = [posBuffer, quatBuffer, colBuffer][i];
+    let data = [posArray, quatArray, colArray][i];
+    let loc  = [aOffset, aQuat, aCol][i];
+    let stride = [3, 4, 3][i];
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.DYNAMIC_DRAW);
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, stride, gl.FLOAT, false, 0, 0);
+    gl.vertexAttribDivisor(loc, 1);
+}
+
+// --- Physics ---
+let world = new OIMO.World({
+    timestep: 1 / 60,
+    iterations: 8,
+    broadphase: 2,
+    worldscale: 1,
+    random: true,
+    info: false,
+    gravity: [0, -9.8, 0]
+});
+
+world.add({
+    type: "box",
+    size: [100, 0.2, 100],
+    pos: [0, -0.1, 0],
+    rot: [0, 0, 0],
+    move: false,
+    density: 1
+});
+
+let bodys = [];
+for (let i = 0; i < number; i++) {
+    let x = (Math.floor(i / 16) - 8) * 3;
+    let y = bh;
+    let z = (8 - (i % 16)) * 3;
+    bodys[i] = world.add({
+        type: "box",
+        size: [bw * 2, bh * 2, bd * 2],
+        pos: [x, y, z],
+        rot: [0, 0, 0],
+        move: true,
+        density: 1
+    });
+}
+// Tilt first column to trigger chain reaction
+for (let i = 0; i < 16; i++) {
+    bodys[i * 16].resetRotation(-15, 0, 0);
+}
+
+// Assign colors from dataset
+for (let i = 0; i < number; i++) {
+    let color = getRgbColor(dataSet[i]);
+    colArray[i * 3 + 0] = color[0];
+    colArray[i * 3 + 1] = color[1];
+    colArray[i * 3 + 2] = color[2];
+}
+gl.bindBuffer(gl.ARRAY_BUFFER, colBuffer);
+gl.bufferData(gl.ARRAY_BUFFER, colArray, gl.STATIC_DRAW);
+
+// Re-bind element array after color setup
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
+function uploadInstanceData() {
+    let pIdx = 0, qIdx = 0;
+    for (let i = 0; i < number; i++) {
+        let p = bodys[i].getPosition();
+        posArray[pIdx++] = p.x;
+        posArray[pIdx++] = p.y;
+        posArray[pIdx++] = p.z;
+        let q = bodys[i].getQuaternion();
+        quatArray[qIdx++] = q.x;
+        quatArray[qIdx++] = q.y;
+        quatArray[qIdx++] = q.z;
+        quatArray[qIdx++] = q.w;
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, posBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, posArray, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, quatBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, quatArray, gl.DYNAMIC_DRAW);
+}
+uploadInstanceData();
+
+// --- Physics loop ---
+setInterval(function () {
+    world.step();
+    uploadInstanceData();
+}, 1000 / 60);
+
+// --- Render loop ---
+(function render() {
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.useProgram(program);
+
+    // Bind per-vertex buffers & instance buffers before draw
+    gl.bindBuffer(gl.ARRAY_BUFFER, posBuffer);
+    gl.vertexAttribPointer(aOffset, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, quatBuffer);
+    gl.vertexAttribPointer(aQuat, 4, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, colBuffer);
+    gl.vertexAttribPointer(aCol, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
+    gl.drawElementsInstanced(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, number);
+    requestAnimationFrame(render);
+})();

--- a/examples/webgl2/oimo/domino/style.css
+++ b/examples/webgl2/oimo/domino/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}

--- a/examples/webgpu/oimo/domino/index.html
+++ b/examples/webgpu/oimo/domino/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGPU + Oimo.js Domino Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/oimo/1.0.9/oimo.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+struct Uniforms {
+    pMatrix: mat4x4<f32>
+};
+@binding(0) @group(0) var<uniform> uniforms: Uniforms;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) vColor: vec3<f32>
+}
+
+fn qtransform(q: vec4<f32>, p: vec3<f32>) -> vec3<f32> {
+    return p + 2.0 * cross(cross(p, q.xyz) - q.w * p, q.xyz);
+}
+
+fn lookAt(eye: vec3<f32>, center: vec3<f32>, up: vec3<f32>) -> mat4x4<f32> {
+    let w = normalize(eye - center);
+    let u = normalize(cross(up, w));
+    let v = normalize(cross(w, u));
+    return mat4x4<f32>(
+        u.x, v.x, w.x, 0.0,
+        u.y, v.y, w.y, 0.0,
+        u.z, v.z, w.z, 0.0,
+        -dot(u, eye), -dot(u, eye), -dot(w, eye), 1.0
+    );
+}
+
+@vertex
+fn main(
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) offset: vec3<f32>,
+    @location(3) quat: vec4<f32>,
+    @location(4) col: vec3<f32>
+) -> VertexOutput {
+    var output: VertexOutput;
+
+    let vMatrix = lookAt(
+        vec3<f32>(60.0, 50.0, 0.0),
+        vec3<f32>(0.0, 0.0, 0.0),
+        vec3<f32>(0.0, 1.0, 0.0)
+    );
+
+    let nor   = qtransform(quat, normal);
+    let light = normalize(vec3<f32>(1.0, 1.0, 1.0));
+    output.vColor = col * max(dot(light, nor), 0.4);
+
+    let pos = qtransform(quat, position) + offset;
+    output.position = uniforms.pMatrix * vMatrix * vec4<f32>(pos, 1.0);
+    return output;
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+@fragment
+fn main(
+    @builtin(position) fragCoord: vec4<f32>,
+    @location(0) vColor: vec3<f32>
+) -> @location(0) vec4<f32> {
+    let fog = min(1.0, pow(fragCoord.w, 2.0) * 5000.0);
+    let col = pow(vColor * fog, vec3<f32>(0.8, 0.8, 0.8));
+    return vec4<f32>(col, 1.0);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgpu/oimo/domino/index.js
+++ b/examples/webgpu/oimo/domino/index.js
@@ -1,0 +1,329 @@
+// WebGPU + Oimo.js Domino Example
+// forked from gaziya's "Domino (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
+
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
+// ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
+// ‥‥‥‥‥■■■□□■□‥■■■
+// ‥‥‥‥■□■□□□■□□■■■
+// ‥‥‥‥■□■■□□□■□□□■
+// ‥‥‥‥■■□□□□■■■■■‥
+// ‥‥‥‥‥‥□□□□□□□■‥‥
+// ‥‥■■■■■〓■■■〓■‥‥‥
+// ‥■■■■■■■〓■■■〓‥‥■
+// □□■■■■■■〓〓〓〓〓‥‥■
+// □□□‥〓〓■〓〓□〓〓□〓■■
+// ‥□‥■〓〓〓〓〓〓〓〓〓〓■■
+// ‥‥■■■〓〓〓〓〓〓〓〓〓■■
+// ‥■■■〓〓〓〓〓〓〓‥‥‥‥‥
+// ‥■‥‥〓〓〓〓‥‥‥‥‥‥‥‥
+
+const dataSet = [
+    "無","無","無","無","無","無","無","無","無","無","無","無","無","肌","肌","肌",
+    "無","無","無","無","無","無","赤","赤","赤","赤","赤","無","無","肌","肌","肌",
+    "無","無","無","無","無","赤","赤","赤","赤","赤","赤","赤","赤","赤","肌","肌",
+    "無","無","無","無","無","茶","茶","茶","肌","肌","茶","肌","無","赤","赤","赤",
+    "無","無","無","無","茶","肌","茶","肌","肌","肌","茶","肌","肌","赤","赤","赤",
+    "無","無","無","無","茶","肌","茶","茶","肌","肌","肌","茶","肌","肌","肌","赤",
+    "無","無","無","無","茶","茶","肌","肌","肌","肌","茶","茶","茶","茶","赤","無",
+    "無","無","無","無","無","無","肌","肌","肌","肌","肌","肌","肌","赤","無","無",
+    "無","無","赤","赤","赤","赤","赤","青","赤","赤","赤","青","赤","無","無","無",
+    "無","赤","赤","赤","赤","赤","赤","赤","青","赤","赤","赤","青","無","無","茶",
+    "肌","肌","赤","赤","赤","赤","赤","赤","青","青","青","青","青","無","無","茶",
+    "肌","肌","肌","無","青","青","赤","青","青","黄","青","青","黄","青","茶","茶",
+    "無","肌","無","茶","青","青","青","青","青","青","青","青","青","青","茶","茶",
+    "無","無","茶","茶","茶","青","青","青","青","青","青","青","青","青","茶","茶",
+    "無","茶","茶","茶","青","青","青","青","青","青","青","無","無","無","無","無",
+    "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
+];
+
+const colorMap = {
+    "無": [0xDC/255, 0xAA/255, 0x6B/255],
+    "白": [1.0, 1.0, 1.0],
+    "肌": [1.0, 0xCC/255, 0xCC/255],
+    "茶": [0x80/255, 0.0, 0.0],
+    "赤": [1.0, 0.0, 0.0],
+    "黄": [1.0, 1.0, 0.0],
+    "緑": [0.0, 1.0, 0.0],
+    "水": [0.0, 1.0, 1.0],
+    "青": [0.0, 0.0, 1.0],
+    "紫": [0x80/255, 0.0, 0x80/255]
+};
+
+const NUMBER = 256;
+const BW = 1, BH = 2, BD = 0.3;
+
+let canvas, device, ctx, format;
+let pipeline, uniformBuffer, bindGroup;
+let positionBuf, normalBuf, indexBuf, indexCount;
+let offsetBuf, quatBuf, colBuf;
+let depthTexture;
+let world, bodys;
+let posArray, quatArray;
+
+async function init() {
+    canvas = document.getElementById('c');
+    canvas.width  = window.innerWidth;
+    canvas.height = window.innerHeight;
+
+    window.addEventListener('resize', () => {
+        canvas.width  = window.innerWidth;
+        canvas.height = window.innerHeight;
+        depthTexture.destroy();
+        depthTexture = createDepthTexture();
+        const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 200);
+        device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+    });
+
+    const gpu = navigator['gpu'];
+    if (!gpu) { alert('WebGPU is not supported.'); return; }
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) { alert('Failed to get GPU adapter.'); return; }
+    device = await adapter.requestDevice();
+
+    ctx = canvas.getContext('webgpu');
+    format = gpu.getPreferredCanvasFormat();
+    ctx.configure({ device, format, alphaMode: 'opaque' });
+
+    // --- Geometry ---
+    const positions = new Float32Array([
+        -BW, -BH, -BD, -BW, -BH,  BD,  BW, -BH,  BD,  BW, -BH, -BD,
+        -BW,  BH, -BD, -BW,  BH,  BD,  BW,  BH,  BD,  BW,  BH, -BD,
+        -BW, -BH, -BD, -BW,  BH, -BD,  BW,  BH, -BD,  BW, -BH, -BD,
+        -BW, -BH,  BD, -BW,  BH,  BD,  BW,  BH,  BD,  BW, -BH,  BD,
+        -BW, -BH, -BD, -BW, -BH,  BD, -BW,  BH,  BD, -BW,  BH, -BD,
+         BW, -BH, -BD,  BW, -BH,  BD,  BW,  BH,  BD,  BW,  BH, -BD]);
+    const normals = new Float32Array([
+         0, -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,  0,
+         0,  1,  0,  0,  1,  0,  0,  1,  0,  0,  1,  0,
+         0,  0, -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,
+         0,  0,  1,  0,  0,  1,  0,  0,  1,  0,  0,  1,
+        -1,  0,  0, -1,  0,  0, -1,  0,  0, -1,  0,  0,
+         1,  0,  0,  1,  0,  0,  1,  0,  0,  1,  0,  0]);
+    const indices = new Uint16Array([
+         0,  2,  1,  0,  3,  2,
+         4,  5,  6,  4,  6,  7,
+         8,  9, 10,  8, 10, 11,
+        12, 15, 14, 12, 14, 13,
+        16, 17, 18, 16, 18, 19,
+        20, 23, 22, 20, 22, 21]);
+    indexCount = indices.length;
+
+    positionBuf = makeVertexBuffer(positions);
+    normalBuf   = makeVertexBuffer(normals);
+    indexBuf    = makeIndexBuffer(indices);
+
+    // --- Instance buffers ---
+    posArray  = new Float32Array(NUMBER * 3);
+    quatArray = new Float32Array(NUMBER * 4);
+    const colData = new Float32Array(NUMBER * 3);
+    for (let i = 0; i < NUMBER; i++) {
+        const c = colorMap[dataSet[i]];
+        colData[i * 3 + 0] = c[0];
+        colData[i * 3 + 1] = c[1];
+        colData[i * 3 + 2] = c[2];
+    }
+
+    offsetBuf = device.createBuffer({
+        size: NUMBER * 3 * 4,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+    });
+    quatBuf = device.createBuffer({
+        size: NUMBER * 4 * 4,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+    });
+    colBuf = makeVertexBuffer(colData);
+
+    // --- Uniform buffer (perspective matrix 64 bytes) ---
+    uniformBuffer = device.createBuffer({
+        size: 64,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 200);
+    device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+
+    // --- Pipeline ---
+    const vModule = device.createShaderModule({ code: document.getElementById('vs').textContent });
+    const fModule = device.createShaderModule({ code: document.getElementById('fs').textContent });
+
+    pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: vModule,
+            entryPoint: 'main',
+            buffers: [
+                { arrayStride: 3*4, stepMode: 'vertex',   attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 3*4, stepMode: 'vertex',   attributes: [{ shaderLocation: 1, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 3*4, stepMode: 'instance', attributes: [{ shaderLocation: 2, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 4*4, stepMode: 'instance', attributes: [{ shaderLocation: 3, offset: 0, format: 'float32x4' }] },
+                { arrayStride: 3*4, stepMode: 'instance', attributes: [{ shaderLocation: 4, offset: 0, format: 'float32x3' }] }
+            ]
+        },
+        fragment: {
+            module: fModule,
+            entryPoint: 'main',
+            targets: [{ format }]
+        },
+        primitive: { topology: 'triangle-list' },
+        depthStencil: {
+            depthWriteEnabled: true,
+            depthCompare: 'less',
+            format: 'depth24plus-stencil8'
+        }
+    });
+
+    bindGroup = device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer: uniformBuffer } }]
+    });
+
+    depthTexture = createDepthTexture();
+
+    // --- Physics ---
+    world = new OIMO.World({
+        timestep: 1 / 60,
+        iterations: 8,
+        broadphase: 2,
+        worldscale: 1,
+        random: true,
+        info: false,
+        gravity: [0, -9.8, 0]
+    });
+
+    world.add({
+        type: 'box',
+        size: [100, 0.2, 100],
+        pos: [0, -0.1, 0],
+        rot: [0, 0, 0],
+        move: false,
+        density: 1
+    });
+
+    bodys = [];
+    for (let i = 0; i < NUMBER; i++) {
+        const x = (Math.floor(i / 16) - 8) * 3;
+        const y = BH;
+        const z = (8 - (i % 16)) * 3;
+        bodys[i] = world.add({
+            type: 'box',
+            size: [BW * 2, BH * 2, BD * 2],
+            pos: [x, y, z],
+            rot: [0, 0, 0],
+            move: true,
+            density: 1
+        });
+    }
+    // Tilt first column to trigger chain reaction
+    for (let i = 0; i < 16; i++) {
+        bodys[i * 16].resetRotation(-15, 0, 0);
+    }
+
+    uploadInstanceData();
+
+    setInterval(function () {
+        world.step();
+        uploadInstanceData();
+    }, 1000 / 60);
+
+    requestAnimationFrame(render);
+}
+
+function uploadInstanceData() {
+    let pIdx = 0, qIdx = 0;
+    for (let i = 0; i < NUMBER; i++) {
+        const p = bodys[i].getPosition();
+        posArray[pIdx++] = p.x;
+        posArray[pIdx++] = p.y;
+        posArray[pIdx++] = p.z;
+        const q = bodys[i].getQuaternion();
+        quatArray[qIdx++] = q.x;
+        quatArray[qIdx++] = q.y;
+        quatArray[qIdx++] = q.z;
+        quatArray[qIdx++] = q.w;
+    }
+    device.queue.writeBuffer(offsetBuf, 0, posArray);
+    device.queue.writeBuffer(quatBuf,   0, quatArray);
+}
+
+function makePerspective(fovy, aspect, near, far) {
+    const v = 1 / Math.tan(fovy * Math.PI / 360.0);
+    const u = v / aspect;
+    const w = near - far;
+    return new Float32Array([
+        u, 0, 0, 0,
+        0, v, 0, 0,
+        0, 0, (near + far) / w, -1,
+        0, 0, near * far * 2 / w, 0
+    ]);
+}
+
+function makeVertexBuffer(data) {
+    const buf = device.createBuffer({
+        size: data.byteLength,
+        usage: GPUBufferUsage.VERTEX,
+        mappedAtCreation: true
+    });
+    new Float32Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+}
+
+function makeIndexBuffer(data) {
+    const buf = device.createBuffer({
+        size: data.byteLength,
+        usage: GPUBufferUsage.INDEX,
+        mappedAtCreation: true
+    });
+    new Uint16Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+}
+
+function createDepthTexture() {
+    return device.createTexture({
+        size: { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+        format: 'depth24plus-stencil8',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT
+    });
+}
+
+function render() {
+    device.queue.writeBuffer(offsetBuf, 0, posArray);
+    device.queue.writeBuffer(quatBuf,   0, quatArray);
+
+    const textureView = ctx.getCurrentTexture().createView();
+    const commandEncoder = device.createCommandEncoder();
+    const passEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [{
+            view: textureView,
+            loadOp: 'clear',
+            clearValue: { r: 0.05, g: 0.05, b: 0.1, a: 1.0 },
+            storeOp: 'store'
+        }],
+        depthStencilAttachment: {
+            view: depthTexture.createView(),
+            depthClearValue: 1.0,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store',
+            stencilClearValue: 0,
+            stencilLoadOp: 'clear',
+            stencilStoreOp: 'store'
+        }
+    });
+
+    passEncoder.setPipeline(pipeline);
+    passEncoder.setVertexBuffer(0, positionBuf);
+    passEncoder.setVertexBuffer(1, normalBuf);
+    passEncoder.setVertexBuffer(2, offsetBuf);
+    passEncoder.setVertexBuffer(3, quatBuf);
+    passEncoder.setVertexBuffer(4, colBuf);
+    passEncoder.setIndexBuffer(indexBuf, 'uint16');
+    passEncoder.setBindGroup(0, bindGroup);
+    passEncoder.drawIndexed(indexCount, NUMBER, 0, 0, 0);
+
+    passEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    requestAnimationFrame(render);
+}
+
+init();

--- a/examples/webgpu/oimo/domino/style.css
+++ b/examples/webgpu/oimo/domino/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}


### PR DESCRIPTION
## Summary

Add domino chain-reaction examples for WebGL 2.0 and WebGPU using Oimo.js.

## Added Files

- `examples/webgl2/oimo/domino/` — WebGL2 domino example
  - Shaders written in `#version 300 es` (`in`/`out`/`fragColor`)
  - Uses native `drawElementsInstanced` + `vertexAttribDivisor` (no `ANGLE_instanced_arrays` extension needed)
- `examples/webgpu/oimo/domino/` — WebGPU domino example
  - WGSL shaders with `lookAt`, `qtransform`, and fog calculation
  - Instanced rendering via `drawIndexed`; physics state uploaded each frame with `writeBuffer`

## Common Behavior

- 256 dominoes arranged in a 16x16 grid
- Each domino is colored based on a character dot-art dataset
- The first column is tilted to trigger the chain reaction