### PR TITLE
Add Havok falling football examples for WebGL1, WebGL2, and WebGPU

### DIFF
--- a/examples/webgl1/havok/football/index.html
+++ b/examples/webgl1/havok/football/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGL 1.0 + Havok Falling Football Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec2 aTexCoord;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+
+void main() {
+    mat3 normalMatrix = mat3(uModel);
+    vNormal = normalize(normalMatrix * aNormal);
+    vTexCoord = aTexCoord;
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D uTexture;
+uniform vec3 uTint;
+uniform vec3 uLightDir;
+uniform float uAlpha;
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+
+void main() {
+    vec3 N = normalize(vNormal);
+    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 tex = texture2D(uTexture, vTexCoord).rgb;
+    gl_FragColor = vec4(tex * uTint * diffuse, uAlpha);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -1,0 +1,479 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BALL_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const FOOTBALL_TEXTURE = '../../../../assets/textures/Football.jpg';
+const GROUND_TEXTURE = '../../../../assets/textures/grass.jpg';
+
+const canvas = document.getElementById('c');
+const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+
+if (!gl) {
+    throw new Error('WebGL 1.0 is not supported.');
+}
+
+let HK;
+let worldId;
+let groundBodyId;
+const ballBodyIds = [];
+const ballSpawnPositions = [];
+const ballTints = [];
+
+let program;
+let attribPosition;
+let attribNormal;
+let attribTexCoord;
+let uniformViewProj;
+let uniformModel;
+let uniformTexture;
+let uniformTint;
+let uniformLightDir;
+let uniformAlpha;
+
+let sphereMesh;
+let planeMesh;
+let footballTexture;
+let grassTexture;
+
+const projectionMatrix = mat4.create();
+const viewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
+const modelMatrix = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') {
+        return Number(value.value);
+    }
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') {
+        return Number(value.m_value);
+    }
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const resultCode = enumToNumber(result);
+    const okCode = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(resultCode) && !Number.isNaN(okCode) && resultCode === okCode) {
+        return;
+    }
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) {
+                return;
+            }
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function createShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        throw new Error(gl.getShaderInfoLog(shader));
+    }
+    return shader;
+}
+
+function createProgram(vsSource, fsSource) {
+    const vs = createShader(gl.VERTEX_SHADER, vsSource);
+    const fs = createShader(gl.FRAGMENT_SHADER, fsSource);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(p));
+    }
+    return p;
+}
+
+function isPowerOf2(v) {
+    return (v & (v - 1)) === 0;
+}
+
+function loadTexture(url) {
+    return new Promise((resolve) => {
+        const tex = gl.createTexture();
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => {
+            gl.bindTexture(gl.TEXTURE_2D, tex);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+
+            if (isPowerOf2(img.width) && isPowerOf2(img.height)) {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+                gl.generateMipmap(gl.TEXTURE_2D);
+            } else {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+            }
+
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            resolve(tex);
+        };
+        img.src = url;
+    });
+}
+
+function createSphereGeometry(radius, latSegments, lonSegments) {
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+
+    for (let y = 0; y <= latSegments; y++) {
+        const v = y / latSegments;
+        const theta = v * Math.PI;
+        const sinTheta = Math.sin(theta);
+        const cosTheta = Math.cos(theta);
+
+        for (let x = 0; x <= lonSegments; x++) {
+            const u = x / lonSegments;
+            const phi = u * Math.PI * 2;
+            const sinPhi = Math.sin(phi);
+            const cosPhi = Math.cos(phi);
+
+            const nx = cosPhi * sinTheta;
+            const ny = cosTheta;
+            const nz = sinPhi * sinTheta;
+
+            positions.push(nx * radius, ny * radius, nz * radius);
+            normals.push(nx, ny, nz);
+            uvs.push(1 - u, 1 - v);
+        }
+    }
+
+    for (let y = 0; y < latSegments; y++) {
+        for (let x = 0; x < lonSegments; x++) {
+            const a = y * (lonSegments + 1) + x;
+            const b = a + lonSegments + 1;
+            indices.push(a, b, a + 1, b, b + 1, a + 1);
+        }
+    }
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(normals), gl.STATIC_DRAW);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(uvs), gl.STATIC_DRAW);
+
+    const indexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+
+    return {
+        positionBuffer,
+        normalBuffer,
+        uvBuffer,
+        indexBuffer,
+        indexCount: indices.length
+    };
+}
+
+function createPlaneGeometry(size, uvRepeat) {
+    const hs = size * 0.5;
+    const positions = new Float32Array([
+        -hs, 0, -hs,
+         hs, 0, -hs,
+         hs, 0,  hs,
+        -hs, 0,  hs
+    ]);
+    const normals = new Float32Array([
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0
+    ]);
+    const uvs = new Float32Array([
+        0, 0,
+        uvRepeat, 0,
+        uvRepeat, uvRepeat,
+        0, uvRepeat
+    ]);
+    const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, normals, gl.STATIC_DRAW);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
+
+    const indexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+    return {
+        positionBuffer,
+        normalBuffer,
+        uvBuffer,
+        indexBuffer,
+        indexCount: indices.length
+    };
+}
+
+function bindMesh(mesh) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.positionBuffer);
+    gl.enableVertexAttribArray(attribPosition);
+    gl.vertexAttribPointer(attribPosition, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.normalBuffer);
+    gl.enableVertexAttribArray(attribNormal);
+    gl.vertexAttribPointer(attribNormal, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uvBuffer);
+    gl.enableVertexAttribArray(attribTexCoord);
+    gl.vertexAttribPointer(attribTexCoord, 2, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, mesh.indexBuffer);
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1.0, 1.0, 1.0];
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    groundBodyId = createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
+    checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
+    const ballShapeId = ballShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const spawn = [
+                -10 + x * 1.5 + Math.random() * 0.1,
+                (DOT_ROWS.length - 1 - y) * 1.2 + Math.random() * 0.1,
+                Math.random() * 0.1
+            ];
+            const bodyId = createBody(ballShapeId, HK.MotionType.DYNAMIC, spawn, IDENTITY_QUATERNION, true);
+            ballBodyIds.push(bodyId);
+            ballSpawnPositions.push(spawn);
+            ballTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function resetIfOut(bodyId, spawn) {
+    const posResult = HK.HP_Body_GetPosition(bodyId);
+    checkResult(posResult[0], 'HP_Body_GetPosition');
+
+    if (posResult[1][1] < -30) {
+        const resetPos = [spawn[0], spawn[1] + 20 + Math.random() * 5, spawn[2]];
+        checkResult(HK.HP_Body_SetPosition(bodyId, resetPos), 'HP_Body_SetPosition reset');
+        checkResult(HK.HP_Body_SetOrientation(bodyId, IDENTITY_QUATERNION), 'HP_Body_SetOrientation reset');
+        checkResult(HK.HP_Body_SetLinearVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetLinearVelocity reset');
+        checkResult(HK.HP_Body_SetAngularVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetAngularVelocity reset');
+    }
+}
+
+function drawMesh(mesh, texture, tint, alpha, position, rotation, scale) {
+    bindMesh(mesh);
+
+    mat4.fromRotationTranslationScale(modelMatrix, rotation, position, scale);
+
+    gl.uniformMatrix4fv(uniformModel, false, modelMatrix);
+    gl.uniform3fv(uniformTint, tint);
+    gl.uniform1f(uniformAlpha, alpha);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+
+    gl.drawElements(gl.TRIANGLES, mesh.indexCount, gl.UNSIGNED_SHORT, 0);
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        resetIfOut(ballBodyIds[i], ballSpawnPositions[i]);
+    }
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20];
+
+    mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
+    mat4.lookAt(viewMatrix, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    gl.clearColor(0.97, 0.97, 0.98, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(program);
+    gl.uniformMatrix4fv(uniformViewProj, false, viewProjMatrix);
+    gl.uniform3fv(uniformLightDir, [0.6, 0.9, 0.4]);
+    gl.uniform1i(uniformTexture, 0);
+
+    drawMesh(planeMesh, grassTexture, [1, 1, 1], 1.0, [0, -2, 0], IDENTITY_QUATERNION, [1, 1, 1]);
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        drawMesh(
+            sphereMesh,
+            footballTexture,
+            ballTints[i],
+            1.0,
+            posResult[1],
+            rotResult[1],
+            [1, 1, 1]
+        );
+    }
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    HK = await HavokPhysics();
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.disable(gl.CULL_FACE);
+
+    program = createProgram(
+        document.getElementById('vs').textContent,
+        document.getElementById('fs').textContent
+    );
+
+    attribPosition = gl.getAttribLocation(program, 'aPosition');
+    attribNormal = gl.getAttribLocation(program, 'aNormal');
+    attribTexCoord = gl.getAttribLocation(program, 'aTexCoord');
+
+    uniformViewProj = gl.getUniformLocation(program, 'uViewProj');
+    uniformModel = gl.getUniformLocation(program, 'uModel');
+    uniformTexture = gl.getUniformLocation(program, 'uTexture');
+    uniformTint = gl.getUniformLocation(program, 'uTint');
+    uniformLightDir = gl.getUniformLocation(program, 'uLightDir');
+    uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
+
+    sphereMesh = createSphereGeometry(0.5, 18, 24);
+    planeMesh = createPlaneGeometry(60, 6);
+
+    footballTexture = await loadTexture(FOOTBALL_TEXTURE);
+    grassTexture = await loadTexture(GROUND_TEXTURE);
+
+    initPhysics();
+
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgl1/havok/football/style.css
+++ b/examples/webgl1/havok/football/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #000;
+  font: 30px sans-serif;
+}

--- a/examples/webgl2/havok/football/index.html
+++ b/examples/webgl2/havok/football/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGL 2.0 + Havok Falling Football Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+in vec3 aNormal;
+in vec2 aTexCoord;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+out vec3 vNormal;
+out vec2 vTexCoord;
+
+void main() {
+    mat3 normalMatrix = mat3(uModel);
+    vNormal = normalize(normalMatrix * aNormal);
+    vTexCoord = aTexCoord;
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform sampler2D uTexture;
+uniform vec3 uTint;
+uniform vec3 uLightDir;
+uniform float uAlpha;
+in vec3 vNormal;
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+void main() {
+    vec3 N = normalize(vNormal);
+    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 tex = texture(uTexture, vTexCoord).rgb;
+    fragColor = vec4(tex * uTint * diffuse, uAlpha);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -1,0 +1,462 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BALL_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const FOOTBALL_TEXTURE = '../../../../assets/textures/Football.jpg';
+const GROUND_TEXTURE = '../../../../assets/textures/grass.jpg';
+
+const canvas = document.getElementById('c');
+const gl = canvas.getContext('webgl2');
+
+if (!gl) {
+    throw new Error('WebGL 2.0 is not supported.');
+}
+
+let HK;
+let worldId;
+const ballBodyIds = [];
+const ballSpawnPositions = [];
+const ballTints = [];
+
+let program;
+let attribPosition;
+let attribNormal;
+let attribTexCoord;
+let uniformViewProj;
+let uniformModel;
+let uniformTexture;
+let uniformTint;
+let uniformLightDir;
+let uniformAlpha;
+
+let sphereMesh;
+let planeMesh;
+let footballTexture;
+let grassTexture;
+
+const projectionMatrix = mat4.create();
+const viewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
+const modelMatrix = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') {
+        return Number(value.value);
+    }
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') {
+        return Number(value.m_value);
+    }
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const resultCode = enumToNumber(result);
+    const okCode = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(resultCode) && !Number.isNaN(okCode) && resultCode === okCode) {
+        return;
+    }
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) {
+                return;
+            }
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function createShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        throw new Error(gl.getShaderInfoLog(shader));
+    }
+    return shader;
+}
+
+function createProgram(vsSource, fsSource) {
+    const vs = createShader(gl.VERTEX_SHADER, vsSource);
+    const fs = createShader(gl.FRAGMENT_SHADER, fsSource);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(p));
+    }
+    return p;
+}
+
+function loadTexture(url) {
+    return new Promise((resolve) => {
+        const tex = gl.createTexture();
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => {
+            gl.bindTexture(gl.TEXTURE_2D, tex);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            gl.generateMipmap(gl.TEXTURE_2D);
+            resolve(tex);
+        };
+        img.src = url;
+    });
+}
+
+function createSphereGeometry(radius, latSegments, lonSegments) {
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+
+    for (let y = 0; y <= latSegments; y++) {
+        const v = y / latSegments;
+        const theta = v * Math.PI;
+        const sinTheta = Math.sin(theta);
+        const cosTheta = Math.cos(theta);
+
+        for (let x = 0; x <= lonSegments; x++) {
+            const u = x / lonSegments;
+            const phi = u * Math.PI * 2;
+            const sinPhi = Math.sin(phi);
+            const cosPhi = Math.cos(phi);
+
+            const nx = cosPhi * sinTheta;
+            const ny = cosTheta;
+            const nz = sinPhi * sinTheta;
+
+            positions.push(nx * radius, ny * radius, nz * radius);
+            normals.push(nx, ny, nz);
+            uvs.push(1 - u, 1 - v);
+        }
+    }
+
+    for (let y = 0; y < latSegments; y++) {
+        for (let x = 0; x < lonSegments; x++) {
+            const a = y * (lonSegments + 1) + x;
+            const b = a + lonSegments + 1;
+            indices.push(a, b, a + 1, b, b + 1, a + 1);
+        }
+    }
+
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribPosition);
+    gl.vertexAttribPointer(attribPosition, 3, gl.FLOAT, false, 0, 0);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(normals), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribNormal);
+    gl.vertexAttribPointer(attribNormal, 3, gl.FLOAT, false, 0, 0);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(uvs), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribTexCoord);
+    gl.vertexAttribPointer(attribTexCoord, 2, gl.FLOAT, false, 0, 0);
+
+    const indexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+
+    gl.bindVertexArray(null);
+
+    return { vao, indexCount: indices.length };
+}
+
+function createPlaneGeometry(size, uvRepeat) {
+    const hs = size * 0.5;
+    const positions = new Float32Array([
+        -hs, 0, -hs,
+         hs, 0, -hs,
+         hs, 0,  hs,
+        -hs, 0,  hs
+    ]);
+    const normals = new Float32Array([
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0
+    ]);
+    const uvs = new Float32Array([
+        0, 0,
+        uvRepeat, 0,
+        uvRepeat, uvRepeat,
+        0, uvRepeat
+    ]);
+    const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribPosition);
+    gl.vertexAttribPointer(attribPosition, 3, gl.FLOAT, false, 0, 0);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, normals, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribNormal);
+    gl.vertexAttribPointer(attribNormal, 3, gl.FLOAT, false, 0, 0);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribTexCoord);
+    gl.vertexAttribPointer(attribTexCoord, 2, gl.FLOAT, false, 0, 0);
+
+    const indexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+    gl.bindVertexArray(null);
+
+    return { vao, indexCount: indices.length };
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1.0, 1.0, 1.0];
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
+    checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
+    const ballShapeId = ballShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const spawn = [
+                -10 + x * 1.5 + Math.random() * 0.1,
+                (DOT_ROWS.length - 1 - y) * 1.2 + Math.random() * 0.1,
+                Math.random() * 0.1
+            ];
+            const bodyId = createBody(ballShapeId, HK.MotionType.DYNAMIC, spawn, IDENTITY_QUATERNION, true);
+            ballBodyIds.push(bodyId);
+            ballSpawnPositions.push(spawn);
+            ballTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function resetIfOut(bodyId, spawn) {
+    const posResult = HK.HP_Body_GetPosition(bodyId);
+    checkResult(posResult[0], 'HP_Body_GetPosition');
+
+    if (posResult[1][1] < -30) {
+        const resetPos = [spawn[0], spawn[1] + 20 + Math.random() * 5, spawn[2]];
+        checkResult(HK.HP_Body_SetPosition(bodyId, resetPos), 'HP_Body_SetPosition reset');
+        checkResult(HK.HP_Body_SetOrientation(bodyId, IDENTITY_QUATERNION), 'HP_Body_SetOrientation reset');
+        checkResult(HK.HP_Body_SetLinearVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetLinearVelocity reset');
+        checkResult(HK.HP_Body_SetAngularVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetAngularVelocity reset');
+    }
+}
+
+function drawMesh(mesh, texture, tint, alpha, position, rotation, scale) {
+    gl.bindVertexArray(mesh.vao);
+
+    mat4.fromRotationTranslationScale(modelMatrix, rotation, position, scale);
+
+    gl.uniformMatrix4fv(uniformModel, false, modelMatrix);
+    gl.uniform3fv(uniformTint, tint);
+    gl.uniform1f(uniformAlpha, alpha);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+
+    gl.drawElements(gl.TRIANGLES, mesh.indexCount, gl.UNSIGNED_SHORT, 0);
+
+    gl.bindVertexArray(null);
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        resetIfOut(ballBodyIds[i], ballSpawnPositions[i]);
+    }
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20];
+
+    mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
+    mat4.lookAt(viewMatrix, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    gl.clearColor(0.97, 0.97, 0.98, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(program);
+    gl.uniformMatrix4fv(uniformViewProj, false, viewProjMatrix);
+    gl.uniform3fv(uniformLightDir, [0.6, 0.9, 0.4]);
+    gl.uniform1i(uniformTexture, 0);
+
+    drawMesh(planeMesh, grassTexture, [1, 1, 1], 1.0, [0, -2, 0], IDENTITY_QUATERNION, [1, 1, 1]);
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        drawMesh(
+            sphereMesh,
+            footballTexture,
+            ballTints[i],
+            1.0,
+            posResult[1],
+            rotResult[1],
+            [1, 1, 1]
+        );
+    }
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    HK = await HavokPhysics();
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.disable(gl.CULL_FACE);
+
+    program = createProgram(
+        document.getElementById('vs').textContent,
+        document.getElementById('fs').textContent
+    );
+
+    attribPosition = gl.getAttribLocation(program, 'aPosition');
+    attribNormal = gl.getAttribLocation(program, 'aNormal');
+    attribTexCoord = gl.getAttribLocation(program, 'aTexCoord');
+
+    uniformViewProj = gl.getUniformLocation(program, 'uViewProj');
+    uniformModel = gl.getUniformLocation(program, 'uModel');
+    uniformTexture = gl.getUniformLocation(program, 'uTexture');
+    uniformTint = gl.getUniformLocation(program, 'uTint');
+    uniformLightDir = gl.getUniformLocation(program, 'uLightDir');
+    uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
+
+    sphereMesh = createSphereGeometry(0.5, 18, 24);
+    planeMesh = createPlaneGeometry(60, 6);
+
+    footballTexture = await loadTexture(FOOTBALL_TEXTURE);
+    grassTexture = await loadTexture(GROUND_TEXTURE);
+
+    initPhysics();
+
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgl2/havok/football/style.css
+++ b/examples/webgl2/havok/football/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #000;
+  font: 30px sans-serif;
+}

--- a/examples/webgpu/havok/football/index.html
+++ b/examples/webgpu/havok/football/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGPU + Havok Falling Football Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+struct Uniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    tintAlpha : vec4<f32>
+};
+
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+@group(0) @binding(1) var texSampler : sampler;
+@group(0) @binding(2) var tex : texture_2d<f32>;
+
+struct VSOut {
+    @builtin(position) Position : vec4<f32>,
+    @location(0) vNormal : vec3<f32>,
+    @location(1) vTexCoord : vec2<f32>,
+    @location(2) vTint : vec4<f32>
+};
+
+@vertex
+fn main(
+    @location(0) position : vec3<f32>,
+    @location(1) normal : vec3<f32>,
+    @location(2) uv : vec2<f32>
+) -> VSOut {
+    var out : VSOut;
+    let normalMatrix = mat3x3<f32>(
+        uniforms.model[0].xyz,
+        uniforms.model[1].xyz,
+        uniforms.model[2].xyz
+    );
+    out.vNormal = normalize(normalMatrix * normal);
+    out.vTexCoord = uv;
+    out.vTint = uniforms.tintAlpha;
+    out.Position = uniforms.viewProj * uniforms.model * vec4<f32>(position, 1.0);
+    return out;
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+@group(0) @binding(1) var texSampler : sampler;
+@group(0) @binding(2) var tex : texture_2d<f32>;
+
+@fragment
+fn main(
+    @location(0) vNormal : vec3<f32>,
+    @location(1) vTexCoord : vec2<f32>,
+    @location(2) vTint : vec4<f32>
+) -> @location(0) vec4<f32> {
+    let lightDir = normalize(vec3<f32>(0.6, 0.9, 0.4));
+    let diffuse = max(dot(normalize(vNormal), lightDir), 0.25);
+    let texColor = textureSample(tex, texSampler, vTexCoord);
+    return vec4<f32>(texColor.rgb * vTint.rgb * diffuse, vTint.a);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -1,0 +1,492 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BALL_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const FOOTBALL_TEXTURE = '../../../../assets/textures/Football.jpg';
+const GROUND_TEXTURE = '../../../../assets/textures/grass.jpg';
+
+// viewProj(64) + model(64) + tintAlpha(16)
+const UNIFORM_SIZE = 144;
+
+const canvas = document.getElementById('c');
+
+let HK;
+let worldId;
+const ballBodyIds = [];
+const ballSpawnPositions = [];
+const ballTints = [];
+
+let device;
+let context;
+let format;
+let pipeline;
+let sampler;
+let depthTexture;
+
+let sphereMesh;
+let planeMesh;
+
+let footballTextureView;
+let grassTextureView;
+
+let groundUniformBuffer;
+let groundBindGroup;
+let ballUniformBuffers = [];
+let ballBindGroups = [];
+
+const projectionMatrix = mat4.create();
+const viewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
+const modelMatrix = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') {
+        return Number(value.value);
+    }
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') {
+        return Number(value.m_value);
+    }
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const resultCode = enumToNumber(result);
+    const okCode = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(resultCode) && !Number.isNaN(okCode) && resultCode === okCode) {
+        return;
+    }
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) {
+                return;
+            }
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1.0, 1.0, 1.0];
+}
+
+function createSphereGeometry(radius, latSegments, lonSegments) {
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+
+    for (let y = 0; y <= latSegments; y++) {
+        const v = y / latSegments;
+        const theta = v * Math.PI;
+        const sinTheta = Math.sin(theta);
+        const cosTheta = Math.cos(theta);
+
+        for (let x = 0; x <= lonSegments; x++) {
+            const u = x / lonSegments;
+            const phi = u * Math.PI * 2;
+            const sinPhi = Math.sin(phi);
+            const cosPhi = Math.cos(phi);
+
+            const nx = cosPhi * sinTheta;
+            const ny = cosTheta;
+            const nz = sinPhi * sinTheta;
+
+            positions.push(nx * radius, ny * radius, nz * radius);
+            normals.push(nx, ny, nz);
+            uvs.push(1 - u, 1 - v);
+        }
+    }
+
+    for (let y = 0; y < latSegments; y++) {
+        for (let x = 0; x < lonSegments; x++) {
+            const a = y * (lonSegments + 1) + x;
+            const b = a + lonSegments + 1;
+            indices.push(a, b, a + 1, b, b + 1, a + 1);
+        }
+    }
+
+    return {
+        positions: new Float32Array(positions),
+        normals: new Float32Array(normals),
+        uvs: new Float32Array(uvs),
+        indices: new Uint16Array(indices)
+    };
+}
+
+function createPlaneGeometry(size, uvRepeat) {
+    const hs = size * 0.5;
+    return {
+        positions: new Float32Array([
+            -hs, 0, -hs,
+             hs, 0, -hs,
+             hs, 0,  hs,
+            -hs, 0,  hs
+        ]),
+        normals: new Float32Array([
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0
+        ]),
+        uvs: new Float32Array([
+            0, 0,
+            uvRepeat, 0,
+            uvRepeat, uvRepeat,
+            0, uvRepeat
+        ]),
+        indices: new Uint16Array([0, 1, 2, 0, 2, 3])
+    };
+}
+
+function createBuffer(data, usage) {
+    const buffer = device.createBuffer({ size: data.byteLength, usage: usage | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(buffer, 0, data);
+    return buffer;
+}
+
+function createMesh(geo) {
+    return {
+        positionBuffer: createBuffer(geo.positions, GPUBufferUsage.VERTEX),
+        normalBuffer: createBuffer(geo.normals, GPUBufferUsage.VERTEX),
+        uvBuffer: createBuffer(geo.uvs, GPUBufferUsage.VERTEX),
+        indexBuffer: createBuffer(geo.indices, GPUBufferUsage.INDEX),
+        indexCount: geo.indices.length
+    };
+}
+
+async function loadTextureView(url) {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const imageBitmap = await createImageBitmap(blob);
+
+    const texture = device.createTexture({
+        size: [imageBitmap.width, imageBitmap.height, 1],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT
+    });
+
+    device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture },
+        [imageBitmap.width, imageBitmap.height]
+    );
+
+    return texture.createView();
+}
+
+function createUniformBuffer() {
+    return device.createBuffer({
+        size: UNIFORM_SIZE,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+}
+
+function createBindGroup(uniformBuffer, textureView) {
+    return device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: sampler },
+            { binding: 2, resource: textureView }
+        ]
+    });
+}
+
+function updateUniform(uniformBuffer, position, rotation, scale, tint, alpha) {
+    mat4.fromRotationTranslationScale(modelMatrix, rotation, position, scale);
+
+    const data = new Float32Array(UNIFORM_SIZE / 4);
+    data.set(viewProjMatrix, 0);
+    data.set(modelMatrix, 16);
+    data[32] = tint[0];
+    data[33] = tint[1];
+    data[34] = tint[2];
+    data[35] = alpha;
+
+    device.queue.writeBuffer(uniformBuffer, 0, data);
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
+    checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
+    const ballShapeId = ballShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const spawn = [
+                -10 + x * 1.5 + Math.random() * 0.1,
+                (DOT_ROWS.length - 1 - y) * 1.2 + Math.random() * 0.1,
+                Math.random() * 0.1
+            ];
+            const bodyId = createBody(ballShapeId, HK.MotionType.DYNAMIC, spawn, IDENTITY_QUATERNION, true);
+            ballBodyIds.push(bodyId);
+            ballSpawnPositions.push(spawn);
+            ballTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function resetIfOut(bodyId, spawn) {
+    const posResult = HK.HP_Body_GetPosition(bodyId);
+    checkResult(posResult[0], 'HP_Body_GetPosition');
+
+    if (posResult[1][1] < -30) {
+        const resetPos = [spawn[0], spawn[1] + 20 + Math.random() * 5, spawn[2]];
+        checkResult(HK.HP_Body_SetPosition(bodyId, resetPos), 'HP_Body_SetPosition reset');
+        checkResult(HK.HP_Body_SetOrientation(bodyId, IDENTITY_QUATERNION), 'HP_Body_SetOrientation reset');
+        checkResult(HK.HP_Body_SetLinearVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetLinearVelocity reset');
+        checkResult(HK.HP_Body_SetAngularVelocity(bodyId, [0, 0, 0]), 'HP_Body_SetAngularVelocity reset');
+    }
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+
+    context.configure({ device, format, alphaMode: 'opaque' });
+
+    depthTexture = device.createTexture({
+        size: { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+        format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT
+    });
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        resetIfOut(ballBodyIds[i], ballSpawnPositions[i]);
+    }
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 20, 10, Math.cos(t * 0.2) * 20];
+
+    mat4.perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 120);
+    mat4.lookAt(viewMatrix, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    updateUniform(groundUniformBuffer, [0, -2, 0], IDENTITY_QUATERNION, [1, 1, 1], [1, 1, 1], 1);
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        updateUniform(ballUniformBuffers[i], posResult[1], rotResult[1], [1, 1, 1], ballTints[i], 1);
+    }
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view: context.getCurrentTexture().createView(),
+            clearValue: { r: 0.97, g: 0.97, b: 0.98, a: 1 },
+            loadOp: 'clear',
+            storeOp: 'store'
+        }],
+        depthStencilAttachment: {
+            view: depthTexture.createView(),
+            depthClearValue: 1,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store'
+        }
+    });
+
+    pass.setPipeline(pipeline);
+
+    // Ground
+    pass.setVertexBuffer(0, planeMesh.positionBuffer);
+    pass.setVertexBuffer(1, planeMesh.normalBuffer);
+    pass.setVertexBuffer(2, planeMesh.uvBuffer);
+    pass.setIndexBuffer(planeMesh.indexBuffer, 'uint16');
+    pass.setBindGroup(0, groundBindGroup);
+    pass.drawIndexed(planeMesh.indexCount, 1, 0, 0, 0);
+
+    // Balls
+    pass.setVertexBuffer(0, sphereMesh.positionBuffer);
+    pass.setVertexBuffer(1, sphereMesh.normalBuffer);
+    pass.setVertexBuffer(2, sphereMesh.uvBuffer);
+    pass.setIndexBuffer(sphereMesh.indexBuffer, 'uint16');
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        pass.setBindGroup(0, ballBindGroups[i]);
+        pass.drawIndexed(sphereMesh.indexCount, 1, 0, 0, 0);
+    }
+
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    if (!navigator.gpu) {
+        throw new Error('WebGPU is not supported in this browser.');
+    }
+
+    HK = await HavokPhysics();
+
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+        throw new Error('Failed to get GPU adapter.');
+    }
+
+    device = await adapter.requestDevice();
+    context = canvas.getContext('webgpu');
+    format = navigator.gpu.getPreferredCanvasFormat();
+
+    const vertexShader = device.createShaderModule({ code: document.getElementById('vs').textContent });
+    const fragmentShader = device.createShaderModule({ code: document.getElementById('fs').textContent });
+
+    pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: vertexShader,
+            entryPoint: 'main',
+            buffers: [
+                { arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 12, attributes: [{ shaderLocation: 1, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 8, attributes: [{ shaderLocation: 2, offset: 0, format: 'float32x2' }] }
+            ]
+        },
+        fragment: {
+            module: fragmentShader,
+            entryPoint: 'main',
+            targets: [{ format }]
+        },
+        primitive: { topology: 'triangle-list', cullMode: 'none' },
+        depthStencil: {
+            format: 'depth24plus',
+            depthWriteEnabled: true,
+            depthCompare: 'less'
+        }
+    });
+
+    sampler = device.createSampler({
+        magFilter: 'linear',
+        minFilter: 'linear',
+        mipmapFilter: 'linear',
+        addressModeU: 'repeat',
+        addressModeV: 'repeat'
+    });
+
+    sphereMesh = createMesh(createSphereGeometry(0.5, 18, 24));
+    planeMesh = createMesh(createPlaneGeometry(60, 6));
+
+    footballTextureView = await loadTextureView(FOOTBALL_TEXTURE);
+    grassTextureView = await loadTextureView(GROUND_TEXTURE);
+
+    groundUniformBuffer = createUniformBuffer();
+    groundBindGroup = createBindGroup(groundUniformBuffer, grassTextureView);
+
+    ballUniformBuffers = [];
+    ballBindGroups = [];
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const ub = createUniformBuffer();
+        ballUniformBuffers.push(ub);
+        ballBindGroups.push(createBindGroup(ub, footballTextureView));
+    }
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    initPhysics();
+
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgpu/havok/football/style.css
+++ b/examples/webgpu/havok/football/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #000;
+  font: 30px sans-serif;
+}


### PR DESCRIPTION
## Summary
- Added new Havok-based Falling Football samples for WebGL 1.0, WebGL 2.0, and WebGPU.
- Implemented sphere colliders using HP_Shape_CreateSphere(center, radius) based on the HavokPhysics.d.ts API.
- Matched visual output to the existing WebGL + Oimo.js football examples by aligning camera, clear color, light direction, and culling behavior.

## What was added
- New sample directories:
  - examples/webgl1/havok/football
  - examples/webgl2/havok/football
  - examples/webgpu/havok/football
- Each directory includes:
  - index.html
  - index.js
  - style.css

## Implementation details
- Physics:
  - Uses Havok HP_* API.
  - Ground: static box.
  - Balls: dynamic sphere shape via HP_Shape_CreateSphere([0, 0, 0], 0.5).
  - Respawn logic for bodies that fall below threshold.
- Rendering:
  - Football texture + per-cell tint from the 16x16 dataset.
  - Ground grass texture.
  - Lighting and camera tuned to match Oimo sample look.

## Validation
- Basic static checks: no editor-reported errors in newly added sample scripts.
- Manual runtime verification performed for brightness parity adjustments.
