### PR TITLE
Tune football sample scale and floor coverage across frameworks

### DIFF
--- a/examples/babylonjs/ammo/football/index.js
+++ b/examples/babylonjs/ammo/football/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/cannon/football/index.js
+++ b/examples/babylonjs/cannon/football/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/havok/football/index.js
+++ b/examples/babylonjs/havok/football/index.js
@@ -75,7 +75,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/oimo/football/index.js
+++ b/examples/babylonjs/oimo/football/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/claygl/oimo/football/index.js
+++ b/examples/claygl/oimo/football/index.js
@@ -67,7 +67,7 @@ let app = clay.application.create('#main', {
         
         // Create a orthographic camera
         this._camera = app.createCamera(null, null, 'perspective');
-        this._camera.position.set(0, 0, 500);
+        this._camera.position.set(0, 0, 60);
         app.resize(window.innerWidth, window.innerHeight);
         // Create geometry
         let geometrySphere  = new clay.geometry.Sphere();
@@ -87,26 +87,26 @@ let app = clay.application.create('#main', {
         
         this._oimoGround = this._world.add({
            type: "box",
-            size: [400*2, 4*2, 400*2],
-            pos: [0, -80, 0],
+            size: [40*2, 0.4*2, 40*2],
+            pos: [0, -8, 0],
             rot: [0, 0, 0],
             move: false,
             density: 1
         });
         
-        let box_size = 8;
+        let box_size = 0.8;
         let i = 0;
         for (let y = 0; y < 16; y++) {
             for (let x = 0; x < 16; x++) {
                 i = (15 - x) + (15 - y) * 16;
                 //i = x + (15 - y) * 16;
-                let x1 = -130 + x * (box_size+1)*2 + Math.random();
-                let y1 = 30 + y * (box_size+1)*2 + Math.random();
-                let z1 = 0 + Math.random();
+                let x1 = -13 + x * (box_size + 0.1) * 2 + Math.random() * 0.1;
+                let y1 = 3 + y * (box_size + 0.1) * 2 + Math.random() * 0.1;
+                let z1 = Math.random() * 0.1;
                 let rgbColor = getRgbColor(dataSet[i]);
                 let meshSphere = app.createSphere({color:rgbColor, diffuseMap:diffuseFootball});
                 meshSphere.scale.set(box_size, box_size, box_size);
-                meshSphere.position.set(x1*2, y1*2, z1*2);
+                meshSphere.position.set(x1, y1, z1);
                 meshSpheres.push(meshSphere);
                 let oimoSphere = this._world.add({
                     type: "sphere",
@@ -122,8 +122,8 @@ let app = clay.application.create('#main', {
         this._rad = 0;
          
         this._meshGround = app.createMesh(geometryGround, materialGround);
-        this._meshGround.scale.set(400, 4, 400);
-        this._meshGround.position.set(0, -80, 0);
+        this._meshGround.scale.set(40, 0.4, 40);
+        this._meshGround.position.set(0, -8, 0);
         materialGround.set('diffuseMap', diffuse);
         
         app.createAmbientLight("#fff", 0.2);

--- a/examples/glboost/oimo/football/index.js
+++ b/examples/glboost/oimo/football/index.js
@@ -1,4 +1,4 @@
-﻿let DOT_SIZE = 8;
+﻿let DOT_SIZE = 0.8;
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
@@ -78,14 +78,14 @@ function init() {
     scene = glBoostContext.createScene();
 
     camera = glBoostContext.createPerspectiveCamera({
-        eye: new GLBoost.Vector3(0.0, 50, 100),
+        eye: new GLBoost.Vector3(0.0, 12, 24),
         center: new GLBoost.Vector3(0.0, 0.0, 0.0),
         up: new GLBoost.Vector3(0.0, 1.0, 0.0)
     }, {
         fovy: 45.0,
         aspect: width/height,
         zNear: 0.001,
-        zFar: 3000.0
+        zFar: 300.0
     });
     camera.cameraController = glBoostContext.createCameraController();
     scene.addChild(camera);
@@ -100,7 +100,7 @@ function init() {
     material.setTexture(texture);
     material.baseColor = new GLBoost.Vector4(1, 1, 1, 1);
 
-    let geo1 = glBoostContext.createCube(new GLBoost.Vector3(200, 2, 200), new GLBoost.Vector4(1, 1, 1, 1));
+    let geo1 = glBoostContext.createCube(new GLBoost.Vector3(20, 0.4, 20), new GLBoost.Vector4(1, 1, 1, 1));
     mground1 = glBoostContext.createMesh(geo1, material);
     mground1.dirty = true;
     scene.addChild(mground1);
@@ -133,8 +133,8 @@ function populate() {
 
     groundBody = world.add({
         type: "box",
-        size: [200, 2, 200],
-        pos: [0, -20, 0],
+        size: [20, 0.4, 20],
+        pos: [0, -2, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -160,9 +160,9 @@ function populate() {
             i = x + (15-y) * 16;
             let c = getRgbColor(dataSet[i]);
             z = 0;
-            let x2 = (-8+x)*DOT_SIZE * 1.1 + Math.random();
-            let y2 = (1+y)*DOT_SIZE * 1.1 + Math.random();
-            let z2 = z*DOT_SIZE + Math.random();
+            let x2 = (-8+x) * DOT_SIZE * 1.1 + Math.random() * 0.1;
+            let y2 = (1+y) * DOT_SIZE * 1.1 + Math.random() * 0.1;
+            let z2 = z * DOT_SIZE + Math.random() * 0.1;
             bodys[i] = world.add({
                 type: "sphere",
                 size: [w*0.5],

--- a/examples/rhodonite/oimo/football/index.js
+++ b/examples/rhodonite/oimo/football/index.js
@@ -98,7 +98,7 @@ const load = async function() {
         tag: "type",
         value: "ground"
     });
-    entity1.scale = Rn.Vector3.fromCopyArray([400 * PHYSICS_SCALE, 0.4 * PHYSICS_SCALE, 400 * PHYSICS_SCALE]);
+    entity1.scale = Rn.Vector3.fromCopyArray([200 * PHYSICS_SCALE, 0.4 * PHYSICS_SCALE, 200 * PHYSICS_SCALE]);
     entity1.position = Rn.Vector3.fromCopyArray([0, -20 * PHYSICS_SCALE, 0]);
     entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', grassTexture, sampler);
     entities.push(entity1);
@@ -107,11 +107,11 @@ const load = async function() {
 
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
-    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 100.0 * PHYSICS_SCALE, 400 * PHYSICS_SCALE]);
+    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 60.0 * PHYSICS_SCALE, 240 * PHYSICS_SCALE]);
     cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([0.0, 0.0, 0.0]);
     const cameraComponent = cameraEntity.getCamera();
     cameraComponent.zNear = 0.1;
-    cameraComponent.zFar = 1000;
+    cameraComponent.zFar = 400;
     cameraComponent.setFovyAndChangeFocalLength(45);
     cameraComponent.aspect = window.innerWidth / window.innerHeight;
 

--- a/examples/threejs/ammo/football/index.js
+++ b/examples/threejs/ammo/football/index.js
@@ -219,10 +219,10 @@ function init() {
     let height = window.innerHeight;
     let deltaT = 60;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 200 * SCALE;
-    camera.position.z = 300 * SCALE;
+    camera.position.y = 120 * SCALE;
+    camera.position.z = 220 * SCALE;
     camera.lookAt(new THREE.Vector3(0, 0, 0));
 
     scene = new THREE.Scene();

--- a/examples/threejs/ammo_legacy/football/index.js
+++ b/examples/threejs/ammo_legacy/football/index.js
@@ -219,10 +219,10 @@ function init() {
     let height = window.innerHeight;
     let deltaT = 60;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 200 * SCALE;
-    camera.position.z = 300 * SCALE;
+    camera.position.y = 120 * SCALE;
+    camera.position.z = 220 * SCALE;
     camera.lookAt(new THREE.Vector3(0, 0, 0));
 
     scene = new THREE.Scene();

--- a/examples/threejs/cannon-es/football/index.js
+++ b/examples/threejs/cannon-es/football/index.js
@@ -80,11 +80,11 @@ function init() {
     parentElement.appendChild(renderer.domElement);
 
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 8;
-    camera.position.y = 20;
-    camera.position.z = 50;
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera.position.y = 10;
+    camera.position.z = 24;
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     initLights();
     initGround();
@@ -109,12 +109,12 @@ function initLights() {
 }
 
 function initGround() {
-    let groundShape = new CANNON.Box(new CANNON.Vec3(50/2, 1/2, 50/2));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(20/2, 0.4/2, 20/2));
     let groundBody = new CANNON.Body({mass: 0});
     groundBody.addShape(groundShape);
     world.addBody(groundBody);
 
-    let box = createBox(50, 1, 50);
+    let box = createBox(20, 0.4, 20);
     scene.add(box);
 }
 

--- a/examples/threejs/cannon/football/index.js
+++ b/examples/threejs/cannon/football/index.js
@@ -79,11 +79,11 @@ function init() {
     parentElement.appendChild(renderer.domElement);
 
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 8;
-    camera.position.y = 20;
-    camera.position.z = 50;
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera.position.y = 10;
+    camera.position.z = 24;
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     initLights();
     initGround();
@@ -108,12 +108,12 @@ function initLights() {
 }
 
 function initGround() {
-    let groundShape = new CANNON.Box(new CANNON.Vec3(50/2, 1/2, 50/2));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(20/2, 0.4/2, 20/2));
     let groundBody = new CANNON.Body({mass: 0});
     groundBody.addShape(groundShape);
     world.add(groundBody);
 
-    let box = createBox(50, 1, 50);
+    let box = createBox(20, 0.4, 20);
     scene.add(box);
 }
 

--- a/examples/threejs/oimo/football/index.js
+++ b/examples/threejs/oimo/football/index.js
@@ -77,8 +77,8 @@ function initOimo() {
     });
     let groundBody = world.add({
         type: "box",
-        size: [50, 1, 50],
-        pos: [0, -5, 0],
+        size: [20, 0.4, 20],
+        pos: [0, -2, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -89,10 +89,10 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 20;
-    camera.position.z = 50;
+    camera.position.y = 10;
+    camera.position.z = 24;
     scene = new THREE.Scene();
 
     loader = new THREE.TextureLoader();
@@ -100,7 +100,7 @@ function initThree() {
     texture_football = loader.load('../../../../assets/textures/football.png');
 
     let material = new THREE.MeshBasicMaterial({map: texture_grass});
-    let geometryGround = new THREE.BoxGeometry(50, 1, 50);
+    let geometryGround = new THREE.BoxGeometry(20, 0.4, 20);
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = -5;
     scene.add(meshGround);

--- a/examples/threejs/oimophysics/football/index.js
+++ b/examples/threejs/oimophysics/football/index.js
@@ -70,12 +70,12 @@ function initOimo() {
     world.gravity = new OIMO.Vec3(0, -9.80665, 0);
     
     let groundShapec = new OIMO.ShapeConfig();
-    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(25, 0, 25));
+    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(10, 0.2, 10));
     groundShapec.friction  = 0.6;
     groundShapec.restitution  = 0.5;
     let groundBodyc = new OIMO.RigidBodyConfig();
     groundBodyc.type = OIMO.RigidBodyType.STATIC;
-    groundBodyc.position = new OIMO.Vec3(0, -5, 0);
+    groundBodyc.position = new OIMO.Vec3(0, -2, 0);
     let groundBody = new OIMO.RigidBody(groundBodyc);
     groundBody.addShape(new OIMO.Shape(groundShapec));
     world.addRigidBody(groundBody);
@@ -83,10 +83,10 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 20;
-    camera.position.z = 50;
+    camera.position.y = 10;
+    camera.position.z = 24;
     scene = new THREE.Scene();
 
     loader = new THREE.TextureLoader();
@@ -94,7 +94,7 @@ function initThree() {
     texture_football = loader.load('../../../../assets/textures/football.png');
 
     let material = new THREE.MeshBasicMaterial({map: texture_grass});
-    let geometryGround = new THREE.PlaneGeometry(50, 50);
+    let geometryGround = new THREE.PlaneGeometry(20, 20);
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.rotation.x = -Math.PI * 90 / 180;
     meshGround.position.y = -5;

--- a/examples/threejs/physx/football/index.js
+++ b/examples/threejs/physx/football/index.js
@@ -208,10 +208,10 @@ function init(PhysX) {
     console.log('Created scene');
     
     // create three.js scene
-    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.01, 1000 );
+    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.01, 300 );
     camera.position.x = 0;
-    camera.position.y = 200 * SCALE;
-    camera.position.z = 300 * SCALE;
+    camera.position.y = 120 * SCALE;
+    camera.position.z = 220 * SCALE;
 
     const sceneThree = new THREE.Scene();
     

--- a/examples/threejs/rapier/football/index.js
+++ b/examples/threejs/rapier/football/index.js
@@ -74,9 +74,9 @@ async function init() {
 
     // Three.js の初期設定
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
-    camera.position.set(8, 20, 50);
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
+    camera.position.set(8, 10, 24);
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     renderer = new THREE.WebGLRenderer();
     renderer.setSize(window.innerWidth, window.innerHeight);
@@ -114,13 +114,13 @@ function initLights() {
 
 function initGround() {
     // Rapier の床のコライダー
-    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(25, 0.5, 25);
+    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(10, 0.2, 10);
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed();
     const groundBody = world.createRigidBody(groundBodyDesc);
     world.createCollider(groundColliderDesc, groundBody);
 
     // Three.js の床メッシュ
-    const box = createBox(50, 1, 50);
+    const box = createBox(20, 0.4, 20);
     scene.add(box);
 }
 

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -302,7 +302,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -359,9 +359,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -286,7 +286,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -343,9 +343,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgpu/oimo/football/index.js
+++ b/examples/webgpu/oimo/football/index.js
@@ -242,7 +242,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -344,9 +344,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
     mat4.multiply(viewProj, projection, view);
 
     const encoder = device.createCommandEncoder();


### PR DESCRIPTION
## Body
This PR normalizes Falling Football scene scale/camera settings across frameworks and fixes floor coverage so spawned balls stay within the floor area.

## Changes include:
- Reduced oversized camera distance/far plane in several football samples
- Normalized ground/object scale in Oimo-based and Three.js-based variants
- Expanded floor size for WebGL1/WebGL2/WebGPU Oimo football samples to fully contain spawn spread
- Kept spawning logic intact where possible to preserve original visual density

## Result:
- Improved perceived simulation speed
- Better cross-framework consistency
- Balls no longer drop outside the floor in the WebGL1/WebGL2/WebGPU football samples