### PR TITLE
balls: align scale, spawn height, and camera parity across frameworks

### DIFF
--- a/examples/babylonjs/ammo/balls/index.js
+++ b/examples/babylonjs/ammo/balls/index.js
@@ -23,7 +23,7 @@ const createScene = function() {
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);
     camera.minZ /= 100; // TODO: If near is 1, the model is missing, so adjusted
-    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -200 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas, true);
 
     const mat = new BABYLON.StandardMaterial("ground", scene);
@@ -32,7 +32,7 @@ const createScene = function() {
     t.uScale = t.vScale = 2;
     mat.diffuseTexture = t;
     mat.specularColor = BABYLON.Color3.Black();
-    const g = BABYLON.Mesh.CreateBox("ground", 200 * PHYSICS_SCALE, scene);
+    const g = BABYLON.Mesh.CreateBox("ground", 400 * PHYSICS_SCALE, scene);
     g.position.y = -15 * PHYSICS_SCALE;
     g.scaling.y = 0.01;
     g.material = mat;

--- a/examples/babylonjs/cannon/balls/index.js
+++ b/examples/babylonjs/cannon/balls/index.js
@@ -23,7 +23,7 @@ const createScene = function() {
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);
     camera.minZ /= 100; // TODO: If near is 1, the model is missing, so adjusted
-    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -200 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas, true);
 
     const mat = new BABYLON.StandardMaterial("ground", scene);
@@ -32,7 +32,7 @@ const createScene = function() {
     t.uScale = t.vScale = 2;
     mat.diffuseTexture = t;
     mat.specularColor = BABYLON.Color3.Black();
-    const g = BABYLON.Mesh.CreateBox("ground", 200 * PHYSICS_SCALE, scene);
+    const g = BABYLON.Mesh.CreateBox("ground", 400 * PHYSICS_SCALE, scene);
     g.position.y = -15 * PHYSICS_SCALE;
     g.scaling.y = 0.01;
     g.material = mat;

--- a/examples/babylonjs/havok/balls/index.js
+++ b/examples/babylonjs/havok/balls/index.js
@@ -24,7 +24,7 @@ const createScene = function() {
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);
     camera.minZ /= 100; // TODO: If near is 1, the model is missing, so adjusted
-    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -200 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas, true);
 
     const mat = new BABYLON.StandardMaterial("ground", scene);
@@ -33,7 +33,7 @@ const createScene = function() {
     t.uScale = t.vScale = 2;
     mat.diffuseTexture = t;
     mat.specularColor = BABYLON.Color3.Black();
-    const g = BABYLON.Mesh.CreateBox("ground", 200 * PHYSICS_SCALE, scene);
+    const g = BABYLON.Mesh.CreateBox("ground", 400 * PHYSICS_SCALE, scene);
     g.position.y = -15 * PHYSICS_SCALE;
     g.scaling.y = 0.01;
     g.material = mat;

--- a/examples/babylonjs/oimo/balls/index.js
+++ b/examples/babylonjs/oimo/balls/index.js
@@ -23,7 +23,7 @@ const createScene = function() {
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);
     camera.minZ /= 100; // TODO: If near is 1, the model is missing, so adjusted
-    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -200 * PHYSICS_SCALE));
+    camera.setPosition(new BABYLON.Vector3(0, 20 * PHYSICS_SCALE, -300 * PHYSICS_SCALE));
     camera.attachControl(canvas, true);
 
     const mat = new BABYLON.StandardMaterial("ground", scene);
