### PR TITLE
box: normalize ground size and camera distance across all frameworks

### DIFF
--- a/examples/babylonjs/ammo/box/index.js
+++ b/examples/babylonjs/ammo/box/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 50 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/cannon/box/index.js
+++ b/examples/babylonjs/cannon/box/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 50 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/havok/box/index.js
+++ b/examples/babylonjs/havok/box/index.js
@@ -75,7 +75,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 50 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/babylonjs/oimo/box/index.js
+++ b/examples/babylonjs/oimo/box/index.js
@@ -74,7 +74,7 @@ const createScene = function() {
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);
-    camera.setPosition(new BABYLON.Vector3(0, 50 * PHYSICS_SCALE, -500 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 30 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas);
     new BABYLON.HemisphericLight("hemi", new BABYLON.Vector3(0, 1, 0), scene);
     new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);

--- a/examples/claygl/oimo/box/index.js
+++ b/examples/claygl/oimo/box/index.js
@@ -67,7 +67,7 @@ let app = clay.application.create('#main', {
         
         // Create a orthographic camera
         this._camera = app.createCamera(null, null, 'perspective');
-        this._camera.position.set(0, 0, 500);
+        this._camera.position.set(0, 0, 60);
         app.resize(window.innerWidth, window.innerHeight);
         // Create geometry
         let geometryCube  = new clay.geometry.Cube();
@@ -84,26 +84,26 @@ let app = clay.application.create('#main', {
                 
         this._oimoGround = this._world.add({
            type: "box",
-            size: [200*2, 4*2, 200*2],
-            pos: [0, -80, 0],
+            size: [40*2, 0.4*2, 40*2],
+            pos: [0, -8, 0],
             rot: [0, 0, 0],
             move: false,
             density: 1
         });
         
-        let box_size = 8;
+        let box_size = 0.8;
         let i = 0;
         for (let y = 0; y < 16; y++) {
             for (let x = 0; x < 16; x++) {
                 //i = (15 - x) + (15 - y) * 16;
                 i = x + (15 - y) * 16;
-                let x1 = -130 + x * (box_size+1)*2;
-                let y1 = 30 + y * (box_size+1)*2;
+                let x1 = -13 + x * (box_size+0.1)*2;
+                let y1 = 3 + y * (box_size+0.1)*2;
                 let z1 = 0;
                 let rgbColor = getRgbColor(dataSet[i]);
                 let meshCube = app.createCube({color:rgbColor});
                 meshCube.scale.set(box_size, box_size, box_size);
-                meshCube.position.set(x1*2, y1*2, z1*2);
+                meshCube.position.set(x1, y1, z1);
                 meshCubes.push(meshCube);
                 let oimoCube = this._world.add({
                     type: "box",
@@ -119,8 +119,8 @@ let app = clay.application.create('#main', {
         this._rad = 0;
          
         this._meshGround = app.createMesh(geometryGround, materialGround);
-        this._meshGround.scale.set(200, 4, 200);
-        this._meshGround.position.set(0, -80, 0);
+        this._meshGround.scale.set(40, 0.4, 40);
+        this._meshGround.position.set(0, -8, 0);
         materialGround.set('diffuseMap', diffuse);
         
         app.createAmbientLight("#fff", 0.2);

--- a/examples/glboost/oimo/box/index.js
+++ b/examples/glboost/oimo/box/index.js
@@ -1,4 +1,4 @@
-﻿let DOT_SIZE = 8;
+﻿let DOT_SIZE = 0.8;
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
@@ -78,14 +78,14 @@ function init() {
     scene = glBoostContext.createScene();
 
     camera = glBoostContext.createPerspectiveCamera({
-        eye: new GLBoost.Vector3(0.0, 50, 100),
+        eye: new GLBoost.Vector3(0.0, 12, 24),
         center: new GLBoost.Vector3(0.0, 0.0, 0.0),
         up: new GLBoost.Vector3(0.0, 1.0, 0.0)
     }, {
         fovy: 45.0,
         aspect: width/height,
         zNear: 0.001,
-        zFar: 3000.0
+        zFar: 300.0
     });
     camera.cameraController = glBoostContext.createCameraController();
     scene.addChild(camera);
@@ -100,7 +100,7 @@ function init() {
     material.setTexture(texture);
     material.baseColor = new GLBoost.Vector4(1, 1, 1, 1);
 
-    let geo1 = glBoostContext.createCube(new GLBoost.Vector3(200, 2, 200), new GLBoost.Vector4(1, 1, 1, 1));
+    let geo1 = glBoostContext.createCube(new GLBoost.Vector3(20, 0.4, 20), new GLBoost.Vector4(1, 1, 1, 1));
     mground1 = glBoostContext.createMesh(geo1, material);
     mground1.dirty = true;
     scene.addChild(mground1);
@@ -133,8 +133,8 @@ function populate() {
 
     groundBody = world.add({
         type: "box",
-        size: [200, 2, 200],
-        pos: [0, -20, 0],
+        size: [20, 0.4, 20],
+        pos: [0, -2, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,

--- a/examples/rhodonite/oimo/box/index.js
+++ b/examples/rhodonite/oimo/box/index.js
@@ -97,8 +97,8 @@ const load = async function() {
         tag: "type",
         value: "ground"
     });
-    entity1.scale = Rn.Vector3.fromCopyArray([400 * PHYSICS_SCALE, 0.4 * PHYSICS_SCALE, 400 * PHYSICS_SCALE]);
-    entity1.position = Rn.Vector3.fromCopyArray([0, -100 * PHYSICS_SCALE, 0]);
+    entity1.scale = Rn.Vector3.fromCopyArray([200 * PHYSICS_SCALE, 0.4 * PHYSICS_SCALE, 200 * PHYSICS_SCALE]);
+    entity1.position = Rn.Vector3.fromCopyArray([0, -50 * PHYSICS_SCALE, 0]);
     entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', grassTexture, sampler);
     entities.push(entity1);
 
@@ -106,11 +106,11 @@ const load = async function() {
 
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
-    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 50 * PHYSICS_SCALE, 500 * PHYSICS_SCALE]);
+    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 30 * PHYSICS_SCALE, 240 * PHYSICS_SCALE]);
     cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([0.0, 0.0, 0.0]);
     const cameraComponent = cameraEntity.getCamera();
     cameraComponent.zNear = 0.1;
-    cameraComponent.zFar = 1000;
+    cameraComponent.zFar = 400;
     cameraComponent.setFovyAndChangeFocalLength(40);
     cameraComponent.aspect = window.innerWidth / window.innerHeight;
 

--- a/examples/threejs/ammo/box/index.js
+++ b/examples/threejs/ammo/box/index.js
@@ -219,7 +219,7 @@ function init() {
     let width = window.innerWidth;
     let height = window.innerHeight;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 300);
     camera.position.x = 0;
     camera.position.y = 100 * SCALE;
     camera.position.z = 150 * SCALE;

--- a/examples/threejs/ammo_legacy/box/index.js
+++ b/examples/threejs/ammo_legacy/box/index.js
@@ -219,7 +219,7 @@ function init() {
     let width = window.innerWidth;
     let height = window.innerHeight;
 
-    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    let camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 300);
     camera.position.x = 0;
     camera.position.y = 100 * SCALE;
     camera.position.z = 150 * SCALE;

--- a/examples/threejs/cannon-es/box/index.js
+++ b/examples/threejs/cannon-es/box/index.js
@@ -80,11 +80,11 @@ function init() {
     parentElement.appendChild(renderer.domElement);
 
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 8;
-    camera.position.y = 20;
-    camera.position.z = 50;
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera.position.y = 10;
+    camera.position.z = 24;
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     initLights();
     initGround();
@@ -109,12 +109,12 @@ function initLights() {
 }
 
 function initGround() {
-    let groundShape = new CANNON.Box(new CANNON.Vec3(50/2, 1/2, 50/2));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(30/2, 0.4/2, 30/2));
     let groundBody = new CANNON.Body({mass: 0});
     groundBody.addShape(groundShape);
     world.addBody(groundBody);
 
-    let ground = createGround(50, 1, 50);
+    let ground = createGround(30, 0.4, 30);
     scene.add(ground);
 }
 
@@ -152,7 +152,7 @@ function createBoxes() {
         for (let y = 0; y < 16; y++) {
             let i = x + (15 - y) * 16;
             let z = 0;
-            let x1 = -10 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
+            let x1 = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
             let y1 = 0 + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
             let z1 = z * BOX_SIZE * 1 + Math.random() * 0.1;
             let color = getRgbColor(dataSet[y * 16 + x]);

--- a/examples/threejs/cannon/box/index.js
+++ b/examples/threejs/cannon/box/index.js
@@ -79,11 +79,11 @@ function init() {
     parentElement.appendChild(renderer.domElement);
 
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 8;
-    camera.position.y = 20;
-    camera.position.z = 50;
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera.position.y = 10;
+    camera.position.z = 24;
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     initLights();
     initGround();
@@ -108,12 +108,12 @@ function initLights() {
 }
 
 function initGround() {
-    let groundShape = new CANNON.Box(new CANNON.Vec3(50/2, 1/2, 50/2));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(30/2, 0.4/2, 30/2));
     let groundBody = new CANNON.Body({mass: 0});
     groundBody.addShape(groundShape);
     world.add(groundBody);
 
-    let ground = createGround(50, 1, 50);
+    let ground = createGround(30, 0.4, 30);
     scene.add(ground);
 }
 
@@ -151,7 +151,7 @@ function createBoxes() {
         for (let y = 0; y < 16; y++) {
             let i = x + (15 - y) * 16;
             let z = 0;
-            let x1 = -10 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
+            let x1 = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
             let y1 = 0 + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
             let z1 = z * BOX_SIZE * 1 + Math.random() * 0.1;
             let color = getRgbColor(dataSet[y * 16 + x]);

--- a/examples/threejs/oimo/box/index.js
+++ b/examples/threejs/oimo/box/index.js
@@ -76,8 +76,8 @@ function initOimo() {
     });
     let groundBody = world.add({
         type: "box",
-        size: [50, 1, 50],
-        pos: [0, -5, 0],
+        size: [30, 0.4, 30],
+        pos: [0, -2, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -86,19 +86,19 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 20;
-    camera.position.z = 50;
+    camera.position.y = 10;
+    camera.position.z = 24;
     scene = new THREE.Scene();
 
     loader = new THREE.TextureLoader();
     texture_grass = loader.load('../../../../assets/textures/grass.jpg');
 
     let material = new THREE.MeshBasicMaterial({map: texture_grass});
-    let geometryGround = new THREE.BoxGeometry(50, 1, 50);
+    let geometryGround = new THREE.BoxGeometry(30, 0.4, 30);
     meshGround = new THREE.Mesh(geometryGround, material);
-    meshGround.position.y = -5;
+    meshGround.position.y = -2;
     scene.add(meshGround);
 
     renderer = new THREE.WebGLRenderer();
@@ -148,8 +148,8 @@ function createBoxes() {
         for (let y = 0; y < 16; y++) {
             let i = x + (15 - y) * 16;
             let z = 0;
-            let x1 = -10 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
-            let y1 = -5  + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
+            let x1 = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
+            let y1 = 0  + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
             let z1 = z * BOX_SIZE * 1 + Math.random() * 0.1;
             let color = getRgbColor(dataSet[y * 16 + x]);
             let w = BOX_SIZE * 1;

--- a/examples/threejs/oimophysics/box/index.js
+++ b/examples/threejs/oimophysics/box/index.js
@@ -70,12 +70,12 @@ function initOimo() {
     world.gravity = new OIMO.Vec3(0, -9.80665, 0);
     
     let groundShapec = new OIMO.ShapeConfig();
-    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(25, 0, 25));
+    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(15, 0.2, 15));
     groundShapec.friction  = 0.6;
     groundShapec.restitution  = 0.5;
     let groundBodyc = new OIMO.RigidBodyConfig();
     groundBodyc.type = OIMO.RigidBodyType.STATIC;
-    groundBodyc.position = new OIMO.Vec3(0, -5, 0);
+    groundBodyc.position = new OIMO.Vec3(0, -2, 0);
     let groundBody = new OIMO.RigidBody(groundBodyc);
     groundBody.addShape(new OIMO.Shape(groundShapec));
     world.addRigidBody(groundBody);
@@ -83,20 +83,20 @@ function initOimo() {
 
 function initThree() {
     container = document.getElementById('container');
-    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 0.1, 300);
     camera.position.x = 0;
-    camera.position.y = 20;
-    camera.position.z = 50;
+    camera.position.y = 10;
+    camera.position.z = 24;
     scene = new THREE.Scene();
 
     loader = new THREE.TextureLoader();
     texture_grass = loader.load('../../../../assets/textures/grass.jpg');
 
     let material = new THREE.MeshBasicMaterial({map: texture_grass});
-    let geometryGround = new THREE.PlaneGeometry(50, 50);
+    let geometryGround = new THREE.PlaneGeometry(30, 30);
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.rotation.x = -Math.PI * 90 / 180;
-    meshGround.position.y = -5;
+    meshGround.position.y = -2;
     scene.add(meshGround);
 
     renderer = new THREE.WebGLRenderer();
@@ -150,8 +150,8 @@ function createBoxes() {
         for (let y = 0; y < 16; y++) {
             let i = x + (15 - y) * 16;
             let z = 0;
-            let x1 = -10 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
-            let y1 = -5 + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
+            let x1 = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
+            let y1 = 0 + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
             let z1 = z * BOX_SIZE * 1 + Math.random() * 0.1;
             let color = getRgbColor(dataSet[y * 16 + x]);
             let w = BOX_SIZE * 1;

--- a/examples/threejs/physx/box/index.js
+++ b/examples/threejs/physx/box/index.js
@@ -212,7 +212,7 @@ function init(PhysX) {
     console.log('Created scene');
     
     // create three.js scene
-    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.01, 1000 );
+    const camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.01, 300 );
     camera.position.x = 0;
     camera.position.y = 100 * SCALE;
     camera.position.z = 150 * SCALE;

--- a/examples/threejs/rapier/box/index.js
+++ b/examples/threejs/rapier/box/index.js
@@ -71,9 +71,9 @@ async function init() {
 
     // Three.js の初期設定
     scene = new THREE.Scene();
-    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
-    camera.position.set(8, 20, 50);
-    camera.lookAt(new THREE.Vector3(0, 10, 0));
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 300);
+    camera.position.set(8, 10, 24);
+    camera.lookAt(new THREE.Vector3(0, 4, 0));
 
     renderer = new THREE.WebGLRenderer();
     renderer.setSize(window.innerWidth, window.innerHeight);
@@ -111,13 +111,13 @@ function initLights() {
 
 function initGround() {
     // Rapier の地面のコライダー
-    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(25, 0.5, 25);
+    const groundColliderDesc = RAPIER.ColliderDesc.cuboid(15, 0.2, 15);
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed();
     const groundBody = world.createRigidBody(groundBodyDesc);
     world.createCollider(groundColliderDesc, groundBody);
 
     // Three.js の地面の作成
-    const ground = createGround(50, 1, 50);
+    const ground = createGround(30, 0.4, 30);
     scene.add(ground);
 }
 
@@ -147,7 +147,7 @@ function createBoxes() {
         for (let y = 0; y < 16; y++) {
             let i = x + (15 - y) * 16;
             let z = 0;
-            let x1 = -10 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
+            let x1 = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
             let y1 = 0 + (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
             let z1 = z * BOX_SIZE * 1 + Math.random() * 0.1;
             let color = getRgbColor(dataSet[y * 16 + x]);

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -287,7 +287,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -309,8 +309,8 @@ function initPhysics() {
                 type: 'box',
                 size: [boxSize, boxSize, boxSize],
                 pos: [
-                    -10 + x * boxSize * 1.5 + Math.random() * 0.1,
-                    -5 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
+                    -12 + x * boxSize * 1.5 + Math.random() * 0.1,
+                    0 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
                     Math.random() * 0.1
                 ],
                 rot: [0, 0, 0],
@@ -341,9 +341,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -271,7 +271,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -293,8 +293,8 @@ function initPhysics() {
                 type: 'box',
                 size: [boxSize, boxSize, boxSize],
                 pos: [
-                    -10 + x * boxSize * 1.5 + Math.random() * 0.1,
-                    -5 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
+                    -12 + x * boxSize * 1.5 + Math.random() * 0.1,
+                    0 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
                     Math.random() * 0.1
                 ],
                 rot: [0, 0, 0],
@@ -325,9 +325,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgpu/oimo/box/index.js
+++ b/examples/webgpu/oimo/box/index.js
@@ -226,7 +226,7 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [50, 1, 50], pos: [0, -5, 0] };
+    ground = { size: [30, 0.4, 30], pos: [0, -2, 0] };
 
     world.add({
         type: 'box',
@@ -248,8 +248,8 @@ function initPhysics() {
                 type: 'box',
                 size: [boxSize, boxSize, boxSize],
                 pos: [
-                    -10 + x * boxSize * 1.5 + Math.random() * 0.1,
-                    -5 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
+                    -12 + x * boxSize * 1.5 + Math.random() * 0.1,
+                    0 + (DOT_ROWS.length - 1 - y) * boxSize * 1.2 + Math.random() * 0.1,
                     Math.random() * 0.1
                 ],
                 rot: [0, 0, 0],
@@ -325,9 +325,9 @@ function render(timeMs) {
     world.step();
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 50, 20, Math.cos(t * 0.2) * 50);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
     mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     const encoder = device.createCommandEncoder();


### PR DESCRIPTION
Reduce oversized ground planes and bring cameras closer so the stacked boxes scene looks consistent with the minimum/domino/football examples. Also fix spawn positions so all boxes fall onto the ground.

Ground / physics body changes:
- webgl1/2/webgpu oimo: ground [50,1,50]->[30,0.4,30] pos y -5->-2, camera radius 50->24 y 20->12, far 200->150
- threejs oimo: same ground shrink to [30,0.4,30], camera y 20->10 z 50->24 far 1000->300
- threejs oimophysics: BoxGeometry(25,0,25)->(15,0.2,15), PlaneGeometry 50->30, ground pos y -5->-2, camera same
- threejs cannon/cannon-es: CANNON.Vec3 half-extents 25/0.5->15/0.2, createGround 50/1->30/0.4, camera y 20->10 z 50->24 far 1000->300
- threejs rapier: cuboid 25/0.5->15/0.2, createGround 50->30, camera same
- threejs ammo/ammo_legacy/physx: far 1000->300
- babylonjs ammo/cannon/oimo/havok: camera z -500->-300 y 50->30 (*PHYSICS_SCALE)
- rhodonite oimo: ground scale 400->200 (*PHYSICS_SCALE), camera z 500->240 y 50->30, zFar 1000->400
- glboost oimo: DOT_SIZE 8->0.8, camera eye (0,50,100)->(0,12,24), zFar 3000->300, ground cube 200/2/200->20/0.4/20 pos y -20->-2
- claygl oimo: camera z 500->60, ground size 200*2->40*2 pos y -80->-8, box_size 8->0.8, spawn offsets scaled down

Spawn position fixes:
- webgl1/2/webgpu oimo: x1 offset -10->-12, y1 base -5->0
- threejs oimo/oimophysics: y1 base -5->0
- threejs cannon/cannon-es/oimo/oimophysics/rapier: x1 offset -10->-12