### PR TITLE
Normalize minimum demo scales and camera distances across engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,19 @@ Examples of WebGL Physics Library.
 |[Babylon.js](https://github.com/BabylonJS/Babylon.js)        |                                                                                        |                                                                                                                                                                                    |[Link](https://cx20.github.io/webgl-physics-examples/examples/babylonjs/havok/cone/)        |                                                                                                                                                                                       |
 |[PlayCanvas](https://github.com/playcanvas/engine)           |[Link](https://cx20.github.io/webgl-physics-examples/examples/playcanvas/ammo/cone/)    |                                                                                                                                                                                    |                                                                                              |                                                                                                                                                                                       |
 |[three.js](https://github.com/mrdoob/three.js/)              |                                                                                        |                                                                                                                                                                                    |                                                                                              |[Link1](https://cx20.github.io/webgl-physics-examples/examples/threejs/oimo/cone/) / [Link2](https://cx20.github.io/webgl-physics-examples/examples/threejs/oimophysics/cone/)        |
+
+## Physics Library Unit Systems
+
+All physics libraries used in this project adopt the **SI (International System of Units)**: meters (m), kilograms (kg), seconds (s), and newtons (N).  
+The convention **1 unit = 1 meter** is recommended for stable simulation results.
+
+| Library | Unit System | Recommended Scale | Notes |
+|:--------|:------------|:------------------|:------|
+| [ammo.js](https://github.com/kripken/ammo.js/) (Bullet) | SI (m / kg / s / N) | 0.05 – 10 m | Most sensitive to scale; official docs strongly recommend matching real-world meter scale |
+| [Cannon.js](https://github.com/schteppe/cannon.js) / [cannon-es](https://github.com/pmndrs/cannon-es) | SI (m / kg / s / N) | Flexible | Relatively tolerant of scale variation |
+| [Havok](https://doc.babylonjs.com/features/featuresDeepDive/physics) | SI (m / kg / s / N) | 0.1 – 10 m | |
+| [Oimo.js](https://github.com/lo-th/Oimo.js/) / [OimoPhysics](https://github.com/saharan/OimoPhysics) | SI (m / kg / s / N) | 0.1 – 10 m | |
+| [PhysX](https://github.com/fabmax/physx-js-webidl) | SI (m / kg / s / N) | 0.1 – 10 m | |
+| [rapier](https://github.com/dimforge/rapier) | SI (m / kg / s / N) | Flexible | Good numerical stability across a wide range of scales |
+
+> **Tip:** Objects smaller than ~0.05 m or larger than ~100 m may cause floating-point instability (jitter, tunneling). Keep rigid bodies within the recommended scale range for best results.

--- a/examples/ashes/oimo/minimum/index.js
+++ b/examples/ashes/oimo/minimum/index.js
@@ -12,7 +12,7 @@ async function main() {
 
     // Set default position
     let cameraTrans = mainCamera.components.Transform;
-    vec3.set(cameraTrans.translate, 0, 0, 200);
+    vec3.set(cameraTrans.translate, 0, 3, 6);
 
     // Add it to scene
     scene.appendChild(mainCamera);
@@ -45,15 +45,15 @@ async function main() {
     EntityMgr.addComponent(entityCube2, textureMR2);
     EntityMgr.addComponent(entityCube1, new OimoComponent(
         "box",
-        [50*2, 50*2, 50*2],
-        [0, 100, 0],
+        [1, 1, 1],
+        [0, 2, 0],
         [10, 0, 10],
         true
     ));
     EntityMgr.addComponent(entityCube2, new OimoComponent(
         "box",
-        [200*2, 4*2, 200*2],
-        [0, -50, 0],
+        [4, 0.1, 4],
+        [0, 0, 0],
         [0, 0, 0],
         false
     ));

--- a/examples/claygl/oimo/minimum/index.js
+++ b/examples/claygl/oimo/minimum/index.js
@@ -12,7 +12,7 @@ let app = clay.application.create('#main', {
         
         // Create a orthographic camera
         this._camera = app.createCamera(null, null, 'perspective');
-        this._camera.position.set(0, 50, 400);
+        this._camera.position.set(0, 3, 6);
         app.resize(window.innerWidth, window.innerHeight);
         
         // Create geometry
@@ -28,8 +28,8 @@ let app = clay.application.create('#main', {
                 
         this._oimoCube = this._world.add({
             type: "box",
-            size: [50*2, 50*2, 50*2],
-            pos: [0, 100, 0],
+            size: [1, 1, 1],
+            pos: [0, 2, 0],
             rot: [10, 0, 10],
             move: true,
             density: 1
@@ -37,8 +37,8 @@ let app = clay.application.create('#main', {
         
         this._oimoGround = this._world.add({
            type: "box",
-            size: [200*2, 4*2, 200*2],
-            pos: [0, -50, 0],
+            size: [4, 0.1, 4],
+            pos: [0, 0, 0],
             rot: [0, 0, 0],
             move: false,
             density: 1
@@ -47,11 +47,13 @@ let app = clay.application.create('#main', {
         this._rad = 0;
          
         this._meshCube = app.createMesh(geometryCube, material);
-        this._meshCube.scale.set(50, 50, 50);
-        this._meshCube.position.set(0, 100, 0);
+        // clay.geometry.Cube has a base size of 2, so use half scale to match Oimo size 1.
+        this._meshCube.scale.set(0.5, 0.5, 0.5);
+        this._meshCube.position.set(0, 2, 0);
         this._meshGround = app.createMesh(geometryGround, material);
-        this._meshGround.scale.set(200, 4, 200);
-        this._meshGround.position.set(0, -50, 0);
+        // Keep render scale aligned with Oimo size [4, 0.1, 4].
+        this._meshGround.scale.set(2, 0.05, 2);
+        this._meshGround.position.set(0, 0, 0);
         let diffuse = new clay.Texture2D;
         diffuse.load("../../../../assets/textures/frog.jpg");
         material.set('diffuseMap', diffuse);

--- a/examples/czpg/oimo/minimum/index.js
+++ b/examples/czpg/oimo/minimum/index.js
@@ -14,8 +14,8 @@ function initOimo() {
 
     let groundBody = world.add({
         type: "box",
-        size: [200, 2, 200],
-        pos: [0, -20, 0],
+        size: [4, 0.1, 4],
+        pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -24,8 +24,8 @@ function initOimo() {
     });
     body = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 0, 10],
         move: true,
         density: 1,
@@ -52,8 +52,8 @@ function initCzpg() {
     controler = scene.controler;
     context.canvas.width = window.innerWidth;
     context.canvas.height = window.innerHeight;    
-    camera = new CZPG.PerspectiveCamera(45, context.canvas.width/context.canvas.height, 0.01, 2000);
-    camera.position = [0, 50, 200];
+    camera = new CZPG.PerspectiveCamera(45, context.canvas.width/context.canvas.height, 0.01, 100);
+    camera.position = [0, 3, 6];
     camera.updateViewMatrix(); // lookAt target is [0,0,0] by default
     // Is there need a orbit control? cause it rotate by default...
     cameraControler = new CZPG.OrbitControls(camera, context.canvas, controler);
@@ -69,13 +69,13 @@ function initCzpg() {
     });
 
     modelCube = CZPG.Cube.createModel();
-    modelCube.scale = [50, 50, 50];
+    modelCube.scale = [1, 1, 1];
     shader = new CZPG.FlatTextureShader(context, camera, textures.pic);
     scene.add({shader: shader, model: modelCube});
 
     modelGround = CZPG.Cube.createModel();
-    modelGround.position = [0, -20, 0];
-    modelGround.scale = [200, 2, 200];
+    modelGround.position = [0, 0, 0];
+    modelGround.scale = [4, 0.1, 4];
     scene.add({shader: shader, model: modelGround});
 
 }

--- a/examples/glboost/oimo/minimum/index.js
+++ b/examples/glboost/oimo/minimum/index.js
@@ -21,8 +21,8 @@ function initOimo() {
 
     groundBody = world.add({
         type: "box",
-        size: [200, 2, 200],
-        pos: [0, -20, 0],
+        size: [4, 0.1, 4],
+        pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -31,8 +31,8 @@ function initOimo() {
     });
     body = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 0, 10],
         move: true,
         density: 1,
@@ -56,7 +56,7 @@ function initBoost() {
     material.setTexture(texture);
     material.baseColor = new GLBoost.Vector4(1, 1, 1, 1);
     
-    let geometryGround = glBoostContext.createCube(new GLBoost.Vector3(200, 2, 200), new GLBoost.Vector4(1, 1, 1, 1));
+    let geometryGround = glBoostContext.createCube(new GLBoost.Vector3(4, 0.1, 4), new GLBoost.Vector4(1, 1, 1, 1));
     meshGround = glBoostContext.createMesh(geometryGround, material);
     scene.addChild(meshGround);
 
@@ -65,7 +65,7 @@ function initBoost() {
     meshGround.translate = new GLBoost.Vector3(p.x, p.y, p.z);
     meshGround.quaternion = new GLBoost.Quaternion(q.x, q.y, q.z, q.w);
 
-    let geometryCube = glBoostContext.createCube(new GLBoost.Vector3(50, 50, 50), new GLBoost.Vector4(1, 1, 1, 1));
+    let geometryCube = glBoostContext.createCube(new GLBoost.Vector3(1, 1, 1), new GLBoost.Vector4(1, 1, 1, 1));
     meshCube = glBoostContext.createMesh(geometryCube, material);
     scene.addChild(meshCube);
     
@@ -73,14 +73,14 @@ function initBoost() {
     scene.addChild( directionalLight );
     
     camera = glBoostContext.createPerspectiveCamera({
-        eye: new GLBoost.Vector3(0.0, 50, 100),
-        center: new GLBoost.Vector3(0.0, 0.0, 0.0),
+        eye: new GLBoost.Vector3(0.0, 1.8, 3.2),
+        center: new GLBoost.Vector3(0.0, 0.5, 0.0),
         up: new GLBoost.Vector3(0.0, 1.0, 0.0)
     }, {
         fovy: 45.0,
         aspect: width/height,
         zNear: 0.001,
-        zFar: 3000.0
+        zFar: 100.0
     });
     camera.cameraController = glBoostContext.createCameraController();
     scene.addChild(camera);

--- a/examples/grimoirejs/oimo/minimum/index.html
+++ b/examples/grimoirejs/oimo/minimum/index.html
@@ -12,12 +12,12 @@
 <script type="text/goml" id="main">
   <goml width="fit" height="fit">
       <scene>
-          <camera class="camera" position="0,10,30">
+          <camera class="camera" position="0,3,6">
               <camera.components>
                   <MouseCameraControl></MouseCameraControl>
               </camera.components>
           </camera>
-          <rigid-cube geometry="cube" position="0,-5,0" scale="20, 0.5, 20" texture="../../../../assets/textures/frog.jpg" move="false">
+          <rigid-cube geometry="cube" position="0,0,0" scale="2, 0.05, 2" texture="../../../../assets/textures/frog.jpg" move="false">
           </rigid-cube>
           <light type="directional" rotation="-30d,30d,0d"  color="white" intensity="4.0"/>
           <light type="directional" rotation="0d,-150d,0d" color="white" intensity="4.0"/>

--- a/examples/grimoirejs/oimo/minimum/index.js
+++ b/examples/grimoirejs/oimo/minimum/index.js
@@ -2,7 +2,7 @@ const Quaternion = gr.lib.math.Quaternion;
 gr(function() {
     const scene = gr("#main")("scene").single();
     const n = scene.addChildByName("rigid-cube", {
-        position: [Math.random() * 3 - 1.5, Math.random() * 5 + 5, Math.random() * 3 - 1.5]
+        position: [Math.random() * 1 - 0.5, Math.random() * 0.5 + 2, Math.random() * 1 - 0.5]
     });
 });
 
@@ -54,7 +54,7 @@ gr.register(() => {
     });
     gr.registerNode("rigid-cube", ["Rigid"], {
         geometry: "cube",
-        scale: 5,
+        scale: 0.5,
         texture: "../../../../assets/textures/frog.jpg"
     }, "mesh");
 });

--- a/examples/grimoirejs/oimophysics/minimum/index.html
+++ b/examples/grimoirejs/oimophysics/minimum/index.html
@@ -12,12 +12,12 @@
 <script type="text/goml" id="main">
   <goml width="fit" height="fit">
       <scene>
-          <camera class="camera" position="0,10,30">
+          <camera class="camera" position="0,3,6">
               <camera.components>
                   <MouseCameraControl></MouseCameraControl>
               </camera.components>
           </camera>
-          <rigid-cube geometry="cube" position="0,-5,0" scale="20, 0.5, 20" texture="../../../../assets/textures/frog.jpg" move="false">
+          <rigid-cube geometry="cube" position="0,0,0" scale="2, 0.05, 2" texture="../../../../assets/textures/frog.jpg" move="false">
           </rigid-cube>
           <light type="directional" rotation="-30d,30d,0d"  color="white" intensity="4.0"/>
           <light type="directional" rotation="0d,-150d,0d" color="white" intensity="4.0"/>

--- a/examples/grimoirejs/oimophysics/minimum/index.js
+++ b/examples/grimoirejs/oimophysics/minimum/index.js
@@ -2,7 +2,7 @@ const Quaternion = gr.lib.math.Quaternion;
 gr(function() {
     const scene = gr("#main")("scene").single();
     const n = scene.addChildByName("rigid-cube", {
-        position: [Math.random() * 3 - 1.5, Math.random() * 5 + 5, Math.random() * 3 - 1.5]
+        position: [Math.random() * 1 - 0.5, Math.random() * 0.5 + 2, Math.random() * 1 - 0.5]
     });
 });
 
@@ -56,7 +56,7 @@ gr.register(() => {
     });
     gr.registerNode("rigid-cube", ["Rigid"], {
         geometry: "cube",
-        scale: 5,
+        scale: 0.5,
         texture: "../../../../assets/textures/frog.jpg"
     }, "mesh");
 });

--- a/examples/hilo3d/oimo/minimum/index.js
+++ b/examples/hilo3d/oimo/minimum/index.js
@@ -14,11 +14,11 @@ let rad = 0;
 function initScene() {
     camera = new Hilo3d.PerspectiveCamera({
         aspect: innerWidth / innerHeight,
-        far: 1000,
+        far: 100,
         near: 0.1,
         x: 0,
-        y: 50,
-        z: 200
+        y: 3,
+        z: 6
     });
 
     stage = new Hilo3d.Stage({
@@ -47,9 +47,9 @@ function addGround() {
     geometryGround.setAllRectUV([[0, 1], [1, 1], [1, 0], [0, 0]]);
 
     meshGround = new Hilo3d.Mesh({
-        scaleX: 200,
-        scaleY: 4,
-        scaleZ: 200,
+        scaleX: 4,
+        scaleY: 0.1,
+        scaleZ: 4,
         x: 0,
         y: 0,
         z: 0,
@@ -64,7 +64,7 @@ function addGround() {
 
     oimoGround = world.add({
         type: "box",
-        size: [200, 4, 200],
+        size: [4, 0.1, 4],
         pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
@@ -83,11 +83,11 @@ function addBox() {
     geometryBox.setAllRectUV([[0, 1], [1, 1], [1, 0], [0, 0]]);
 
     meshBox = new Hilo3d.Mesh({
-        scaleX: 50,
-        scaleY: 50,
-        scaleZ: 50,
+        scaleX: 1,
+        scaleY: 1,
+        scaleZ: 1,
         x: 0,
-        y: 100,
+        y: 2,
         z: 0,
         geometry: geometryBox,
         material: new Hilo3d.BasicMaterial({
@@ -102,8 +102,8 @@ function addBox() {
 
     oimoBox = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 0, 10],
         move: true,
         density: 1
@@ -122,7 +122,7 @@ function animate() {
         meshBox.quaternion.set(rot.x, rot.y, rot.z, rot.w);
         
         camera.lookAt( new Hilo3d.Vector3(0,0,0));
-        camera.setPosition( 200 * Math.sin(rad), 50, 200 * Math.cos(rad));
+        camera.setPosition( 6 * Math.sin(rad), 3, 6 * Math.cos(rad));
         
         rad += Math.PI/180 * 0.1;
     };

--- a/examples/rhodonite/oimo/minimum/index.js
+++ b/examples/rhodonite/oimo/minimum/index.js
@@ -1,7 +1,5 @@
 import Rn from 'rhodonite';
 
-const PHYSICS_SCALE = 1/10;
-
 let engine;
 
 const load = async function() {
@@ -51,7 +49,7 @@ const load = async function() {
         tag: "type",
         value: "ground"
     });
-    entity1.scale = Rn.Vector3.fromCopyArray([200 / 2 * PHYSICS_SCALE, 2 / 2 * PHYSICS_SCALE, 200 / 2 * PHYSICS_SCALE]);
+    entity1.scale = Rn.Vector3.fromCopyArray([2, 0.05, 2]);
     entities.push(entity1);
 
     // Cube
@@ -69,18 +67,18 @@ const load = async function() {
         tag: "type",
         value: "cube"
     });
-    entity2.position = Rn.Vector3.fromCopyArray([0, 100 * PHYSICS_SCALE, 0]);
-    entity2.scale = Rn.Vector3.fromCopyArray([50 / 2 * PHYSICS_SCALE, 50 / 2 * PHYSICS_SCALE, 50 / 2 * PHYSICS_SCALE]);
+    entity2.position = Rn.Vector3.fromCopyArray([0, 2, 0]);
+    entity2.scale = Rn.Vector3.fromCopyArray([0.5, 0.5, 0.5]);
     entities.push(entity2);
 
     const startTime = Date.now();
 
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
-    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 50 * PHYSICS_SCALE, 200 * PHYSICS_SCALE]);
+    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0, 3, 6]);
     const cameraComponent = cameraEntity.getCamera();
     cameraComponent.zNear = 0.1;
-    cameraComponent.zFar = 1000;
+    cameraComponent.zFar = 100;
     cameraComponent.setFovyAndChangeFocalLength(45);
     cameraComponent.aspect = window.innerWidth / window.innerHeight;
 

--- a/examples/threejs/ammo/minimum/index.js
+++ b/examples/threejs/ammo/minimum/index.js
@@ -113,7 +113,7 @@ class Plane {
 
     initThreeObj() {
         let s = this.s;
-        let geometry = new THREE.BoxGeometry(s, 1 * SCALE, s);
+        let geometry = new THREE.BoxGeometry(s, 2 * SCALE, s);
         let material = new THREE.MeshBasicMaterial({
             map: texture
         });
@@ -127,7 +127,7 @@ class Plane {
 
     initBulletObj(m) {
         let s = this.s;
-        let tmpVec = new Ammo.btVector3(s / 2, 0 / 2, s / 2);
+        let tmpVec = new Ammo.btVector3(s / 2, 0.05, s / 2);
         let shape = new Ammo.btBoxShape(tmpVec);
         Ammo.destroy(tmpVec);
         let startTransform = new Ammo.btTransform();
@@ -169,15 +169,15 @@ function init() {
     let width = window.innerWidth;
     let height = window.innerHeight;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
     camera.position.x = 0;
-    camera.position.y = 50 * SCALE;
-    camera.position.z = 200 * SCALE;
+    camera.position.y = 60 * SCALE;
+    camera.position.z = 120 * SCALE;
 
     scene = new THREE.Scene();
 
     world = initWorld();
-    let ground = new Plane(0, 0, 0, 200 * SCALE, 0, 0xdddddd);
+    let ground = new Plane(0, 0, 0, 80 * SCALE, 0, 0xdddddd);
     scene.add(ground.threeObj);
     world.addRigidBody(ground.bulletObj);
 
@@ -217,11 +217,11 @@ function init() {
 function createBox() {
     let z = 0;
     let x1 = 0;
-    let y1 = 50 * SCALE;
+    let y1 = 40 * SCALE;
     let z1 = 0;
-    let w = 50 * SCALE;
-    let h = 50 * SCALE;
-    let d = 50 * SCALE;
+    let w = 20 * SCALE;
+    let h = 20 * SCALE;
+    let d = 20 * SCALE;
     let box = new Box(x1, y1, z1, w, h, d, 10);
     scene.add(box.threeObj);
     world.addRigidBody(box.bulletObj);

--- a/examples/threejs/ammo_legacy/minimum/index.js
+++ b/examples/threejs/ammo_legacy/minimum/index.js
@@ -113,7 +113,7 @@ class Plane {
 
     initThreeObj() {
         let s = this.s;
-        let geometry = new THREE.BoxGeometry(s, 1 * SCALE, s);
+        let geometry = new THREE.BoxGeometry(s, 2 * SCALE, s);
         let material = new THREE.MeshBasicMaterial({
             map: texture
         });
@@ -127,7 +127,7 @@ class Plane {
 
     initBulletObj(m) {
         let s = this.s;
-        let tmpVec = new Ammo.btVector3(s / 2, 0 / 2, s / 2);
+        let tmpVec = new Ammo.btVector3(s / 2, 0.05, s / 2);
         let shape = new Ammo.btBoxShape(tmpVec);
         Ammo.destroy(tmpVec);
         let startTransform = new Ammo.btTransform();
@@ -169,15 +169,15 @@ function init() {
     let width = window.innerWidth;
     let height = window.innerHeight;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
     camera.position.x = 0;
-    camera.position.y = 50 * SCALE;
-    camera.position.z = 200 * SCALE;
+    camera.position.y = 60 * SCALE;
+    camera.position.z = 120 * SCALE;
 
     scene = new THREE.Scene();
 
     world = initWorld();
-    let ground = new Plane(0, 0, 0, 200 * SCALE, 0, 0xdddddd);
+    let ground = new Plane(0, 0, 0, 80 * SCALE, 0, 0xdddddd);
     scene.add(ground.threeObj);
     world.addRigidBody(ground.bulletObj);
 
@@ -217,11 +217,11 @@ function init() {
 function createBox() {
     let z = 0;
     let x1 = 0;
-    let y1 = 50 * SCALE;
+    let y1 = 40 * SCALE;
     let z1 = 0;
-    let w = 50 * SCALE;
-    let h = 50 * SCALE;
-    let d = 50 * SCALE;
+    let w = 20 * SCALE;
+    let h = 20 * SCALE;
+    let d = 20 * SCALE;
     let box = new Box(x1, y1, z1, w, h, d, 10);
     scene.add(box.threeObj);
     world.addRigidBody(box.bulletObj);

--- a/examples/threejs/cannon-es/minimum/index.js
+++ b/examples/threejs/cannon-es/minimum/index.js
@@ -32,18 +32,18 @@ function initCannon() {
     // Create a plane
     let groundBody = new CANNON.Body({
         mass: 0, // mass == 0 makes the body static
-        position: new CANNON.Vec3(0, -45, 0),
+        position: new CANNON.Vec3(0, 0, 0),
         //material: groundMaterial
     });
-    let groundShape = new CANNON.Box(new CANNON.Vec3(100, 1, 100));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(2, 0.05, 2));
     groundBody.addShape(groundShape);
     world.addBody(groundBody);
 
     // Create a box
-    shape = new CANNON.Box(new CANNON.Vec3(50, 50, 50));
+    shape = new CANNON.Box(new CANNON.Vec3(0.5, 0.5, 0.5));
     body = new CANNON.Body({
         mass: 100, // kg
-        position: new CANNON.Vec3(0, 100, 0), // m
+        position: new CANNON.Vec3(0, 2, 0), // m
         shape: shape,
         material: groundMaterial
     });
@@ -53,21 +53,21 @@ function initCannon() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 1, 1000);
-    camera.position.y = 50;
-    camera.position.z = 200;
+    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.y = 3;
+    camera.position.z = 6;
     scene = new THREE.Scene();
 
     let loader = new THREE.TextureLoader();
     let texture = loader.load('../../../../assets/textures/frog.jpg');  // frog.jpg
 
     let material = new THREE.MeshBasicMaterial({map: texture});
-    let geometryGround = new THREE.BoxGeometry(200, 2, 200);
+    let geometryGround = new THREE.BoxGeometry(4, 0.1, 4);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -20;
+    meshGround.position.y = 0;
     scene.add(meshGround);
 
-    let geometryCube = new THREE.BoxGeometry(50, 50, 50);
+    let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     meshCube.rigidBody = body; // THREE.Object3D#rigidBody has a field of CANNON.RigidBody
     scene.add(meshCube);

--- a/examples/threejs/cannon/minimum/index.js
+++ b/examples/threejs/cannon/minimum/index.js
@@ -31,18 +31,18 @@ function initCannon() {
     // Create a plane
     let groundBody = new CANNON.Body({
         mass: 0, // mass == 0 makes the body static
-        position: new CANNON.Vec3(0, -45, 0),
+        position: new CANNON.Vec3(0, 0, 0),
         //material: groundMaterial
     });
-    let groundShape = new CANNON.Box(new CANNON.Vec3(100, 1, 100));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(2, 0.05, 2));
     groundBody.addShape(groundShape);
     world.addBody(groundBody);
 
     // Create a box
-    shape = new CANNON.Box(new CANNON.Vec3(50, 50, 50));
+    shape = new CANNON.Box(new CANNON.Vec3(0.5, 0.5, 0.5));
     body = new CANNON.Body({
         mass: 100, // kg
-        position: new CANNON.Vec3(0, 100, 0), // m
+        position: new CANNON.Vec3(0, 2, 0), // m
         shape: shape,
         material: groundMaterial
     });
@@ -52,21 +52,21 @@ function initCannon() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 1, 1000);
-    camera.position.y = 50;
-    camera.position.z = 200;
+    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.y = 3;
+    camera.position.z = 6;
     scene = new THREE.Scene();
 
     let loader = new THREE.TextureLoader();
     let texture = loader.load('../../../../assets/textures/frog.jpg');  // frog.jpg
 
     let material = new THREE.MeshBasicMaterial({map: texture});
-    let geometryGround = new THREE.BoxGeometry(200, 2, 200);
+    let geometryGround = new THREE.BoxGeometry(4, 0.1, 4);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -20;
+    meshGround.position.y = 0;
     scene.add(meshGround);
 
-    let geometryCube = new THREE.BoxGeometry(50, 50, 50);
+    let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     meshCube.rigidBody = body; // THREE.Object3D#rigidBody has a field of CANNON.RigidBody
     scene.add(meshCube);

--- a/examples/threejs/oimo/minimum/index.js
+++ b/examples/threejs/oimo/minimum/index.js
@@ -22,8 +22,8 @@ function initOimo() {
 
     let groundBody = world.add({
         type: "box",
-        size: [200, 2, 200],
-        pos: [0, -10, 0],
+        size: [4, 0.1, 4],
+        pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -32,8 +32,8 @@ function initOimo() {
     });
     body = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 0, 10],
         move: true,
         density: 1,
@@ -44,21 +44,21 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 1, 1000);
-    camera.position.y = 50;
-    camera.position.z = 200;
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.y = 3;
+    camera.position.z = 6;
     scene = new THREE.Scene();
 
     let loader = new THREE.TextureLoader();
     let texture = loader.load('../../../../assets/textures/frog.jpg');  // frog.jpg
 
     let material = new THREE.MeshBasicMaterial({map: texture});
-    let geometryGround = new THREE.BoxGeometry(200, 2, 200);
+    let geometryGround = new THREE.BoxGeometry(4, 0.1, 4);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -10;
+    meshGround.position.y = 0;
     scene.add(meshGround);
 
-    let geometryCube = new THREE.BoxGeometry(50, 50, 50);
+    let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
 

--- a/examples/threejs/oimophysics/minimum/index.js
+++ b/examples/threejs/oimophysics/minimum/index.js
@@ -14,19 +14,19 @@ function initOimo() {
     world.gravity = new OIMO.Vec3(0, -9.80665, 0);
     
     let groundShapec = new OIMO.ShapeConfig();
-    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(100, 1, 100));
+    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(2, 0.05, 2));
     let groundBodyc = new OIMO.RigidBodyConfig();
     groundBodyc.type = OIMO.RigidBodyType.STATIC;
-    groundBodyc.position = new OIMO.Vec3(0, -20, 0);
+    groundBodyc.position = new OIMO.Vec3(0, 0, 0);
     let groundBody = new OIMO.RigidBody(groundBodyc);
     groundBody.addShape(new OIMO.Shape(groundShapec));
     world.addRigidBody(groundBody);
     
     let shapec = new OIMO.ShapeConfig();
-    shapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(25, 25, 25));
+    shapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(0.5, 0.5, 0.5));
     let bodyc = new OIMO.RigidBodyConfig();
     bodyc.type = OIMO.RigidBodyType.DYNAMIC;
-    bodyc.position = new OIMO.Vec3(0, 100, 0);
+    bodyc.position = new OIMO.Vec3(0, 2, 0);
     body = new OIMO.RigidBody(bodyc);
     body.setRotationXyz(new OIMO.Vec3(Math.PI*10/180, 0, Math.PI*10/180));
     body.addShape(new OIMO.Shape(shapec));
@@ -35,21 +35,21 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 1, 1000);
-    camera.position.y = 50;
-    camera.position.z = 200;
+    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.y = 3;
+    camera.position.z = 6;
     scene = new THREE.Scene();
 
     let loader = new THREE.TextureLoader();
     let texture = loader.load('../../../../assets/textures/frog.jpg');  // frog.jpg
 
     let material = new THREE.MeshBasicMaterial({map: texture});
-    let geometryGround = new THREE.BoxGeometry(200, 2, 200);
+    let geometryGround = new THREE.BoxGeometry(4, 0.1, 4);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -20;
+    meshGround.position.y = 0;
     scene.add(meshGround);
 
-    let geometryCube = new THREE.BoxGeometry(50, 50, 50);
+    let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
 

--- a/examples/threejs/physx/minimum/index.js
+++ b/examples/threejs/physx/minimum/index.js
@@ -148,21 +148,21 @@ function init(PhysX) {
     console.log('Created scene');
     
     // create three.js scene
-    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.01, 1000 );
+    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.1, 100 );
     camera.position.x = 0;
-    camera.position.y = 5;
-    camera.position.z = 20;
+    camera.position.y = 3;
+    camera.position.z = 6;
 
     const sceneThree = new THREE.Scene();
 
     const loader = new THREE.TextureLoader();
     const texture = loader.load('../../../../assets/textures/frog.jpg');
     
-    let ground = new Ground(0, 0, 0, 20, 1, 20, texture);
+    let ground = new Ground(0, 0, 0, 4, 0.1, 4, texture);
     sceneThree.add(ground.threeObj);
     scenePhysx.addActor(ground.physxObj);
     
-    let box = new Box(0, 10, 0, 5, 5, 5, texture);
+    let box = new Box(0, 2, 0, 1, 1, 1, texture);
     sceneThree.add(box.threeObj);
     scenePhysx.addActor(box.physxObj);
     box.move();

--- a/examples/threejs/rapier/minimum/index.js
+++ b/examples/threejs/rapier/minimum/index.js
@@ -13,13 +13,13 @@ async function initRapier() {
     const gravity = new RAPIER.Vector3(0, -9.81, 0);
     world = new RAPIER.World(gravity);
 
-    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(100, 1, 100).setRestitution(0.1).setFriction(0.5);
-    const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -45, 0);
+    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(2, 0.05, 2).setRestitution(0.1).setFriction(0.5);
+    const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, 0, 0);
     groundBody = world.createRigidBody(groundBodyDesc);
     world.createCollider(groundColliderDesc, groundBody);
 
-    const boxColliderDesc = RAPIER.ColliderDesc.cuboid(50, 50, 50);
-    const boxBodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(0, 100, 0);
+    const boxColliderDesc = RAPIER.ColliderDesc.cuboid(0.5, 0.5, 0.5);
+    const boxBodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(0, 2, 0);
     boxBody = world.createRigidBody(boxBodyDesc);
     world.createCollider(boxColliderDesc, boxBody);
 
@@ -30,21 +30,21 @@ async function initRapier() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 1, 1000);
-    camera.position.y = 50;
-    camera.position.z = 200;
+    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.y = 3;
+    camera.position.z = 6;
     scene = new THREE.Scene();
 
     const loader = new THREE.TextureLoader();
     const texture = loader.load('../../../../assets/textures/frog.jpg');
     const material = new THREE.MeshBasicMaterial({ map: texture });
 
-    const geometryGround = new THREE.BoxGeometry(200, 2, 200);
+    const geometryGround = new THREE.BoxGeometry(4, 0.1, 4);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -20;
+    meshGround.position.y = 0;
     scene.add(meshGround);
 
-    const geometryCube = new THREE.BoxGeometry(50, 50, 50);
+    const geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
 

--- a/examples/webgl1/oimo/minimum/index.js
+++ b/examples/webgl1/oimo/minimum/index.js
@@ -40,7 +40,7 @@ function initWebGL() {
     eye = vec3.create();
     center = vec3.create();
     up = vec3.create();
-    vec3.set(eye, 0, 50, 200);
+    vec3.set(eye, 0, 3, 6);
     vec3.set(center, 0, 0, 0);
     vec3.set(up, 0, 1, 0);
     view = mat4.create();
@@ -227,7 +227,7 @@ function initBuffers() {
 function addGround() {
     oimoGround = world.add({
         type: "box",
-        size: [200, 4, 200],
+        size: [4, 0.1, 4],
         pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
@@ -238,8 +238,8 @@ function addGround() {
 function addBox() {
     oimoBox = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 10, 10],
         move: true,
         density: 1
@@ -253,18 +253,18 @@ function draw() {
     rad -= Math.PI * 1.0 / 180.0 * 0.1;
 
     // Camera
-    vec3.set(eye, 200 * Math.sin(rad), 50, 200 * Math.cos(rad));
+    vec3.set(eye, 6 * Math.sin(rad), 3, 6 * Math.cos(rad));
     vec3.set(center, 0, 0, 0);
     vec3.set(up, 0, 1, 0);
     mat4.lookAt(view, eye, center, up);
-    mat4.perspective(pMatrix, 45, c.width / c.height, 0.1, 1000.0);
+    mat4.perspective(pMatrix, 45, c.width / c.height, 0.1, 100.0);
     mat4.multiply(pMatrix, pMatrix, view);
 
     // Ground
     mat4.identity(mvMatrix);
     p = oimoGround.getPosition();
     r = oimoGround.getQuaternion();
-    vec3.set(scale, 200, 4, 200);
+    vec3.set(scale, 4, 0.1, 4);
     vec3.set(translation, p.x, p.y, p.z);
     mat4.translate(mvMatrix, mvMatrix, translation);
     q = quat.fromValues(r.x, r.y, r.z, r.w);
@@ -279,7 +279,7 @@ function draw() {
 
     // Box
     mat4.identity(mvMatrix);
-    vec3.set(scale, 50.0, 50.0, 50.0);
+    vec3.set(scale, 1.0, 1.0, 1.0);
     p = oimoBox.getPosition();
     r = oimoBox.getQuaternion();
     vec3.set(translation, p.x, p.y, p.z);

--- a/examples/webgl2/oimo/minimum/index.js
+++ b/examples/webgl2/oimo/minimum/index.js
@@ -38,7 +38,7 @@ function initWebGL() {
     eye = vec3.create();
     center = vec3.create();
     up = vec3.create();
-    vec3.set(eye, 0, 50, 200);
+    vec3.set(eye, 0, 3, 6);
     vec3.set(center, 0, 0, 0);
     vec3.set(up, 0, 1, 0);
     viewMatrix = mat4.create();
@@ -188,7 +188,7 @@ function initBuffers() {
 function addGround() {
     groundBody = world.add({
         type: 'box',
-        size: [200, 4, 200],
+        size: [4, 0.1, 4],
         pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
@@ -199,8 +199,8 @@ function addGround() {
 function addBox() {
     boxBody = world.add({
         type: 'box',
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 10, 10],
         move: true,
         density: 1
@@ -232,14 +232,14 @@ function draw() {
     gl.clearColor(1, 1, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-    vec3.set(eye, 200 * Math.sin(angle), 50, 200 * Math.cos(angle));
+    vec3.set(eye, 6 * Math.sin(angle), 3, 6 * Math.cos(angle));
     mat4.lookAt(viewMatrix, eye, center, up);
-    mat4.perspective(projectionMatrix, 45, canvas.width / canvas.height, 0.1, 1000.0);
+    mat4.perspective(projectionMatrix, 45, canvas.width / canvas.height, 0.1, 100.0);
     mat4.multiply(projectionMatrix, projectionMatrix, viewMatrix);
 
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexIndexBuffer);
-    drawBody(groundBody, [200, 4, 200]);
-    drawBody(boxBody, [50, 50, 50]);
+    drawBody(groundBody, [4, 0.1, 4]);
+    drawBody(boxBody, [1, 1, 1]);
 
     gl.flush();
 }

--- a/examples/webgpu/oimo/minimum/index.js
+++ b/examples/webgpu/oimo/minimum/index.js
@@ -49,7 +49,7 @@ async function init() {
     // Setup matrices
     const aspect = canvas.width / canvas.height;
     projectionMatrix = mat4.create();
-    mat4.perspective(projectionMatrix, 45, aspect, 0.1, 1000.0);
+    mat4.perspective(projectionMatrix, 45, aspect, 0.1, 100.0);
 
     // Create shaders
     const vShaderModule = device.createShaderModule({ code: vertexShaderWGSL });
@@ -267,7 +267,7 @@ function initWorld() {
 function addGround() {
     groundBody = world.add({
         type: 'box',
-        size: [200, 4, 200],
+        size: [4, 0.1, 4],
         pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
@@ -278,8 +278,8 @@ function addGround() {
 function addBox() {
     boxBody = world.add({
         type: 'box',
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 10, 10],
         move: true,
         density: 1
@@ -336,9 +336,9 @@ async function render() {
     // Calculate view matrix
     angle -= Math.PI / 180 * 0.1;
     const eyePos = vec3.fromValues(
-        200 * Math.sin(angle),
-        50,
-        200 * Math.cos(angle)
+        6 * Math.sin(angle),
+        3,
+        6 * Math.cos(angle)
     );
     const centerPos = vec3.fromValues(0, 0, 0);
     const upVec = vec3.fromValues(0, 1, 0);
@@ -360,7 +360,7 @@ async function render() {
         const groundRotationMatrix = mat4.create();
         mat4.fromQuat(groundRotationMatrix, groundQuaternion);
         mat4.multiply(groundWorldMatrix, groundWorldMatrix, groundRotationMatrix);
-        mat4.scale(groundWorldMatrix, groundWorldMatrix, [200, 4, 200]);
+        mat4.scale(groundWorldMatrix, groundWorldMatrix, [4, 0.1, 4]);
 
         const groundMVPMatrix = mat4.create();
         mat4.multiply(groundMVPMatrix, projectionMatrix, viewMatrix);
@@ -407,7 +407,7 @@ async function render() {
         const boxRotationMatrix = mat4.create();
         mat4.fromQuat(boxRotationMatrix, boxQuaternion);
         mat4.multiply(boxWorldMatrix, boxWorldMatrix, boxRotationMatrix);
-        mat4.scale(boxWorldMatrix, boxWorldMatrix, [50, 50, 50]);
+        mat4.scale(boxWorldMatrix, boxWorldMatrix, [1, 1, 1]);
 
         const boxMVPMatrix = mat4.create();
         mat4.multiply(boxMVPMatrix, projectionMatrix, viewMatrix);

--- a/examples/xenogl/oimo/minimum/index.js
+++ b/examples/xenogl/oimo/minimum/index.js
@@ -185,7 +185,7 @@ async function initBuffers() {
 function addGround() {
     oimoGround = world.add({
         type: "box",
-        size: [200, 4, 200],
+        size: [4, 0.1, 4],
         pos: [0, 0, 0],
         rot: [0, 0, 0],
         move: false,
@@ -196,8 +196,8 @@ function addGround() {
 function addCube() {
     oimoCube = world.add({
         type: "box",
-        size: [50, 50, 50],
-        pos: [0, 100, 0],
+        size: [1, 1, 1],
+        pos: [0, 2, 0],
         rot: [10, 10, 10],
         move: true,
         density: 1
@@ -220,13 +220,13 @@ async function draw() {
     let rot = oimoCube.getQuaternion();
 
     // Camera
-    const camera = new Vector3(200 * Math.sin(rad), 50, 200 * Math.cos(rad));
+    const camera = new Vector3(6 * Math.sin(rad), 3, 6 * Math.cos(rad));
     const lookAt = new Vector3(0, 0, 0);
     const cameraUpDirection = new Vector3(0, 1, 0);
     const view = Matrix4.lookAt(camera, lookAt, cameraUpDirection);
     
     // Cube
-    let pMatrix = Matrix4.perspective({fovYRadian: 45 * Math.PI/180, aspectRatio: window.innerWidth/window.innerHeight, near: 0.1, far: 1000});
+    let pMatrix = Matrix4.perspective({fovYRadian: 45 * Math.PI/180, aspectRatio: window.innerWidth/window.innerHeight, near: 0.1, far: 100});
     let identity = Matrix4.identity();
     let translation = Matrix4.translation(pos.x, pos.y, pos.z);
     let q = new Quaternion(rot.x, rot.y, rot.z, rot.w);
@@ -234,7 +234,7 @@ async function draw() {
     let mvMatrix = identity.mulByMatrix4(translation)
                            .mulByMatrix4(view)
                            .mulByMatrix4(rotation)
-                           .scale(50, 50, 50)
+                           .scale(1, 1, 1)
     
     if ( uMVMatrix !== undefined ) uMVMatrix.setMatrix(mvMatrix.values);
     if ( uPMatrix !== undefined ) uPMatrix.setMatrix(pMatrix.values);
@@ -251,7 +251,7 @@ async function draw() {
     mvMatrix = identity.mulByMatrix4(translation)
                        .mulByMatrix4(view)
                        .mulByMatrix4(rotation)
-                       .scale(200, 4, 200)
+                       .scale(4, 0.1, 4)
     
     if ( uMVMatrix !== undefined ) uMVMatrix.setMatrix(mvMatrix.values);
     if ( uPMatrix !== undefined ) uPMatrix.setMatrix(pMatrix.values);

--- a/examples/xenogl/oimophysics/minimum/index.js
+++ b/examples/xenogl/oimophysics/minimum/index.js
@@ -177,10 +177,10 @@ async function initBuffers() {
 
 function addGround() {
     let groundShapec = new OIMO.ShapeConfig();
-    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(100, 1, 100));
+    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(2, 0.05, 2));
     let groundBodyc = new OIMO.RigidBodyConfig();
     groundBodyc.type = OIMO.RigidBodyType.STATIC;
-    groundBodyc.position = new OIMO.Vec3(0, -20, 0);
+    groundBodyc.position = new OIMO.Vec3(0, 0, 0);
     groundBody = new OIMO.RigidBody(groundBodyc);
     groundBody.addShape(new OIMO.Shape(groundShapec));
     world.addRigidBody(groundBody);
@@ -188,10 +188,10 @@ function addGround() {
 
 function addCube() {
     let shapec = new OIMO.ShapeConfig();
-    shapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(25, 25, 25));
+    shapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(0.5, 0.5, 0.5));
     let bodyc = new OIMO.RigidBodyConfig();
     bodyc.type = OIMO.RigidBodyType.DYNAMIC;
-    bodyc.position = new OIMO.Vec3(0, 100, 0);
+    bodyc.position = new OIMO.Vec3(0, 2, 0);
     body = new OIMO.RigidBody(bodyc);
     body.setRotationXyz(new OIMO.Vec3(Math.PI*10/180, 0, Math.PI*10/180));
     body.addShape(new OIMO.Shape(shapec));
@@ -213,13 +213,13 @@ async function draw() {
     let rot = body.getOrientation();
 
     // Camera
-    const camera = new Vector3(200 * Math.sin(rad), 50, 200 * Math.cos(rad));
+    const camera = new Vector3(6 * Math.sin(rad), 3, 6 * Math.cos(rad));
     const lookAt = new Vector3(0, 0, 0);
     const cameraUpDirection = new Vector3(0, 1, 0);
     const view = Matrix4.lookAt(camera, lookAt, cameraUpDirection);
     
     // Cube
-    let pMatrix = Matrix4.perspective({fovYRadian: 45 * Math.PI/180, aspectRatio: window.innerWidth/window.innerHeight, near: 0.1, far: 1000});
+    let pMatrix = Matrix4.perspective({fovYRadian: 45 * Math.PI/180, aspectRatio: window.innerWidth/window.innerHeight, near: 0.1, far: 100});
     let identity = Matrix4.identity();
     let translation = Matrix4.translation(pos.x, pos.y, pos.z);
     let q = new Quaternion(rot.x, rot.y, rot.z, rot.w);
@@ -227,7 +227,7 @@ async function draw() {
     let mvMatrix = identity.mulByMatrix4(translation)
                            .mulByMatrix4(view)
                            .mulByMatrix4(rotation)
-                           .scale(50, 50, 50)
+                           .scale(1, 1, 1)
     
     if ( uMVMatrix !== undefined ) uMVMatrix.setMatrix(mvMatrix.values);
     if ( uPMatrix !== undefined ) uPMatrix.setMatrix(pMatrix.values);
@@ -244,7 +244,7 @@ async function draw() {
     mvMatrix = identity.mulByMatrix4(translation)
                        .mulByMatrix4(view)
                        .mulByMatrix4(rotation)
-                       .scale(200, 4, 200)
+                       .scale(4, 0.1, 4)
     
     if ( uMVMatrix !== undefined ) uMVMatrix.setMatrix(mvMatrix.values);
     if ( uPMatrix !== undefined ) uPMatrix.setMatrix(pMatrix.values);


### PR DESCRIPTION
## Summary
This PR normalizes the `minimum` physics demo parameters across engines/frameworks so that motion speed, scale perception, and camera framing are consistent and less “sluggish”.

## What Changed
- Unified scene scale for `minimum` demos:
  - Dynamic cube size: ~`1 x 1 x 1`
  - Ground size: ~`4 x 0.1 x 4`
  - Drop height: ~`y = 2` (keeps relative drop ratio consistent)
- Brought cameras closer to match the new scale:
  - Typical target framing around `(0, 3, 6)`
  - Reduced far plane where appropriate (commonly `zFar = 100`)
- Applied equivalent tuning across multiple stacks:
  - WebGL1 / WebGL2 / WebGPU (Oimo)
  - Ashes, ClayGL, CZPG, GLBoost, Hilo3d
  - Grimoire.js (Oimo / OimoPhysics)
  - Rhodonite (Oimo)
  - three.js backends (Ammo, Ammo legacy, Cannon, Cannon-es, Oimo, OimoPhysics, PhysX, Rapier)
  - XenoGL (Oimo / OimoPhysics)
- Added README note clarifying SI unit-system guidance and practical scale recommendations for physics stability.

## Why
Several `minimum` demos were still using large legacy scales (e.g. 50/200-class dimensions with distant cameras), which made dynamics appear slow and visually inconsistent between implementations.  
This PR aligns those parameters so demos are easier to compare side-by-side and behave with similar perceived timing.

## Validation
- Manually adjusted affected demos to consistent baseline values.
- Checked edited files for syntax/problems in workspace diagnostics.
- Confirmed legacy large-scale parameter patterns were removed from updated `minimum` targets.

## Notes
- ClayGL received an additional render/physics scale alignment fix (its cube primitive base size required matching adjustments to avoid visible interpenetration).
- No functional API changes; this is tuning for demo consistency and presentation.