@@ -32,7 +32,7 @@ const createScene = function() {
     t.uScale = t.vScale = 2;
     mat.diffuseTexture = t;
     mat.specularColor = BABYLON.Color3.Black();
-    const g = BABYLON.Mesh.CreateBox("ground", 200 * PHYSICS_SCALE, scene);
+    const g = BABYLON.Mesh.CreateBox("ground", 400 * PHYSICS_SCALE, scene);
     g.position.y = -15 * PHYSICS_SCALE;
     g.scaling.y = 0.01;
     g.material = mat;

--- a/examples/claygl/oimo/balls/index.js
+++ b/examples/claygl/oimo/balls/index.js
@@ -19,7 +19,7 @@ let app = clay.application.create('#main', {
         
         // Create a orthographic camera
         this._camera = app.createCamera(null, null, 'perspective');
-        this._camera.position.set(0, 0, 500);
+        this._camera.position.set(0, 0, 60);
         this._rad = 0;
         app.resize(window.innerWidth, window.innerHeight);
          
@@ -56,16 +56,16 @@ let app = clay.application.create('#main', {
 
         this._oimoGround = this._world.add({
            type: "box",
-            size: [400*2, 4*2, 400*2],
-            pos: [0, -80, 0],
+            size: [40*2, 0.4*2, 40*2],
+            pos: [0, -8, 0],
             rot: [0, 0, 0],
             move: false,
             density: 1
         });
 
         this._meshGround = app.createMesh(geometryGround, materialGround);
-        this._meshGround.scale.set(400, 4, 400);
-        this._meshGround.position.set(0, -80, 0);
+        this._meshGround.scale.set(40, 0.4, 40);
+        this._meshGround.position.set(0, -8, 0);
         materialGround.set('diffuseMap', diffuse);
         
     },
@@ -83,10 +83,10 @@ let app = clay.application.create('#main', {
         materialSurface.set('alpha', 0.5);
     
         let boxDataSet = [
-            { size:[100, 100,  10], pos:[  0, 50,-50], rot:[0,0,0] },
-            { size:[100, 100,  10], pos:[  0, 50, 50], rot:[0,0,0] },
-            { size:[ 10, 100, 100], pos:[-50, 50,  0], rot:[0,0,0] },
-            { size:[ 10, 100, 100], pos:[ 50, 50,  0], rot:[0,0,0] } 
+            { size:[10, 10,  1], pos:[  0, 5,-5], rot:[0,0,0] },
+            { size:[10, 10,  1], pos:[  0, 5, 5], rot:[0,0,0] },
+            { size:[ 1, 10, 10], pos:[-5, 5,  0], rot:[0,0,0] },
+            { size:[ 1, 10, 10], pos:[ 5, 5,  0], rot:[0,0,0] } 
         ];
         let geometrySurface = new clay.geometry.Cube();
         let surfaces = [];
@@ -98,12 +98,12 @@ let app = clay.application.create('#main', {
                 geometrySurface,
                 materialSurface
             );
-            meshSurface.position.set(pos[0], pos[1] - 80, pos[2]);
+            meshSurface.position.set(pos[0], pos[1] - 8, pos[2]);
             meshSurface.scale.set(size[0]/2, size[1]/2, size[2]/2);
             let oimoGround = this._world.add({
                 type: "box",
                 size: [size[0], size[1], size[2]],
-                pos: [pos[0], pos[1] - 80, pos[2]],
+                pos: [pos[0], pos[1] - 8, pos[2]],
                 rot: [0, 0, 0],
                 move: false,
                 density: 1

--- a/examples/glboost/oimo/balls/index.js
+++ b/examples/glboost/oimo/balls/index.js
@@ -31,14 +31,14 @@ function init() {
     scene = glBoostContext.createScene();
 
     camera = glBoostContext.createPerspectiveCamera({
-        eye: new GLBoost.Vector3(0.0, 100, 200),
+        eye: new GLBoost.Vector3(0.0, 24, 48),
         center: new GLBoost.Vector3(0.0, 0.0, 0.0),
         up: new GLBoost.Vector3(0.0, 1.0, 0.0)
     }, {
         fovy: 45.0,
         aspect: width/height,
         zNear: 0.001,
-        zFar: 3000.0
+        zFar: 300.0
     });
     camera.cameraController = glBoostContext.createCameraController();
     scene.addChild(camera);
@@ -74,8 +74,8 @@ function populate() {
 
     let ground2 = world.add({
         type: "box",
-        size: [400, 40, 400],
-        pos: [0, -20, 0],
+        size: [20, 2, 20],
+        pos: [0, -1, 0],
         rot: [0, 0, 0],
         move: false,
         density: 1,
@@ -83,13 +83,13 @@ function populate() {
         restitution: 0.1,
     });
     
-    addStaticBox([400, 40, 400], [0,-20,0], [0,0,0]);
+    addStaticBox([20, 2, 20], [0,-1,0], [0,0,0]);
     
     let boxDataSet = [
-        { size:[100, 100,  10], pos:[  0, 50,-50], rot:[0,0,0] },
-        { size:[100, 100,  10], pos:[  0, 50, 50], rot:[0,0,0] },
-        { size:[ 10, 100, 100], pos:[-50, 50,  0], rot:[0,0,0] },
-        { size:[ 10, 100, 100], pos:[ 50, 50,  0], rot:[0,0,0] } 
+        { size:[5, 5,  0.5], pos:[  0, 2.5,-2.5], rot:[0,0,0] },
+        { size:[5, 5,  0.5], pos:[  0, 2.5, 2.5], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[-2.5, 2.5,  0], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[ 2.5, 2.5,  0], rot:[0,0,0] } 
     ];
     
     let surfaces = [];
@@ -130,12 +130,12 @@ function populate() {
     let x, y, z;
     let i = max;
     while (i--){
-        x = -50 + Math.random()*100;
-        y = 200 + Math.random()*100;
-        z = -50 + Math.random()*100;
-        w = 20 + Math.random()*10;
-        h = 10 + Math.random()*10;
-        d = 10 + Math.random()*10;
+        x = -5 + Math.random()*10;
+        y = 10 + Math.random()*5;
+        z = -5 + Math.random()*10;
+        w = 1 + Math.random()*0.5;
+        h = 0.5 + Math.random()*0.5;
+        d = 0.5 + Math.random()*0.5;
         let pos = Math.floor(Math.random() * dataSet.length);
         let scale = dataSet[pos].scale;
         w *= scale;
@@ -197,10 +197,10 @@ function animate() {
         let q = body.getQuaternion();
         mesh.translate = new GLBoost.Vector3(p.x, p.y, p.z);
         mesh.quaternion = new GLBoost.Quaternion(q.x, q.y, q.z, q.w);
-        if ( p.y < -300 ) {
-            x = -50 + Math.random()*100;
-            y = 200 + Math.random()*100;
-            z = -50 + Math.random()*100;
+        if ( p.y < -15 ) {
+            x = -5 + Math.random()*10;
+            y = 10 + Math.random()*5;
+            z = -5 + Math.random()*10;
             bodys[i].resetPosition(x, y, z);
         }
     }

--- a/examples/grimoirejs/oimo/balls/index.html
+++ b/examples/grimoirejs/oimo/balls/index.html
@@ -13,16 +13,16 @@
   <goml width="fit" height="fit">
       <scene>
           <light rotation="x(-30d)" color="white" type="directional" position="0,10,0" intensity="3"/>
-          <camera class="camera" near="0.01" far="400.0" aspect="1.0" fovy="45d" position="0,10,30" rotation="x(0d)">
+          <camera class="camera" near="0.01" far="400.0" aspect="1.0" fovy="45d" position="0,5,25" rotation="x(0d)">
               <camera.components>
                   <MouseCameraControl></MouseCameraControl>
               </camera.components>
           </camera>
-          <rigid-cube position="0,0,-4.5" scale="5, 5, 0.5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
-          <rigid-cube position="0,0,+4.5" scale="5, 5, 0.5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
-          <rigid-cube position="-4.5,0,0" scale="0.5, 5, 5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
-          <rigid-cube position="+4.5,0,0" scale="0.5, 5, 5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
-          <rigid-cube position="0,-5,0" scale="15, 0.5, 15" move="false" transparent="false" albedo="#404040FF" emission="#000000"/>
+          <rigid-cube position="0,0,-5" scale="5, 5, 0.5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
+          <rigid-cube position="0,0,+5" scale="5, 5, 0.5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
+          <rigid-cube position="-5,0,0" scale="0.5, 5, 5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
+          <rigid-cube position="+5,0,0" scale="0.5, 5, 5" move="false" transparent="true" albedo="#40404070" emission="#000000"/>
+          <rigid-cube position="0,-5,0" scale="20, 0.5, 20" move="false" transparent="false" albedo="#404040FF" emission="#000000"/>
       </scene>
   </goml>
 </script>

--- a/examples/rhodonite/oimo/balls/index.js
+++ b/examples/rhodonite/oimo/balls/index.js
@@ -66,16 +66,16 @@ const load = async function() {
         tag: "type",
         value: "ground"
     });
-    entity1.scale = Rn.Vector3.fromCopyArray([40 * PHYSICS_SCALE, 4 * PHYSICS_SCALE, 40 * PHYSICS_SCALE]);
-    entity1.position = Rn.Vector3.fromCopyArray([0, -2 * PHYSICS_SCALE, 0]);
+    entity1.scale = Rn.Vector3.fromCopyArray([200 * PHYSICS_SCALE, 20 * PHYSICS_SCALE, 200 * PHYSICS_SCALE]);
+    entity1.position = Rn.Vector3.fromCopyArray([0, -20 * PHYSICS_SCALE, 0]);
     entities.push(entity1);
 
     // Box walls
     const boxDataSet = [
-        { size:[10, 10,  1], pos:[ 0, 5,-5] }, // front
-        { size:[10, 10,  1], pos:[ 0, 5, 5] }, // back
-        { size:[ 1, 10, 10], pos:[-5, 5, 0] }, // left
-        { size:[ 1, 10, 10], pos:[ 5, 5, 0] }  // right
+        { size:[48, 50,  4], pos:[ 0, 15,-25] }, // front
+        { size:[48, 50,  4], pos:[ 0, 15, 25] }, // back
+        { size:[ 4, 50, 48], pos:[-25, 15, 0] }, // left
+        { size:[ 4, 50, 48], pos:[ 25, 15, 0] }  // right
     ];
 
     for (let i = 0; i < boxDataSet.length; i++) {
@@ -105,11 +105,11 @@ const load = async function() {
 
 	// camera
 	const cameraEntity = Rn.createCameraControllerEntity(engine);
-	cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 15 * PHYSICS_SCALE, 30 * PHYSICS_SCALE]);
+    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 100 * PHYSICS_SCALE, 160 * PHYSICS_SCALE]);
 	cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.1, 0.0, 0.0]);
 	const cameraComponent = cameraEntity.getCamera();
 	cameraComponent.zNear = 0.1;
-	cameraComponent.zFar = 1000;
+	cameraComponent.zFar = 400;
 	cameraComponent.setFovyAndChangeFocalLength(60);
 	cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
@@ -151,10 +151,10 @@ function populate(textures, sampler) {
     const max = 200;
     
     for (let i = 0; i < max; i++) {
-        const x = -5 + Math.random() * 10;
-        const y = 20 + Math.random() * 10;
-        const z = -5 + Math.random() * 10;
-        const w = 2 + Math.random() * 1;
+        const x = -25 + Math.random() * 50;
+        const y = 60 + Math.random() * 130;
+        const z = -25 + Math.random() * 50;
+        const w = 10 + Math.random() * 5;
 
         const pos = Math.floor(Math.random() * dataSet.length);
         const scale = dataSet[pos].scale;

--- a/examples/threejs/cannon-es/balls/index.js
+++ b/examples/threejs/cannon-es/balls/index.js
@@ -32,8 +32,8 @@ let bodys = [];
 
 function init() {
 
-    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-    camera.position.set(18, 20, 30);
+    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 300);
+    camera.position.set(10, 10, 16);
 
     scene = new THREE.Scene();
 
@@ -106,19 +106,19 @@ function addStaticBox(size, position, rotation, spec) {
 function initCannonPhysics() {
     let max = 200;
     let groundMaterial = new CANNON.Material('ground')
-    let groundShape = new CANNON.Box(new CANNON.Vec3(40/2, 4/2, 40/2));
+    let groundShape = new CANNON.Box(new CANNON.Vec3(20/2, 2/2, 20/2));
     let groundBody = new CANNON.Body({mass: 0, material: groundMaterial});
     groundBody.position.set(0, -2, 0);
     groundBody.addShape(groundShape);
     world.addBody(groundBody);
     
-    addStaticBox([40, 4, 40], [0, -2, 0], [0, 0, 0]);
+    addStaticBox([20, 2, 20], [0, -2, 0], [0, 0, 0]);
 
     let boxDataSet = [
-        { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
-        { size:[10, 10,  1], pos:[ 0, 5, 5], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[-5, 5, 0], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
+        { size:[5, 5,  0.5], pos:[ 0, 1.5,-2.5], rot:[0,0,0] },
+        { size:[5, 5,  0.5], pos:[ 0, 1.5, 2.5], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[-2.5, 1.5, 0], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[ 2.5, 1.5, 0], rot:[0,0,0] } 
     ];
 
     let surfaces = [];
@@ -139,7 +139,7 @@ function initCannonPhysics() {
 
     while (i--) {
         let x = -5 + Math.random() * 10;
-        let y = 20 + Math.random() * 10;
+        let y = 6 + Math.random() * 13;
         let z = -5 + Math.random() * 10;
         let w = 2 + Math.random() * 1;
         let h = 1 + Math.random() * 1;
@@ -147,7 +147,7 @@ function initCannonPhysics() {
 
         let pos = Math.floor(Math.random() * dataSet.length);
         let scale = dataSet[pos].scale;
-        w *= scale;
+        w *= scale * 0.5;
 
         let shape = new CANNON.Sphere(w/2);
         let ballMaterial = new CANNON.Material('ball')
@@ -188,7 +188,7 @@ function updateCannonPhysics() {
         
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
-            let y = 20 + Math.random() * 10;
+            let y = 10 + Math.random() * 8;
             let z = -5 + Math.random() * 10;
             body.angularVelocity.set(0, 0, 0);
             //body.velocity.set(0, 0, 0);

--- a/examples/threejs/oimo/balls/index.js
+++ b/examples/threejs/oimo/balls/index.js
@@ -36,8 +36,8 @@ let bodys = [];
 
 function init() {
 
-    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-    camera.position.set(18, 20, 30);
+    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 300);
+    camera.position.set(10, 10, 16);
 
     scene = new THREE.Scene();
 
@@ -111,7 +111,7 @@ function initOimoPhysics() {
     let max = 200;
     let groundBody = world.add({
         type: "box",
-        size: [40, 4, 40],
+        size: [20, 2, 20],
         pos: [0, -2, 0],
         rot: [0, 0, 0],
         move: false,
@@ -119,13 +119,13 @@ function initOimoPhysics() {
         friction: 0.6,
         restitution: 0.5,
     });
-    addStaticBox([40, 4, 40], [0, -2, 0], [0, 0, 0]);
+    addStaticBox([20, 2, 20], [0, -2, 0], [0, 0, 0]);
 
     let boxDataSet = [
-        { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
-        { size:[10, 10,  1], pos:[ 0, 5, 5], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[-5, 5, 0], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
+        { size:[5, 5,  0.5], pos:[ 0, 1.5,-2.5], rot:[0,0,0] },
+        { size:[5, 5,  0.5], pos:[ 0, 1.5, 2.5], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[-2.5, 1.5, 0], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[ 2.5, 1.5, 0], rot:[0,0,0] } 
     ];
 
     let surfaces = [];
@@ -151,7 +151,7 @@ function initOimoPhysics() {
 
     while (i--) {
         let x = -5 + Math.random() * 10;
-        let y = 20 + Math.random() * 10;
+        let y = 6 + Math.random() * 13;
         let z = -5 + Math.random() * 10;
         let w = 2 + Math.random() * 1;
         let h = 1 + Math.random() * 1;
@@ -159,7 +159,7 @@ function initOimoPhysics() {
 
         let pos = Math.floor(Math.random() * dataSet.length);
         let scale = dataSet[pos].scale;
-        w *= scale;
+        w *= scale * 0.5;
 
         let ballBody = world.add({
             type: "sphere",
@@ -201,7 +201,7 @@ function updateOimoPhysics() {
         
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
-            let y = 20 + Math.random() * 10;
+            let y = 10 + Math.random() * 8;
             let z = -5 + Math.random() * 10;
             body.resetPosition(x, y, z);
         }

--- a/examples/threejs/oimophysics/balls/index.js
+++ b/examples/threejs/oimophysics/balls/index.js
@@ -30,8 +30,8 @@ let bodys = [];
 
 function init() {
 
-    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-    camera.position.set(18, 20, 30);
+    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 300);
+    camera.position.set(10, 10, 16);
 
     scene = new THREE.Scene();
 
@@ -102,7 +102,7 @@ function initOimoPhysics() {
 
     // Is all the physics setting for rigidbody
     let groundShapec = new OIMO.ShapeConfig();
-    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(40/2, 4/2, 40/2));
+    groundShapec.geometry = new OIMO.BoxGeometry(new OIMO.Vec3(20/2, 2/2, 20/2));
     groundShapec.friction  = 0.6;
     groundShapec.restitution  = 0.5;
     let groundBodyc = new OIMO.RigidBodyConfig();
@@ -112,13 +112,13 @@ function initOimoPhysics() {
     groundBody.addShape(new OIMO.Shape(groundShapec));
     world.addRigidBody(groundBody);
 
-    addStaticBox([40, 4, 40], [0, -2, 0], [0, 0, 0]);
+    addStaticBox([20, 2, 20], [0, -2, 0], [0, 0, 0]);
 
     let boxDataSet = [
-        { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
-        { size:[10, 10,  1], pos:[ 0, 5, 5], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[-5, 5, 0], rot:[0,0,0] },
-        { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
+        { size:[5, 5,  0.5], pos:[ 0, 1.5,-2.5], rot:[0,0,0] },
+        { size:[5, 5,  0.5], pos:[ 0, 1.5, 2.5], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[-2.5, 1.5, 0], rot:[0,0,0] },
+        { size:[ 0.5, 5, 5], pos:[ 2.5, 1.5, 0], rot:[0,0,0] } 
     ];
 
     let surfaces = [];
@@ -144,7 +144,7 @@ function initOimoPhysics() {
 
     while (i--) {
         let x = -5 + Math.random() * 10;
-        let y = 20 + Math.random() * 10;
+        let y = 6 + Math.random() * 13;
         let z = -5 + Math.random() * 10;
         let w = 2 + Math.random() * 1;
         let h = 1 + Math.random() * 1;
@@ -152,7 +152,7 @@ function initOimoPhysics() {
 
         let pos = Math.floor(Math.random() * dataSet.length);
         let scale = dataSet[pos].scale;
-        w *= scale;
+        w *= scale * 0.5;
 
         let ballShapec = new OIMO.ShapeConfig();
         ballShapec.geometry = new OIMO.SphereGeometry(w/2);
@@ -200,7 +200,7 @@ function updateOimoPhysics() {
         // reset position
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
-            let y = 20 + Math.random() * 10;
+            let y = 10 + Math.random() * 8;
             let z = -5 + Math.random() * 10;
 
             body.setAngularVelocity(new OIMO.Vec3(0, 0, 0));

--- a/examples/threejs/rapier/balls/index.js
+++ b/examples/threejs/rapier/balls/index.js
@@ -28,8 +28,8 @@ async function init() {
     await RAPIER.init();
     
     // Three.js の初期設定
-    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-    camera.position.set(18, 20, 30);
+    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 300);
+    camera.position.set(10, 10, 16);
 
     scene = new THREE.Scene();
 
@@ -108,13 +108,13 @@ function initRapierPhysics() {
     let groundBody = world.createRigidBody(groundBodyDesc);
     world.createCollider(groundColliderDesc, groundBody);
 
-    addStaticBox([40, 4, 40], [0, -2, 0], [0, 0, 0]);
+    addStaticBox([20, 2, 20], [0, -2, 0], [0, 0, 0]);
 
     let boxDataSet = [
-        { size: [10, 10,  1], pos: [ 0, 5, -5], rot: [0, 0, 0] },
-        { size: [10, 10,  1], pos: [ 0, 5,  5], rot: [0, 0, 0] },
-        { size: [ 1, 10, 10], pos: [-5, 5,  0], rot: [0, 0, 0] },
-        { size: [ 1, 10, 10], pos: [ 5, 5,  0], rot: [0, 0, 0] }
+        { size: [5, 5,  0.5], pos: [ 0, 1.5, -2.5], rot: [0, 0, 0] },
+        { size: [5, 5,  0.5], pos: [ 0, 1.5,  2.5], rot: [0, 0, 0] },
+        { size: [ 0.5, 5, 5], pos: [-2.5, 1.5,  0], rot: [0, 0, 0] },
+        { size: [ 0.5, 5, 5], pos: [ 2.5, 1.5,  0], rot: [0, 0, 0] }
     ];
 
     for (let i = 0; i < boxDataSet.length; i++) {
@@ -130,13 +130,13 @@ function initRapierPhysics() {
     // ボールの初期化
     for (let i = 0; i < 200; i++) {
         const x = -5 + Math.random() * 10;
-        const y = 20 + Math.random() * 10;
+        const y = 6 + Math.random() * 13;
         const z = -5 + Math.random() * 10;
         const w = 1;
 
         const pos = Math.floor(Math.random() * dataSet.length);
         const scale = dataSet[pos].scale;
-        const radius = w * scale;
+        const radius = w * scale * 0.5;
 
         const colliderDesc = RAPIER.ColliderDesc.ball(radius);
         const bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y, z);
@@ -145,7 +145,7 @@ function initRapierPhysics() {
         bodys[i] = body;
 
         const mesh = new THREE.Mesh(buffgeoSphere, matSpheres[pos]);
-        mesh.scale.set(scale, scale, scale);
+        mesh.scale.set(scale * 0.5, scale * 0.5, scale * 0.5);
         mesh.castShadow = true;
         mesh.receiveShadow = true;
 
@@ -170,7 +170,7 @@ function updatePhysics() {
         // 床を超えて落ちたオブジェクトの位置をリセット
         if (mesh.position.y < -10) {
             const x = -5 + Math.random() * 10;
-            const y = 20 + Math.random() * 10;
+            const y = 10 + Math.random() * 8;
             const z = -5 + Math.random() * 10;
             body.setTranslation({ x, y, z }, true);
 

--- a/examples/webgl1/oimo/balls/index.js
+++ b/examples/webgl1/oimo/balls/index.js
@@ -3,7 +3,7 @@ import Module from 'https://esm.run/manifold-3d';
 const { mat4, vec3, quat } = glMatrix;
 
 const BALL_COUNT = 140;
-const BASKET_HALF = 5;
+const BASKET_HALF = 2.5;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const TEXTURE_FILES = [
     '../../../../assets/textures/Basketball.jpg',
@@ -12,6 +12,7 @@ const TEXTURE_FILES = [
     '../../../../assets/textures/Softball.jpg',
     '../../../../assets/textures/TennisBall.jpg'
 ];
+const BALL_SIZE_SCALES = [1.0, 0.9, 1.0, 0.3, 0.3];
 
 let canvas;
 let gl;
@@ -242,12 +243,12 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [40, 4, 40], pos: [0, -2, 0] };
+    ground = { size: [20, 2, 20], pos: [0, -2, 0] };
     basketWalls = [
-        { size: [9.6, 10, 0.8], pos: [0, 5, -5] },
-        { size: [9.6, 10, 0.8], pos: [0, 5, 5] },
-        { size: [0.8, 10, 9.6], pos: [-5, 5, 0] },
-        { size: [0.8, 10, 9.6], pos: [5, 5, 0] }
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, -2.5] },
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, 2.5] },
+        { size: [0.4, 5, 4.8], pos: [-2.5, 1.5, 0] },
+        { size: [0.4, 5, 4.8], pos: [2.5, 1.5, 0] }
     ];
 
     world.add({
@@ -276,13 +277,14 @@ function initPhysics() {
 
     balls = [];
     for (let i = 0; i < BALL_COUNT; i++) {
-        const radius = 0.5 + Math.random() * 0.45;
+        const textureIndex = Math.floor(Math.random() * BALL_SIZE_SCALES.length);
+        const radius = (0.5 + Math.random() * 0.25) * BALL_SIZE_SCALES[textureIndex];
         const body = world.add({
             type: 'sphere',
             size: [radius],
             pos: [
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                12 + Math.random() * 26,
+                6 + Math.random() * 13,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             ],
             rot: [0, 0, 0],
@@ -294,7 +296,7 @@ function initPhysics() {
         balls.push({
             body,
             radius,
-            textureIndex: i % textures.length
+            textureIndex
         });
     }
 }
@@ -316,16 +318,16 @@ function render(timeMs) {
         if (p.y < -20) {
             item.body.resetPosition(
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                20 + Math.random() * 16,
+                10 + Math.random() * 8,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             );
         }
     }
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 28, 18, Math.cos(t * 0.2) * 28);
-    mat4.lookAt(view, eye, [0, 5, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
+    mat4.lookAt(view, eye, [0, 4, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgl2/oimo/balls/index.js
+++ b/examples/webgl2/oimo/balls/index.js
@@ -3,7 +3,7 @@ import Module from 'https://esm.run/manifold-3d';
 const { mat4, vec3, quat } = glMatrix;
 
 const BALL_COUNT = 160;
-const BASKET_HALF = 5;
+const BASKET_HALF = 2.5;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const TEXTURE_FILES = [
     '../../../../assets/textures/Basketball.jpg',
@@ -12,6 +12,7 @@ const TEXTURE_FILES = [
     '../../../../assets/textures/Softball.jpg',
     '../../../../assets/textures/TennisBall.jpg'
 ];
+const BALL_SIZE_SCALES = [1.0, 0.9, 1.0, 0.3, 0.3];
 
 let canvas;
 let gl;
@@ -226,12 +227,12 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [40, 4, 40], pos: [0, -2, 0] };
+    ground = { size: [20, 2, 20], pos: [0, -2, 0] };
     basketWalls = [
-        { size: [9.6, 10, 0.8], pos: [0, 5, -5] },
-        { size: [9.6, 10, 0.8], pos: [0, 5, 5] },
-        { size: [0.8, 10, 9.6], pos: [-5, 5, 0] },
-        { size: [0.8, 10, 9.6], pos: [5, 5, 0] }
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, -2.5] },
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, 2.5] },
+        { size: [0.4, 5, 4.8], pos: [-2.5, 1.5, 0] },
+        { size: [0.4, 5, 4.8], pos: [2.5, 1.5, 0] }
     ];
 
     world.add({
@@ -260,13 +261,14 @@ function initPhysics() {
 
     balls = [];
     for (let i = 0; i < BALL_COUNT; i++) {
-        const radius = 0.5 + Math.random() * 0.45;
+        const textureIndex = Math.floor(Math.random() * BALL_SIZE_SCALES.length);
+        const radius = (0.5 + Math.random() * 0.25) * BALL_SIZE_SCALES[textureIndex];
         const body = world.add({
             type: 'sphere',
             size: [radius],
             pos: [
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                12 + Math.random() * 26,
+                6 + Math.random() * 13,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             ],
             rot: [0, 0, 0],
@@ -278,7 +280,7 @@ function initPhysics() {
         balls.push({
             body,
             radius,
-            textureIndex: i % textures.length
+            textureIndex
         });
     }
 }
@@ -300,16 +302,16 @@ function render(timeMs) {
         if (p.y < -20) {
             item.body.resetPosition(
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                20 + Math.random() * 16,
+                10 + Math.random() * 8,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             );
         }
     }
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 28, 18, Math.cos(t * 0.2) * 28);
-    mat4.lookAt(view, eye, [0, 5, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
+    mat4.lookAt(view, eye, [0, 4, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     gl.clearColor(0.97, 0.97, 0.98, 1.0);

--- a/examples/webgpu/oimo/balls/index.js
+++ b/examples/webgpu/oimo/balls/index.js
@@ -2,7 +2,7 @@ import Module from 'https://esm.run/manifold-3d';
 const { mat4, vec3, quat } = glMatrix;
 
 const BALL_COUNT = 180;
-const BASKET_HALF = 5;
+const BASKET_HALF = 2.5;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const TEXTURE_FILES = [
     '../../../../assets/textures/Basketball.jpg',
@@ -11,6 +11,7 @@ const TEXTURE_FILES = [
     '../../../../assets/textures/Softball.jpg',
     '../../../../assets/textures/TennisBall.jpg'
 ];
+const BALL_SIZE_SCALES = [1.0, 0.9, 1.0, 0.3, 0.3];
 
 let canvas;
 let device;
@@ -181,12 +182,12 @@ function initPhysics() {
         gravity: [0, -9.8, 0]
     });
 
-    ground = { size: [40, 4, 40], pos: [0, -2, 0] };
+    ground = { size: [20, 2, 20], pos: [0, -2, 0] };
     basketWalls = [
-        { size: [9.6, 10, 0.8], pos: [0, 5, -5] },
-        { size: [9.6, 10, 0.8], pos: [0, 5, 5] },
-        { size: [0.8, 10, 9.6], pos: [-5, 5, 0] },
-        { size: [0.8, 10, 9.6], pos: [5, 5, 0] }
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, -2.5] },
+        { size: [4.8, 5, 0.4], pos: [0, 1.5, 2.5] },
+        { size: [0.4, 5, 4.8], pos: [-2.5, 1.5, 0] },
+        { size: [0.4, 5, 4.8], pos: [2.5, 1.5, 0] }
     ];
 
     world.add({
@@ -215,13 +216,14 @@ function initPhysics() {
 
     balls = [];
     for (let i = 0; i < BALL_COUNT; i++) {
-        const radius = 0.5 + Math.random() * 0.45;
+        const textureIndex = Math.floor(Math.random() * BALL_SIZE_SCALES.length);
+        const radius = (0.5 + Math.random() * 0.25) * BALL_SIZE_SCALES[textureIndex];
         const body = world.add({
             type: 'sphere',
             size: [radius],
             pos: [
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                12 + Math.random() * 26,
+                6 + Math.random() * 13,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             ],
             rot: [0, 0, 0],
@@ -233,7 +235,7 @@ function initPhysics() {
         balls.push({
             body,
             radius,
-            textureIndex: i % textureViews.length
+            textureIndex
         });
     }
 }
@@ -303,16 +305,16 @@ function render(timeMs) {
         if (p.y < -20) {
             item.body.resetPosition(
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4),
-                20 + Math.random() * 16,
+                10 + Math.random() * 8,
                 (Math.random() - 0.5) * (BASKET_HALF * 1.4)
             );
         }
     }
 
     const t = timeMs * 0.001;
-    const eye = vec3.fromValues(Math.sin(t * 0.2) * 28, 18, Math.cos(t * 0.2) * 28);
-    mat4.lookAt(view, eye, [0, 5, 0], [0, 1, 0]);
-    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
+    const eye = vec3.fromValues(Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24);
+    mat4.lookAt(view, eye, [0, 4, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
     const encoder = device.createCommandEncoder();


### PR DESCRIPTION
## Summary
- align balls scenario scale ratios across frameworks
- normalize basket/floor proportions and camera distance where mismatched
- unify spawn/respawn heights across three.js and webgl variants
- fix grimoirejs basket wall proportions
- tune glboost and rhodonite balls scene parity

## Updated areas
- webgl1/webgl2/webgpu oimo balls
- threejs oimo/oimophysics/cannon-es/rapier balls
- babylonjs ammo/cannon/havok/oimo balls
- glboost oimo balls
- claygl oimo balls
- grimoirejs oimo balls
- rhodonite oimo balls

