### PR TITLE
Add WebGPU marbles cubemap and shading parity

### DIFF
--- a/examples/webgpu/oimo/marbles/index.html
+++ b/examples/webgpu/oimo/marbles/index.html
@@ -17,6 +17,8 @@ struct Uniforms {
     lightDir : vec4<f32>,
     params0 : vec4<f32>,
     params1 : vec4<f32>,
+    params2 : vec4<f32>,
+    flags : vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform> uniforms : Uniforms;
@@ -53,6 +55,8 @@ struct Uniforms {
     lightDir : vec4<f32>,
     params0 : vec4<f32>,
     params1 : vec4<f32>,
+    params2 : vec4<f32>,
+    flags : vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform> uniforms : Uniforms;
@@ -60,22 +64,102 @@ struct Uniforms {
 @group(0) @binding(2) var tex : texture_2d<f32>;
 @group(0) @binding(3) var iridescenceTex : texture_2d<f32>;
 @group(0) @binding(4) var iridescenceThicknessTex : texture_2d<f32>;
+@group(0) @binding(5) var envCubeTex : texture_cube<f32>;
 
 fn sq(x: f32) -> f32 {
     return x * x;
 }
 
+fn sq3(x: vec3<f32>) -> vec3<f32> {
+    return x * x;
+}
+
+fn saturate(x: f32) -> f32 {
+    return clamp(x, 0.0, 1.0);
+}
+
 fn fresnelSchlick(f0: vec3<f32>, cosTheta: f32) -> vec3<f32> {
-    let c = clamp(cosTheta, 0.0, 1.0);
+    let c = saturate(cosTheta);
     return f0 + (vec3<f32>(1.0) - f0) * pow(1.0 - c, 5.0);
 }
 
-fn rainbowFromThickness(thickness: f32, ndotv: f32) -> vec3<f32> {
-    let phase = thickness * 0.045 * (1.0 - ndotv * 0.65);
-    let r = 0.5 + 0.5 * sin(phase + 0.0);
-    let g = 0.5 + 0.5 * sin(phase + 2.0943951);
-    let b = 0.5 + 0.5 * sin(phase + 4.1887902);
-    return vec3<f32>(r, g, b);
+fn iorToFresnel0(transmittedIor: f32, incidentIor: f32) -> f32 {
+    return sq((transmittedIor - incidentIor) / (transmittedIor + incidentIor));
+}
+
+fn fresnel0ToIor(fresnel0: vec3<f32>) -> vec3<f32> {
+    let sqrtF0 = sqrt(fresnel0);
+    return (vec3<f32>(1.0) + sqrtF0) / (vec3<f32>(1.0) - sqrtF0);
+}
+
+fn evalSensitivity(opd: f32, shift: vec3<f32>) -> vec3<f32> {
+    let M_PI = 3.14159265359;
+    let XYZ_TO_REC709 = mat3x3<f32>(
+         3.2404542, -0.9692660,  0.0556434,
+        -1.5371385,  1.8760108, -0.2040259,
+        -0.4985314,  0.0415560,  1.0572252
+    );
+
+    let phase = 2.0 * M_PI * opd * 1.0e-9;
+    let val = vec3<f32>(5.4856e-13, 4.4201e-13, 5.2481e-13);
+    let pos = vec3<f32>(1.6810e+06, 1.7953e+06, 2.2084e+06);
+    let varv = vec3<f32>(4.3278e+09, 9.3046e+09, 6.6121e+09);
+
+    var xyz = val * sqrt(2.0 * M_PI * varv) * cos(pos * phase + shift) * exp(-sq(phase) * varv);
+    xyz.x += 9.7470e-14 * sqrt(2.0 * M_PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift.x) * exp(-4.5282e+09 * sq(phase));
+    xyz = xyz / vec3<f32>(1.0685e-7);
+
+    return XYZ_TO_REC709 * xyz;
+}
+
+fn evalIridescence(outsideIor: f32, eta2: f32, cosTheta1: f32, thinFilmThickness: f32, baseF0: vec3<f32>) -> vec3<f32> {
+    let M_PI = 3.14159265359;
+
+    let iridescenceIor = mix(outsideIor, eta2, smoothstep(0.0, 0.03, thinFilmThickness));
+    let sinTheta2Sq = sq(outsideIor / iridescenceIor) * (1.0 - sq(cosTheta1));
+    let cosTheta2Sq = 1.0 - sinTheta2Sq;
+    if (cosTheta2Sq < 0.0) {
+        return vec3<f32>(1.0);
+    }
+
+    let cosTheta2 = sqrt(cosTheta2Sq);
+    let r0 = iorToFresnel0(iridescenceIor, outsideIor);
+    let r12 = r0 + (1.0 - r0) * pow(1.0 - cosTheta1, 5.0);
+    let t121 = 1.0 - r12;
+
+    var phi12 = 0.0;
+    if (iridescenceIor < outsideIor) {
+        phi12 = M_PI;
+    }
+    let phi21 = M_PI - phi12;
+
+    let baseIOR = fresnel0ToIor(clamp(baseF0, vec3<f32>(0.0), vec3<f32>(0.9999)));
+    let r1 = sq3((baseIOR - vec3<f32>(iridescenceIor)) / (baseIOR + vec3<f32>(iridescenceIor)));
+    let r23 = fresnelSchlick(r1, cosTheta2);
+
+    var phi23 = vec3<f32>(0.0);
+    if (baseIOR.x < iridescenceIor) { phi23.x = M_PI; }
+    if (baseIOR.y < iridescenceIor) { phi23.y = M_PI; }
+    if (baseIOR.z < iridescenceIor) { phi23.z = M_PI; }
+
+    let opd = 2.0 * iridescenceIor * thinFilmThickness * cosTheta2;
+    let phi = vec3<f32>(phi21) + phi23;
+
+    let r123 = clamp(vec3<f32>(r12) * r23, vec3<f32>(1e-5), vec3<f32>(0.9999));
+    let rr123 = sqrt(r123);
+    let rs = sq3(vec3<f32>(t121)) * r23 / (vec3<f32>(1.0) - r123);
+
+    let c0 = vec3<f32>(r12) + rs;
+    var i = c0;
+
+    var cm = rs - vec3<f32>(t121);
+    for (var m: i32 = 1; m <= 2; m = m + 1) {
+        cm = cm * rr123;
+        let sm = 2.0 * evalSensitivity(f32(m) * opd, f32(m) * phi);
+        i = i + cm * sm;
+    }
+
+    return max(i, vec3<f32>(0.0));
 }
 
 @fragment
@@ -87,12 +171,29 @@ fn main(
     let lightDir = normalize(uniforms.lightDir.xyz);
     let N = normalize(normal);
     let V = normalize(uniforms.cameraPos.xyz - worldPos);
+    let H = normalize(lightDir + V);
     let ndotv = max(dot(N, V), 0.0);
-    let diffuse = max(dot(N, lightDir), 0.25);
+    let ndotl = max(dot(N, lightDir), 0.0);
+    let ndoth = max(dot(N, H), 0.0);
+
+    let envIntensity = uniforms.params1.w;
+    let envExposure = uniforms.params2.x;
+    let envDiffuseStrength = uniforms.params2.y;
+    let metallic = clamp(uniforms.params2.z, 0.0, 1.0);
+    let roughness = clamp(uniforms.params2.w, 0.04, 1.0);
+    let hasEnvCube = uniforms.flags.x > 0.5;
+    let unlitTextureOnly = uniforms.flags.y > 0.5;
+
+    let baseTex = textureSample(tex, samp, uv);
+    let base = uniforms.baseColor * baseTex;
+    if (unlitTextureOnly) {
+        return vec4<f32>(base.rgb, base.a);
+    }
 
     let ior = max(uniforms.params0.x, 1.0);
     let f0s = sq((ior - 1.0) / (ior + 1.0));
-    let fresnel = fresnelSchlick(vec3<f32>(f0s), ndotv);
+    let baseF0 = mix(vec3<f32>(f0s), base.rgb, metallic);
+    let fresnel = fresnelSchlick(baseF0, ndotv);
 
     var irFactor = uniforms.params0.y;
     if (uniforms.params0.w > 0.5) {
@@ -105,14 +206,75 @@ fn main(
         irThickness = mix(uniforms.params1.x, uniforms.params1.y, t);
     }
 
-    let rainbow = rainbowFromThickness(irThickness, ndotv);
-    let irFresnel = fresnel * rainbow;
-    let specColor = mix(fresnel, irFresnel, clamp(irFactor, 0.0, 1.0));
+    let irFresnel = evalIridescence(1.0, uniforms.params0.z, ndotv, irThickness, baseF0);
+    let specColor = mix(fresnel, irFresnel, clamp(irFactor * 1.25, 0.0, 1.0));
 
-    let texColor = textureSample(tex, samp, uv);
-    let base = uniforms.baseColor * texColor;
-    let color = base.rgb * diffuse + specColor * 0.6;
+    let shininess = mix(256.0, 8.0, roughness * roughness);
+    let specLobe = pow(max(ndoth, 0.0), shininess);
+    let kd = (1.0 - metallic) * (1.0 - max(max(specColor.r, specColor.g), specColor.b));
+    let directDiffuse = base.rgb * (0.15 + 0.85 * ndotl) * kd;
+    let directSpec = specColor * specLobe * mix(0.3, 1.1, metallic);
+
+    var color = directDiffuse + directSpec;
+
+    if (hasEnvCube) {
+        let R = normalize(reflect(-V, N));
+        let blurredR = normalize(mix(R, N, roughness * roughness));
+        let envDiffuse = textureSample(envCubeTex, samp, N).rgb * envExposure;
+        let envSpec = textureSample(envCubeTex, samp, blurredR).rgb * envExposure;
+        color += base.rgb * envDiffuse * ((0.08 + 0.22 * (1.0 - roughness)) * kd * envIntensity * envDiffuseStrength);
+        color += specColor * envSpec * ((0.65 + 0.55 * metallic) * envIntensity);
+    }
+
+    color = color / (color + vec3<f32>(1.0));
+    color = pow(color, vec3<f32>(1.0 / 2.2));
     return vec4<f32>(color, base.a);
+}
+</script>
+
+<script id="skybox-vs" type="x-shader/x-vertex">
+struct SkyboxUniforms {
+    projection : mat4x4<f32>,
+    viewNoTranslation : mat4x4<f32>,
+    exposure : f32,
+    _pad0 : vec3<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : SkyboxUniforms;
+
+struct VSOut {
+    @builtin(position) Position : vec4<f32>,
+    @location(0) dir : vec3<f32>,
+};
+
+@vertex
+fn main(@location(0) position : vec3<f32>) -> VSOut {
+    var out : VSOut;
+    out.dir = position;
+    let pos = uniforms.projection * uniforms.viewNoTranslation * vec4<f32>(position, 1.0);
+    out.Position = vec4<f32>(pos.xy, pos.w, pos.w);
+    return out;
+}
+</script>
+
+<script id="skybox-fs" type="x-shader/x-fragment">
+struct SkyboxUniforms {
+    projection : mat4x4<f32>,
+    viewNoTranslation : mat4x4<f32>,
+    exposure : f32,
+    _pad0 : vec3<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : SkyboxUniforms;
+@group(0) @binding(1) var samp : sampler;
+@group(0) @binding(2) var envCubeTex : texture_cube<f32>;
+
+@fragment
+fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
+    var env = textureSample(envCubeTex, samp, normalize(dir)).rgb * uniforms.exposure;
+    env = env / (env + vec3<f32>(1.0));
+    env = pow(env, vec3<f32>(1.0 / 2.2));
+    return vec4<f32>(env, 1.0);
 }
 </script>
 

--- a/examples/webgpu/oimo/marbles/index.js
+++ b/examples/webgpu/oimo/marbles/index.js
@@ -1,6 +1,8 @@
 const { mat4, vec3, quat } = glMatrix;
 
 const MARBLES_GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
+const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
+const ENV_HDR_URL = 'https://cx20.github.io/gltf-test/textures/hdr/papermill.hdr';
 const MARBLE_SCALE = 1.0;
 const MAX_MARBLES = 120;
 
@@ -13,16 +15,24 @@ let depthTexture;
 let pipeline;
 let sampler;
 let whiteTextureView;
+let blackCubeTextureView;
+let envCubeTextureView;
+let skyboxPipeline;
+let skyboxUniformBuffer;
+let skyboxBindGroup;
+let skyboxVertexBuffer;
 
 let world;
 const marbles = [];
 
 let groundMesh;
 let groundRenderItem;
+let groundTextureView;
 
 const projection = mat4.create();
 const view = mat4.create();
 const viewProj = mat4.create();
+const viewNoTranslation = mat4.create();
 
 function rand(min, max) {
     return min + Math.random() * (max - min);
@@ -234,6 +244,26 @@ function createSolidTextureView(r, g, b, a) {
     return texture.createView();
 }
 
+function createSolidCubeTextureView(r, g, b, a) {
+    const texture = device.createTexture({
+        size: [1, 1, 6],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    });
+
+    const pixel = new Uint8Array([r, g, b, a]);
+    for (let layer = 0; layer < 6; layer++) {
+        device.queue.writeTexture(
+            { texture, origin: { x: 0, y: 0, z: layer } },
+            pixel,
+            { bytesPerRow: 4, rowsPerImage: 1 },
+            { width: 1, height: 1, depthOrArrayLayers: 1 }
+        );
+    }
+
+    return texture.createView({ dimension: 'cube' });
+}
+
 async function loadTextureView(url) {
     const response = await fetch(url);
     const blob = await response.blob();
@@ -254,9 +284,186 @@ async function loadTextureView(url) {
     return texture.createView();
 }
 
-function createRenderItem(textureView, iridescenceTextureView, iridescenceThicknessTextureView) {
+function parseHDR(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let offset = 0;
+
+    function readLine() {
+        let line = '';
+        while (offset < bytes.length) {
+            const c = bytes[offset++];
+            if (c === 10) break;
+            if (c !== 13) line += String.fromCharCode(c);
+        }
+        return line;
+    }
+
+    let line = readLine();
+    if (!line.startsWith('#?RADIANCE') && !line.startsWith('#?RGBE')) {
+        throw new Error('Invalid HDR header.');
+    }
+
+    while (offset < bytes.length) {
+        line = readLine();
+        if (line.trim() === '') break;
+    }
+
+    const resolution = readLine();
+    const match = resolution.match(/-Y\s+(\d+)\s+\+X\s+(\d+)/);
+    if (!match) {
+        throw new Error('Unsupported HDR resolution format.');
+    }
+
+    const height = parseInt(match[1], 10);
+    const width = parseInt(match[2], 10);
+    const data = new Float32Array(width * height * 3);
+    const scanline = new Uint8Array(width * 4);
+
+    for (let y = 0; y < height; y++) {
+        if (offset + 4 > bytes.length) throw new Error('Unexpected HDR EOF.');
+
+        const b0 = bytes[offset++];
+        const b1 = bytes[offset++];
+        const b2 = bytes[offset++];
+        const b3 = bytes[offset++];
+        if (b0 !== 2 || b1 !== 2 || (b2 & 0x80) !== 0 || ((b2 << 8) | b3) !== width) {
+            throw new Error('Unsupported non-RLE HDR scanline.');
+        }
+
+        for (let c = 0; c < 4; c++) {
+            let x = 0;
+            while (x < width) {
+                const code = bytes[offset++];
+                if (code > 128) {
+                    const run = code - 128;
+                    const val = bytes[offset++];
+                    for (let i = 0; i < run; i++) scanline[c * width + x++] = val;
+                } else {
+                    const run = code;
+                    for (let i = 0; i < run; i++) scanline[c * width + x++] = bytes[offset++];
+                }
+            }
+        }
+
+        for (let x = 0; x < width; x++) {
+            const r = scanline[x];
+            const g = scanline[width + x];
+            const b = scanline[2 * width + x];
+            const e = scanline[3 * width + x];
+            const dst = (y * width + x) * 3;
+            if (e) {
+                const f = Math.pow(2.0, e - 136.0);
+                data[dst] = r * f;
+                data[dst + 1] = g * f;
+                data[dst + 2] = b * f;
+            }
+        }
+    }
+
+    return { width, height, data };
+}
+
+function sampleEquirectHDR(hdr, u, v) {
+    const w = hdr.width;
+    const h = hdr.height;
+    const uu = ((u % 1) + 1) % 1;
+    const vv = Math.min(Math.max(v, 0), 1);
+
+    const x = uu * (w - 1);
+    const y = vv * (h - 1);
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const x1 = (x0 + 1) % w;
+    const y1 = Math.min(y0 + 1, h - 1);
+    const tx = x - x0;
+    const ty = y - y0;
+
+    const i00 = (y0 * w + x0) * 3;
+    const i10 = (y0 * w + x1) * 3;
+    const i01 = (y1 * w + x0) * 3;
+    const i11 = (y1 * w + x1) * 3;
+
+    const c00 = [hdr.data[i00], hdr.data[i00 + 1], hdr.data[i00 + 2]];
+    const c10 = [hdr.data[i10], hdr.data[i10 + 1], hdr.data[i10 + 2]];
+    const c01 = [hdr.data[i01], hdr.data[i01 + 1], hdr.data[i01 + 2]];
+    const c11 = [hdr.data[i11], hdr.data[i11 + 1], hdr.data[i11 + 2]];
+
+    const c0 = [
+        c00[0] * (1 - tx) + c10[0] * tx,
+        c00[1] * (1 - tx) + c10[1] * tx,
+        c00[2] * (1 - tx) + c10[2] * tx
+    ];
+    const c1 = [
+        c01[0] * (1 - tx) + c11[0] * tx,
+        c01[1] * (1 - tx) + c11[1] * tx,
+        c01[2] * (1 - tx) + c11[2] * tx
+    ];
+
+    return [
+        c0[0] * (1 - ty) + c1[0] * ty,
+        c0[1] * (1 - ty) + c1[1] * ty,
+        c0[2] * (1 - ty) + c1[2] * ty
+    ];
+}
+
+function directionForCubeFace(faceIndex, u, v) {
+    if (faceIndex === 0) return vec3.normalize(vec3.create(), vec3.fromValues(1, -v, -u));
+    if (faceIndex === 1) return vec3.normalize(vec3.create(), vec3.fromValues(-1, -v, u));
+    if (faceIndex === 2) return vec3.normalize(vec3.create(), vec3.fromValues(u, 1, v));
+    if (faceIndex === 3) return vec3.normalize(vec3.create(), vec3.fromValues(u, -1, -v));
+    if (faceIndex === 4) return vec3.normalize(vec3.create(), vec3.fromValues(u, -v, 1));
+    return vec3.normalize(vec3.create(), vec3.fromValues(-u, -v, -1));
+}
+
+async function loadHDRAsCubeTextureView(url, size = 192) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error('Failed to fetch HDR: ' + response.status);
+    }
+
+    const buffer = await response.arrayBuffer();
+    const hdr = parseHDR(buffer);
+    const texture = device.createTexture({
+        size: [size, size, 6],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    });
+
+    for (let face = 0; face < 6; face++) {
+        const faceData = new Uint8Array(size * size * 4);
+        let p = 0;
+        for (let y = 0; y < size; y++) {
+            const vv = 2 * ((y + 0.5) / size) - 1;
+            for (let x = 0; x < size; x++) {
+                const uu = 2 * ((x + 0.5) / size) - 1;
+                const dir = directionForCubeFace(face, uu, vv);
+                const phi = Math.atan2(dir[2], dir[0]);
+                const theta = Math.acos(Math.min(Math.max(dir[1], -1), 1));
+                const eu = phi / (2 * Math.PI) + 0.5;
+                const ev = theta / Math.PI;
+                const c = sampleEquirectHDR(hdr, eu, ev);
+
+                faceData[p++] = Math.max(0, Math.min(255, Math.floor(Math.min(Math.max(c[0], 0), 1) * 255)));
+                faceData[p++] = Math.max(0, Math.min(255, Math.floor(Math.min(Math.max(c[1], 0), 1) * 255)));
+                faceData[p++] = Math.max(0, Math.min(255, Math.floor(Math.min(Math.max(c[2], 0), 1) * 255)));
+                faceData[p++] = 255;
+            }
+        }
+
+        device.queue.writeTexture(
+            { texture, origin: { x: 0, y: 0, z: face } },
+            faceData,
+            { bytesPerRow: size * 4, rowsPerImage: size },
+            { width: size, height: size, depthOrArrayLayers: 1 }
+        );
+    }
+
+    return texture.createView({ dimension: 'cube' });
+}
+
+function createRenderItem(textureView, iridescenceTextureView, iridescenceThicknessTextureView, envCubeView) {
     const uniformBuffer = device.createBuffer({
-        size: 208,
+        size: 240,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
@@ -267,7 +474,8 @@ function createRenderItem(textureView, iridescenceTextureView, iridescenceThickn
             { binding: 1, resource: sampler },
             { binding: 2, resource: textureView },
             { binding: 3, resource: iridescenceTextureView },
-            { binding: 4, resource: iridescenceThicknessTextureView }
+            { binding: 4, resource: iridescenceThicknessTextureView },
+            { binding: 5, resource: envCubeView }
         ]
     });
 
@@ -290,6 +498,18 @@ function writeUniforms(renderItem, modelMatrix, baseColor, cameraPos, materialPa
         materialParams.iridescenceThicknessMin,
         materialParams.iridescenceThicknessMax,
         materialParams.hasIridescenceThicknessMap,
+        materialParams.envIntensity
+    ]));
+    device.queue.writeBuffer(renderItem.uniformBuffer, 208, new Float32Array([
+        materialParams.envExposure,
+        materialParams.envDiffuseStrength,
+        materialParams.metallic,
+        materialParams.roughness
+    ]));
+    device.queue.writeBuffer(renderItem.uniformBuffer, 224, new Float32Array([
+        materialParams.hasEnvCube,
+        materialParams.unlitTextureOnly,
+        0.0,
         0.0
     ]));
 }
@@ -359,6 +579,8 @@ async function loadMarblesFromGLTF() {
             let iridescenceThicknessMax = 400.0;
             let hasIridescenceMap = 0.0;
             let hasIridescenceThicknessMap = 0.0;
+            let metallic = 1.0;
+            let roughness = 0.2;
             if (primitive.material !== undefined) {
                 const material = gltf.materials[primitive.material];
                 if (material && material.pbrMetallicRoughness) {
@@ -366,6 +588,8 @@ async function loadMarblesFromGLTF() {
                     if (pbr.baseColorFactor) {
                         baseColor = pbr.baseColorFactor;
                     }
+                    if (pbr.metallicFactor !== undefined) metallic = pbr.metallicFactor;
+                    if (pbr.roughnessFactor !== undefined) roughness = pbr.roughnessFactor;
                     if (pbr.baseColorTexture) {
                         textureView = await getTextureView(pbr.baseColorTexture.index);
                     }
@@ -394,7 +618,12 @@ async function loadMarblesFromGLTF() {
                 }
             }
 
-            const renderItem = createRenderItem(textureView, iridescenceTextureView, iridescenceThicknessTextureView);
+            const renderItem = createRenderItem(
+                textureView,
+                iridescenceTextureView,
+                iridescenceThicknessTextureView,
+                envCubeTextureView || blackCubeTextureView
+            );
             primitives.push({
                 mesh,
                 renderItem,
@@ -405,7 +634,9 @@ async function loadMarblesFromGLTF() {
                 iridescenceThicknessMin,
                 iridescenceThicknessMax,
                 hasIridescenceMap,
-                hasIridescenceThicknessMap
+                hasIridescenceThicknessMap,
+                metallic,
+                roughness
             });
         }
 
@@ -506,16 +737,20 @@ function drawMesh(pass, mesh, bindGroup) {
     pass.draw(mesh.vertexCount, 1, 0, 0);
 }
 
-function render(timeMs) {
-    world.step();
+function drawSkybox(encoder) {
+    if (!envCubeTextureView || !skyboxPipeline) return;
 
-    const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 10, Math.cos(t * 0.2) * 24);
-    mat4.lookAt(view, eye, [0, 2, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
-    mat4.multiply(viewProj, projection, view);
+    mat4.copy(viewNoTranslation, view);
+    viewNoTranslation[12] = 0;
+    viewNoTranslation[13] = 0;
+    viewNoTranslation[14] = 0;
 
-    const encoder = device.createCommandEncoder();
+    const skyboxUniformData = new Float32Array(40);
+    skyboxUniformData.set(projection, 0);
+    skyboxUniformData.set(viewNoTranslation, 16);
+    skyboxUniformData[32] = 1.0;
+    device.queue.writeBuffer(skyboxUniformBuffer, 0, skyboxUniformData);
+
     const pass = encoder.beginRenderPass({
         colorAttachments: [{
             view: context.getCurrentTexture().createView(),
@@ -527,6 +762,37 @@ function render(timeMs) {
             view: depthTexture.createView(),
             depthClearValue: 1.0,
             depthLoadOp: 'clear',
+            depthStoreOp: 'store'
+        }
+    });
+
+    pass.setPipeline(skyboxPipeline);
+    pass.setBindGroup(0, skyboxBindGroup);
+    pass.setVertexBuffer(0, skyboxVertexBuffer);
+    pass.draw(36, 1, 0, 0);
+    pass.end();
+}
+
+function render(timeMs) {
+    world.step();
+
+    const t = timeMs * 0.001;
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 10, Math.cos(t * 0.2) * 24);
+    mat4.lookAt(view, eye, [0, 2, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.multiply(viewProj, projection, view);
+
+    const encoder = device.createCommandEncoder();
+    drawSkybox(encoder);
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view: context.getCurrentTexture().createView(),
+            loadOp: 'load',
+            storeOp: 'store'
+        }],
+        depthStencilAttachment: {
+            view: depthTexture.createView(),
+            depthLoadOp: 'load',
             depthStoreOp: 'store'
         }
     });
@@ -543,7 +809,14 @@ function render(timeMs) {
         hasIridescenceMap: 0.0,
         iridescenceThicknessMin: 100.0,
         iridescenceThicknessMax: 400.0,
-        hasIridescenceThicknessMap: 0.0
+        hasIridescenceThicknessMap: 0.0,
+        envIntensity: 0.55,
+        envExposure: 0.92,
+        envDiffuseStrength: 0.18,
+        metallic: 0.0,
+        roughness: 1.0,
+                hasEnvCube: 0.0,
+        unlitTextureOnly: 1.0
     });
     drawMesh(pass, groundMesh, groundRenderItem.bindGroup);
 
@@ -568,7 +841,14 @@ function render(timeMs) {
                 hasIridescenceMap: prim.hasIridescenceMap,
                 iridescenceThicknessMin: prim.iridescenceThicknessMin,
                 iridescenceThicknessMax: prim.iridescenceThicknessMax,
-                hasIridescenceThicknessMap: prim.hasIridescenceThicknessMap
+                hasIridescenceThicknessMap: prim.hasIridescenceThicknessMap,
+                envIntensity: 1.0,
+                envExposure: 1.0,
+                envDiffuseStrength: 1.0,
+                metallic: prim.metallic,
+                roughness: prim.roughness,
+                hasEnvCube: envCubeTextureView ? 1.0 : 0.0,
+                unlitTextureOnly: 0.0
             });
             drawMesh(pass, prim.mesh, prim.renderItem.bindGroup);
         }
@@ -640,12 +920,83 @@ async function main() {
     });
 
     whiteTextureView = createSolidTextureView(255, 255, 255, 255);
+    blackCubeTextureView = createSolidCubeTextureView(0, 0, 0, 255);
+    try {
+        envCubeTextureView = await loadHDRAsCubeTextureView(ENV_HDR_URL, 192);
+    } catch (e) {
+        console.warn('HDR cube map load failed:', e);
+        envCubeTextureView = null;
+    }
+    groundTextureView = await loadTextureView(GROUND_TEXTURE_FILE);
+
+    const skyboxVs = device.createShaderModule({ code: document.getElementById('skybox-vs').textContent });
+    const skyboxFs = device.createShaderModule({ code: document.getElementById('skybox-fs').textContent });
+    skyboxPipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: skyboxVs,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: {
+            module: skyboxFs,
+            entryPoint: 'main',
+            targets: [{ format }]
+        },
+        primitive: {
+            topology: 'triangle-list',
+            cullMode: 'none'
+        },
+        depthStencil: {
+            format: 'depth24plus',
+            depthWriteEnabled: false,
+            depthCompare: 'less-equal'
+        }
+    });
+
+    const skyboxVerts = new Float32Array([
+        -1, -1, -1,  1, -1, -1,  1,  1, -1,
+        -1, -1, -1,  1,  1, -1, -1,  1, -1,
+        -1, -1,  1,  1, -1,  1,  1,  1,  1,
+        -1, -1,  1,  1,  1,  1, -1,  1,  1,
+        -1, -1, -1, -1,  1, -1, -1,  1,  1,
+        -1, -1, -1, -1,  1,  1, -1, -1,  1,
+         1, -1, -1,  1,  1, -1,  1,  1,  1,
+         1, -1, -1,  1,  1,  1,  1, -1,  1,
+        -1, -1, -1, -1, -1,  1,  1, -1,  1,
+        -1, -1, -1,  1, -1,  1,  1, -1, -1,
+        -1,  1, -1, -1,  1,  1,  1,  1,  1,
+        -1,  1, -1,  1,  1,  1,  1,  1, -1
+    ]);
+    skyboxVertexBuffer = device.createBuffer({
+        size: skyboxVerts.byteLength,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+    });
+    device.queue.writeBuffer(skyboxVertexBuffer, 0, skyboxVerts);
+
+    skyboxUniformBuffer = device.createBuffer({
+        size: 40 * 4,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    skyboxBindGroup = device.createBindGroup({
+        layout: skyboxPipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: skyboxUniformBuffer } },
+            { binding: 1, resource: sampler },
+            { binding: 2, resource: envCubeTextureView || blackCubeTextureView }
+        ]
+    });
 
     resize();
     window.addEventListener('resize', resize);
 
     groundMesh = createGroundMesh();
-    groundRenderItem = createRenderItem(whiteTextureView, whiteTextureView, whiteTextureView);
+    groundRenderItem = createRenderItem(
+        groundTextureView,
+        whiteTextureView,
+        whiteTextureView,
+        envCubeTextureView || blackCubeTextureView
+    );
 
     const templates = await loadMarblesFromGLTF();
     initPhysics(templates);


### PR DESCRIPTION
Implement WebGPU parity updates for the Oimo marbles example.

- add grass floor texture rendering
- add HDR cubemap loading and skybox rendering
- add environment cubemap lighting in WGSL
- align iridescence shading with the WebGL2 implementation
- fix skybox uniform buffer sizing for WebGPU validation
