### PR TITLE
Add Havok stacked boxes examples for WebGL1, WebGL2, and WebGPU

### DIFF
--- a/examples/webgl1/havok/box/index.html
+++ b/examples/webgl1/havok/box/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGL 1.0 + Havok Stacked Boxes Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+attribute vec3 aNormal;
+attribute vec2 aTexCoord;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+
+void main() {
+    mat3 normalMatrix = mat3(uModel);
+    vNormal = normalize(normalMatrix * aNormal);
+    vTexCoord = aTexCoord;
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D uTexture;
+uniform vec3 uTint;
+uniform vec3 uLightDir;
+uniform float uAlpha;
+varying vec3 vNormal;
+varying vec2 vTexCoord;
+
+void main() {
+    vec3 N = normalize(vNormal);
+    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 tex = texture2D(uTexture, vTexCoord).rgb;
+    gl_FragColor = vec4(tex * uTint * diffuse, uAlpha);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -1,0 +1,467 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BOX_SIZE = 1;
+const BOX_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
+const GROUND_UV_REPEAT = 6;
+
+const canvas = document.getElementById('c');
+const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+
+if (!gl) {
+    throw new Error('WebGL 1.0 is not supported.');
+}
+
+let HK;
+let worldId;
+
+let program;
+let attribs;
+let uniforms;
+let cubeMesh;
+let groundMesh;
+let groundTexture;
+let whiteTexture;
+
+const boxBodyIds = [];
+const boxTints = [];
+
+const viewProj = mat4.create();
+const projection = mat4.create();
+const view = mat4.create();
+const model = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') return Number(value.value);
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') return Number(value.m_value);
+
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const rc = enumToNumber(result);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc === ok) return;
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) return;
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function createShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        throw new Error(gl.getShaderInfoLog(shader));
+    }
+    return shader;
+}
+
+function createProgram(vsSource, fsSource) {
+    const vs = createShader(gl.VERTEX_SHADER, vsSource);
+    const fs = createShader(gl.FRAGMENT_SHADER, fsSource);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(p));
+    }
+    return p;
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+function isPowerOf2(v) {
+    return (v & (v - 1)) === 0;
+}
+
+function loadTexture(url) {
+    return new Promise((resolve) => {
+        const texture = gl.createTexture();
+        const image = new Image();
+        image.crossOrigin = 'anonymous';
+        image.onload = () => {
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+
+            if (isPowerOf2(image.width) && isPowerOf2(image.height)) {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+                gl.generateMipmap(gl.TEXTURE_2D);
+            } else {
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+            }
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            resolve(texture);
+        };
+        image.src = url;
+    });
+}
+
+function createSolidTexture(r, g, b, a) {
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        1,
+        1,
+        0,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        new Uint8Array([r, g, b, a])
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    return texture;
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1, 1, 1];
+}
+
+function createBoxGeometry() {
+    const positions = new Float32Array([
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,
+        -0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+
+         0.5, -0.5, -0.5,  -0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,
+         0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,   0.5,  0.5, -0.5,
+
+        -0.5, -0.5, -0.5,  -0.5, -0.5,  0.5,  -0.5,  0.5,  0.5,
+        -0.5, -0.5, -0.5,  -0.5,  0.5,  0.5,  -0.5,  0.5, -0.5,
+
+         0.5, -0.5,  0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,
+         0.5, -0.5,  0.5,   0.5,  0.5, -0.5,   0.5,  0.5,  0.5,
+
+        -0.5,  0.5,  0.5,   0.5,  0.5,  0.5,   0.5,  0.5, -0.5,
+        -0.5,  0.5,  0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5, -0.5,  0.5,
+        -0.5, -0.5, -0.5,   0.5, -0.5,  0.5,  -0.5, -0.5,  0.5
+    ]);
+
+    const normals = new Float32Array([
+         0,  0,  1,   0,  0,  1,   0,  0,  1,
+         0,  0,  1,   0,  0,  1,   0,  0,  1,
+
+         0,  0, -1,   0,  0, -1,   0,  0, -1,
+         0,  0, -1,   0,  0, -1,   0,  0, -1,
+
+        -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+        -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+
+         1,  0,  0,   1,  0,  0,   1,  0,  0,
+         1,  0,  0,   1,  0,  0,   1,  0,  0,
+
+         0,  1,  0,   0,  1,  0,   0,  1,  0,
+         0,  1,  0,   0,  1,  0,   0,  1,  0,
+
+         0, -1,  0,   0, -1,  0,   0, -1,  0,
+         0, -1,  0,   0, -1,  0,   0, -1,  0
+    ]);
+
+    const uvs = new Float32Array([
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1
+    ]);
+
+    return createMeshBuffers(positions, normals, uvs);
+}
+
+function createGroundPlaneData(repeat) {
+    const positions = new Float32Array([
+        -0.5, 0.0, -0.5,
+         0.5, 0.0, -0.5,
+         0.5, 0.0,  0.5,
+        -0.5, 0.0, -0.5,
+         0.5, 0.0,  0.5,
+        -0.5, 0.0,  0.5
+    ]);
+    const normals = new Float32Array([
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0
+    ]);
+    const uvs = new Float32Array([
+        0, 0,
+        repeat, 0,
+        repeat, repeat,
+        0, 0,
+        repeat, repeat,
+        0, repeat
+    ]);
+    return createMeshBuffers(positions, normals, uvs);
+}
+
+function createMeshBuffers(positions, normals, uvs) {
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, normals, gl.STATIC_DRAW);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
+
+    return {
+        positionBuffer,
+        normalBuffer,
+        uvBuffer,
+        vertexCount: positions.length / 3
+    };
+}
+
+function bindMesh(mesh) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.positionBuffer);
+    gl.vertexAttribPointer(attribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(attribs.position);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.normalBuffer);
+    gl.vertexAttribPointer(attribs.normal, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(attribs.normal);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, mesh.uvBuffer);
+    gl.vertexAttribPointer(attribs.uv, 2, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(attribs.uv);
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const boxShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+    checkResult(boxShapeResult[0], 'HP_Shape_CreateBox (box)');
+    const boxShapeId = boxShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(boxShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const bodyId = createBody(
+                boxShapeId,
+                HK.MotionType.DYNAMIC,
+                [
+                    -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1,
+                    (DOT_ROWS.length - 1 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1,
+                    Math.random() * 0.1
+                ],
+                IDENTITY_QUATERNION,
+                true
+            );
+
+            boxBodyIds.push(bodyId);
+            boxTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function drawMesh(mesh, texture, tint, transform) {
+    bindMesh(mesh);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.uniformMatrix4fv(uniforms.model, false, transform);
+    gl.uniform3fv(uniforms.tint, tint);
+    gl.drawArrays(gl.TRIANGLES, 0, mesh.vertexCount);
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24];
+    mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
+    mat4.multiply(viewProj, projection, view);
+
+    gl.clearColor(0.97, 0.97, 0.98, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(program);
+    gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
+    gl.uniform3f(uniforms.lightDir, 0.6, 0.9, 0.4);
+    gl.uniform1f(uniforms.alpha, 1.0);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    drawMesh(groundMesh, groundTexture, [1, 1, 1], model);
+
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        drawMesh(cubeMesh, whiteTexture, boxTints[i], model);
+    }
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    HK = await HavokPhysics();
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.disable(gl.CULL_FACE);
+
+    program = createProgram(
+        document.getElementById('vs').textContent,
+        document.getElementById('fs').textContent
+    );
+
+    attribs = {
+        position: gl.getAttribLocation(program, 'aPosition'),
+        normal: gl.getAttribLocation(program, 'aNormal'),
+        uv: gl.getAttribLocation(program, 'aTexCoord')
+    };
+    uniforms = {
+        viewProj: gl.getUniformLocation(program, 'uViewProj'),
+        model: gl.getUniformLocation(program, 'uModel'),
+        texture: gl.getUniformLocation(program, 'uTexture'),
+        tint: gl.getUniformLocation(program, 'uTint'),
+        lightDir: gl.getUniformLocation(program, 'uLightDir'),
+        alpha: gl.getUniformLocation(program, 'uAlpha')
+    };
+
+    gl.useProgram(program);
+    gl.uniform1i(uniforms.texture, 0);
+
+    cubeMesh = createBoxGeometry();
+    groundMesh = createGroundPlaneData(GROUND_UV_REPEAT);
+
+    groundTexture = await loadTexture(GROUND_TEXTURE_FILE);
+    whiteTexture = createSolidTexture(255, 255, 255, 255);
+
+    initPhysics();
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgl1/havok/box/style.css
+++ b/examples/webgl1/havok/box/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}

--- a/examples/webgl2/havok/box/index.html
+++ b/examples/webgl2/havok/box/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGL 2.0 + Havok Stacked Boxes Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+in vec3 aNormal;
+in vec2 aTexCoord;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+out vec3 vNormal;
+out vec2 vTexCoord;
+
+void main() {
+    mat3 normalMatrix = mat3(uModel);
+    vNormal = normalize(normalMatrix * aNormal);
+    vTexCoord = aTexCoord;
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform sampler2D uTexture;
+uniform vec3 uTint;
+uniform vec3 uLightDir;
+uniform float uAlpha;
+in vec3 vNormal;
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+void main() {
+    vec3 N = normalize(vNormal);
+    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 tex = texture(uTexture, vTexCoord).rgb;
+    fragColor = vec4(tex * uTint * diffuse, uAlpha);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -1,0 +1,452 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BOX_SIZE = 1;
+const BOX_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
+const GROUND_UV_REPEAT = 6;
+
+const canvas = document.getElementById('c');
+const gl = canvas.getContext('webgl2');
+
+if (!gl) {
+    throw new Error('WebGL 2.0 is not supported.');
+}
+
+let HK;
+let worldId;
+
+let program;
+let attribs;
+let uniforms;
+let cubeMesh;
+let groundMesh;
+let groundTexture;
+let whiteTexture;
+
+const boxBodyIds = [];
+const boxTints = [];
+
+const viewProj = mat4.create();
+const projection = mat4.create();
+const view = mat4.create();
+const model = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') return Number(value.value);
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') return Number(value.m_value);
+
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const rc = enumToNumber(result);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc === ok) return;
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) return;
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function createShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        throw new Error(gl.getShaderInfoLog(shader));
+    }
+    return shader;
+}
+
+function createProgram(vsSource, fsSource) {
+    const vs = createShader(gl.VERTEX_SHADER, vsSource);
+    const fs = createShader(gl.FRAGMENT_SHADER, fsSource);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+        throw new Error(gl.getProgramInfoLog(p));
+    }
+    return p;
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+    gl.viewport(0, 0, canvas.width, canvas.height);
+}
+
+function loadTexture(url) {
+    return new Promise((resolve) => {
+        const texture = gl.createTexture();
+        const image = new Image();
+        image.crossOrigin = 'anonymous';
+        image.onload = () => {
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            gl.generateMipmap(gl.TEXTURE_2D);
+            resolve(texture);
+        };
+        image.src = url;
+    });
+}
+
+function createSolidTexture(r, g, b, a) {
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        1,
+        1,
+        0,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        new Uint8Array([r, g, b, a])
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    return texture;
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1, 1, 1];
+}
+
+function createBoxGeometry() {
+    const positions = new Float32Array([
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,
+        -0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+
+         0.5, -0.5, -0.5,  -0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,
+         0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,   0.5,  0.5, -0.5,
+
+        -0.5, -0.5, -0.5,  -0.5, -0.5,  0.5,  -0.5,  0.5,  0.5,
+        -0.5, -0.5, -0.5,  -0.5,  0.5,  0.5,  -0.5,  0.5, -0.5,
+
+         0.5, -0.5,  0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,
+         0.5, -0.5,  0.5,   0.5,  0.5, -0.5,   0.5,  0.5,  0.5,
+
+        -0.5,  0.5,  0.5,   0.5,  0.5,  0.5,   0.5,  0.5, -0.5,
+        -0.5,  0.5,  0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5, -0.5,  0.5,
+        -0.5, -0.5, -0.5,   0.5, -0.5,  0.5,  -0.5, -0.5,  0.5
+    ]);
+
+    const normals = new Float32Array([
+         0,  0,  1,   0,  0,  1,   0,  0,  1,
+         0,  0,  1,   0,  0,  1,   0,  0,  1,
+
+         0,  0, -1,   0,  0, -1,   0,  0, -1,
+         0,  0, -1,   0,  0, -1,   0,  0, -1,
+
+        -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+        -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+
+         1,  0,  0,   1,  0,  0,   1,  0,  0,
+         1,  0,  0,   1,  0,  0,   1,  0,  0,
+
+         0,  1,  0,   0,  1,  0,   0,  1,  0,
+         0,  1,  0,   0,  1,  0,   0,  1,  0,
+
+         0, -1,  0,   0, -1,  0,   0, -1,  0,
+         0, -1,  0,   0, -1,  0,   0, -1,  0
+    ]);
+
+    const uvs = new Float32Array([
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1,
+
+        0, 0, 1, 0, 1, 1,
+        0, 0, 1, 1, 0, 1
+    ]);
+
+    return createMeshBuffers(positions, normals, uvs);
+}
+
+function createGroundPlaneData(repeat) {
+    const positions = new Float32Array([
+        -0.5, 0.0, -0.5,
+         0.5, 0.0, -0.5,
+         0.5, 0.0,  0.5,
+        -0.5, 0.0, -0.5,
+         0.5, 0.0,  0.5,
+        -0.5, 0.0,  0.5
+    ]);
+    const normals = new Float32Array([
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0,
+        0, 1, 0
+    ]);
+    const uvs = new Float32Array([
+        0, 0,
+        repeat, 0,
+        repeat, repeat,
+        0, 0,
+        repeat, repeat,
+        0, repeat
+    ]);
+    return createMeshBuffers(positions, normals, uvs);
+}
+
+function createMeshBuffers(positions, normals, uvs) {
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribs.position);
+    gl.vertexAttribPointer(attribs.position, 3, gl.FLOAT, false, 0, 0);
+
+    const normalBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, normals, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribs.normal);
+    gl.vertexAttribPointer(attribs.normal, 3, gl.FLOAT, false, 0, 0);
+
+    const uvBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, uvBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, uvs, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(attribs.uv);
+    gl.vertexAttribPointer(attribs.uv, 2, gl.FLOAT, false, 0, 0);
+
+    gl.bindVertexArray(null);
+
+    return {
+        vao,
+        vertexCount: positions.length / 3
+    };
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const boxShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+    checkResult(boxShapeResult[0], 'HP_Shape_CreateBox (box)');
+    const boxShapeId = boxShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(boxShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const bodyId = createBody(
+                boxShapeId,
+                HK.MotionType.DYNAMIC,
+                [
+                    -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1,
+                    (DOT_ROWS.length - 1 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1,
+                    Math.random() * 0.1
+                ],
+                IDENTITY_QUATERNION,
+                true
+            );
+
+            boxBodyIds.push(bodyId);
+            boxTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function drawMesh(mesh, texture, tint, transform) {
+    gl.bindVertexArray(mesh.vao);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.uniformMatrix4fv(uniforms.model, false, transform);
+    gl.uniform3fv(uniforms.tint, tint);
+    gl.drawArrays(gl.TRIANGLES, 0, mesh.vertexCount);
+    gl.bindVertexArray(null);
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24];
+    mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
+    mat4.multiply(viewProj, projection, view);
+
+    gl.clearColor(0.97, 0.97, 0.98, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(program);
+    gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
+    gl.uniform3f(uniforms.lightDir, 0.6, 0.9, 0.4);
+    gl.uniform1f(uniforms.alpha, 1.0);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    drawMesh(groundMesh, groundTexture, [1, 1, 1], model);
+
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        drawMesh(cubeMesh, whiteTexture, boxTints[i], model);
+    }
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    HK = await HavokPhysics();
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.disable(gl.CULL_FACE);
+
+    program = createProgram(
+        document.getElementById('vs').textContent,
+        document.getElementById('fs').textContent
+    );
+
+    attribs = {
+        position: gl.getAttribLocation(program, 'aPosition'),
+        normal: gl.getAttribLocation(program, 'aNormal'),
+        uv: gl.getAttribLocation(program, 'aTexCoord')
+    };
+    uniforms = {
+        viewProj: gl.getUniformLocation(program, 'uViewProj'),
+        model: gl.getUniformLocation(program, 'uModel'),
+        texture: gl.getUniformLocation(program, 'uTexture'),
+        tint: gl.getUniformLocation(program, 'uTint'),
+        lightDir: gl.getUniformLocation(program, 'uLightDir'),
+        alpha: gl.getUniformLocation(program, 'uAlpha')
+    };
+
+    gl.useProgram(program);
+    gl.uniform1i(uniforms.texture, 0);
+
+    cubeMesh = createBoxGeometry();
+    groundMesh = createGroundPlaneData(GROUND_UV_REPEAT);
+
+    groundTexture = await loadTexture(GROUND_TEXTURE_FILE);
+    whiteTexture = createSolidTexture(255, 255, 255, 255);
+
+    initPhysics();
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgl2/havok/box/style.css
+++ b/examples/webgl2/havok/box/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}

--- a/examples/webgpu/havok/box/index.html
+++ b/examples/webgpu/havok/box/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGPU + Havok Stacked Boxes Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
+  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+</head>
+<body>
+
+<script id="vs" type="x-shader/x-vertex">
+struct Uniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    tint : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+
+struct VSOut {
+    @builtin(position) Position : vec4<f32>,
+    @location(0) normal : vec3<f32>,
+    @location(1) uv : vec2<f32>,
+};
+
+@vertex
+fn main(
+    @location(0) position : vec3<f32>,
+    @location(1) normal : vec3<f32>,
+    @location(2) uv : vec2<f32>
+) -> VSOut {
+    var out : VSOut;
+    out.Position = uniforms.viewProj * uniforms.model * vec4<f32>(position, 1.0);
+    out.normal = normalize((uniforms.model * vec4<f32>(normal, 0.0)).xyz);
+    out.uv = uv;
+    return out;
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+struct Uniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    tint : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : Uniforms;
+@group(0) @binding(1) var samp : sampler;
+@group(0) @binding(2) var tex : texture_2d<f32>;
+
+@fragment
+fn main(
+    @location(0) normal : vec3<f32>,
+    @location(1) uv : vec2<f32>
+) -> @location(0) vec4<f32> {
+    let lightDir = normalize(vec3<f32>(0.6, 0.9, 0.4));
+    let diffuse = max(dot(normalize(normal), lightDir), 0.25);
+    let base = textureSample(tex, samp, uv).rgb;
+    return vec4<f32>(base * uniforms.tint.rgb * diffuse, uniforms.tint.a);
+}
+</script>
+
+<canvas id="c"></canvas>
+
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -1,0 +1,492 @@
+const { mat4 } = glMatrix;
+
+const DOT_ROWS = [
+    '.............ppp',
+    '......rrrrr..ppp',
+    '.....rrrrrrrrrpp',
+    '.....nnnppnp.rrr',
+    '....npnpppnpprrr',
+    '....npnnpppnpppr',
+    '....nnppppnnnnr.',
+    '......pppppppr..',
+    '..rrrrrbrrrbr...',
+    '.rrrrrrrrbrrrb..n',
+    'pprrrrrrbbbbb..n',
+    'ppp.bbrbbybbybnn',
+    '.p.nbbbbbbbbbbnn',
+    '..nnnbbbbbbbbbnn',
+    '.nnnbbbbbbb.....',
+    '.n..bbbb........'
+];
+
+const BOX_SIZE = 1;
+const BOX_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
+const IDENTITY_QUATERNION = [0, 0, 0, 1];
+
+const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
+const GROUND_UV_REPEAT = 6;
+
+const canvas = document.getElementById('c');
+
+let HK;
+let worldId;
+
+let device;
+let context;
+let format;
+let pipeline;
+let sampler;
+let depthTexture;
+let whiteTextureView;
+let groundTextureView;
+
+let cubeMesh;
+let groundMesh;
+
+const boxBodyIds = [];
+const boxTints = [];
+let groundRenderItem;
+let boxRenderItems = [];
+
+const viewProj = mat4.create();
+const projection = mat4.create();
+const view = mat4.create();
+const model = mat4.create();
+
+function enumToNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'bigint') return Number(value);
+    if (typeof value === 'string') {
+        const parsed = Number(value.trim());
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+    if (!value || typeof value !== 'object') return NaN;
+
+    if (typeof value.value === 'number' || typeof value.value === 'bigint') return Number(value.value);
+    if (typeof value.m_value === 'number' || typeof value.m_value === 'bigint') return Number(value.m_value);
+
+    if (typeof value.value === 'function') {
+        const n = enumToNumber(value.value());
+        if (!Number.isNaN(n)) return n;
+    }
+    if (typeof value.valueOf === 'function') {
+        const v = value.valueOf();
+        if (v !== value) {
+            const n = enumToNumber(v);
+            if (!Number.isNaN(n)) return n;
+        }
+    }
+
+    return NaN;
+}
+
+function checkResult(result, label) {
+    if (result === HK.Result.RESULT_OK) return;
+
+    const rc = enumToNumber(result);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc === ok) return;
+
+    if (typeof result === 'object' && typeof HK.Result.RESULT_OK === 'object') {
+        try {
+            if (JSON.stringify(result) === JSON.stringify(HK.Result.RESULT_OK)) return;
+        } catch (_e) {
+        }
+    }
+
+    throw new Error(label + ' failed with code: ' + String(result));
+}
+
+function getTintColor(code) {
+    const map = {
+        '.': [0xDC / 255, 0xAA / 255, 0x6B / 255],
+        'p': [1.0, 0xCC / 255, 0xCC / 255],
+        'n': [0x80 / 255, 0.0, 0.0],
+        'r': [1.0, 0.0, 0.0],
+        'y': [1.0, 1.0, 0.0],
+        'b': [0.0, 0.0, 1.0]
+    };
+    return map[code] || [1, 1, 1];
+}
+
+function createBoxGeometry() {
+    return {
+        positions: new Float32Array([
+            -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,
+            -0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+
+             0.5, -0.5, -0.5,  -0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,
+             0.5, -0.5, -0.5,  -0.5,  0.5, -0.5,   0.5,  0.5, -0.5,
+
+            -0.5, -0.5, -0.5,  -0.5, -0.5,  0.5,  -0.5,  0.5,  0.5,
+            -0.5, -0.5, -0.5,  -0.5,  0.5,  0.5,  -0.5,  0.5, -0.5,
+
+             0.5, -0.5,  0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,
+             0.5, -0.5,  0.5,   0.5,  0.5, -0.5,   0.5,  0.5,  0.5,
+
+            -0.5,  0.5,  0.5,   0.5,  0.5,  0.5,   0.5,  0.5, -0.5,
+            -0.5,  0.5,  0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+
+            -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5, -0.5,  0.5,
+            -0.5, -0.5, -0.5,   0.5, -0.5,  0.5,  -0.5, -0.5,  0.5
+        ]),
+        normals: new Float32Array([
+             0,  0,  1,   0,  0,  1,   0,  0,  1,
+             0,  0,  1,   0,  0,  1,   0,  0,  1,
+
+             0,  0, -1,   0,  0, -1,   0,  0, -1,
+             0,  0, -1,   0,  0, -1,   0,  0, -1,
+
+            -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+            -1,  0,  0,  -1,  0,  0,  -1,  0,  0,
+
+             1,  0,  0,   1,  0,  0,   1,  0,  0,
+             1,  0,  0,   1,  0,  0,   1,  0,  0,
+
+             0,  1,  0,   0,  1,  0,   0,  1,  0,
+             0,  1,  0,   0,  1,  0,   0,  1,  0,
+
+             0, -1,  0,   0, -1,  0,   0, -1,  0,
+             0, -1,  0,   0, -1,  0,   0, -1,  0
+        ]),
+        uvs: new Float32Array([
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1,
+
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1,
+
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1,
+
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1,
+
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1,
+
+            0, 0, 1, 0, 1, 1,
+            0, 0, 1, 1, 0, 1
+        ])
+    };
+}
+
+function createGroundPlaneData(repeat) {
+    return {
+        positions: new Float32Array([
+            -0.5, 0.0, -0.5,
+             0.5, 0.0, -0.5,
+             0.5, 0.0,  0.5,
+            -0.5, 0.0, -0.5,
+             0.5, 0.0,  0.5,
+            -0.5, 0.0,  0.5
+        ]),
+        normals: new Float32Array([
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0,
+            0, 1, 0
+        ]),
+        uvs: new Float32Array([
+            0, 0,
+            repeat, 0,
+            repeat, repeat,
+            0, 0,
+            repeat, repeat,
+            0, repeat
+        ])
+    };
+}
+
+function createVertexBuffer(data) {
+    const buffer = device.createBuffer({
+        size: data.byteLength,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+    });
+    device.queue.writeBuffer(buffer, 0, data);
+    return buffer;
+}
+
+function createMesh(data) {
+    return {
+        positionBuffer: createVertexBuffer(data.positions),
+        normalBuffer: createVertexBuffer(data.normals),
+        uvBuffer: createVertexBuffer(data.uvs),
+        vertexCount: data.positions.length / 3
+    };
+}
+
+async function loadTexture(url) {
+    const response = await fetch(url);
+    const blob = await response.blob();
+    const imageBitmap = await createImageBitmap(blob);
+
+    const texture = device.createTexture({
+        size: [imageBitmap.width, imageBitmap.height, 1],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT
+    });
+
+    device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture },
+        [imageBitmap.width, imageBitmap.height]
+    );
+
+    return texture;
+}
+
+function createSolidTextureView(r, g, b, a) {
+    const texture = device.createTexture({
+        size: [1, 1, 1],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST
+    });
+
+    device.queue.writeTexture(
+        { texture },
+        new Uint8Array([r, g, b, a]),
+        { bytesPerRow: 4 },
+        [1, 1, 1]
+    );
+
+    return texture.createView();
+}
+
+function createRenderItem(textureView) {
+    const uniformBuffer = device.createBuffer({
+        size: 144,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    const bindGroup = device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: sampler },
+            { binding: 2, resource: textureView }
+        ]
+    });
+
+    return { uniformBuffer, bindGroup };
+}
+
+function writeUniforms(uniformBuffer, tint) {
+    device.queue.writeBuffer(uniformBuffer, 0, viewProj);
+    device.queue.writeBuffer(uniformBuffer, 64, model);
+    device.queue.writeBuffer(uniformBuffer, 128, new Float32Array(tint));
+}
+
+function drawMesh(pass, mesh, bindGroup) {
+    pass.setVertexBuffer(0, mesh.positionBuffer);
+    pass.setVertexBuffer(1, mesh.normalBuffer);
+    pass.setVertexBuffer(2, mesh.uvBuffer);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(mesh.vertexCount, 1, 0, 0);
+}
+
+function createBody(shapeId, motionType, position, rotation, setMass) {
+    const created = HK.HP_Body_Create();
+    checkResult(created[0], 'HP_Body_Create');
+    const bodyId = created[1];
+
+    checkResult(HK.HP_Body_SetShape(bodyId, shapeId), 'HP_Body_SetShape');
+    checkResult(HK.HP_Body_SetMotionType(bodyId, motionType), 'HP_Body_SetMotionType');
+
+    if (setMass) {
+        const massResult = HK.HP_Shape_BuildMassProperties(shapeId);
+        checkResult(massResult[0], 'HP_Shape_BuildMassProperties');
+        checkResult(HK.HP_Body_SetMassProperties(bodyId, massResult[1]), 'HP_Body_SetMassProperties');
+    }
+
+    checkResult(HK.HP_Body_SetPosition(bodyId, position), 'HP_Body_SetPosition');
+    checkResult(HK.HP_Body_SetOrientation(bodyId, rotation), 'HP_Body_SetOrientation');
+    checkResult(HK.HP_World_AddBody(worldId, bodyId, false), 'HP_World_AddBody');
+
+    return bodyId;
+}
+
+function initPhysics() {
+    const world = HK.HP_World_Create();
+    checkResult(world[0], 'HP_World_Create');
+    worldId = world[1];
+
+    checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
+    checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
+
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
+
+    const boxShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+    checkResult(boxShapeResult[0], 'HP_Shape_CreateBox (box)');
+    const boxShapeId = boxShapeResult[1];
+    checkResult(HK.HP_Shape_SetDensity(boxShapeId, 1), 'HP_Shape_SetDensity');
+
+    for (let y = 0; y < DOT_ROWS.length; y++) {
+        const row = DOT_ROWS[y];
+        for (let x = 0; x < row.length; x++) {
+            const bodyId = createBody(
+                boxShapeId,
+                HK.MotionType.DYNAMIC,
+                [
+                    -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1,
+                    (DOT_ROWS.length - 1 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1,
+                    Math.random() * 0.1
+                ],
+                IDENTITY_QUATERNION,
+                true
+            );
+
+            boxBodyIds.push(bodyId);
+            boxTints.push(getTintColor(row[x]));
+        }
+    }
+}
+
+function initRenderItems() {
+    groundRenderItem = createRenderItem(groundTextureView);
+    boxRenderItems = boxBodyIds.map(() => createRenderItem(whiteTextureView));
+}
+
+function createDepthTexture() {
+    depthTexture = device.createTexture({
+        size: { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+        format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT
+    });
+}
+
+function resize() {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(window.innerWidth * dpr);
+    canvas.height = Math.floor(window.innerHeight * dpr);
+    canvas.style.width = window.innerWidth + 'px';
+    canvas.style.height = window.innerHeight + 'px';
+
+    context.configure({ device, format, alphaMode: 'opaque' });
+    createDepthTexture();
+}
+
+function render(timeMs) {
+    checkResult(HK.HP_World_Step(worldId, 1 / 60), 'HP_World_Step');
+
+    const t = timeMs * 0.001;
+    const eye = [Math.sin(t * 0.2) * 24, 12, Math.cos(t * 0.2) * 24];
+    mat4.lookAt(view, eye, [0, 8, 0], [0, 1, 0]);
+    mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
+    mat4.multiply(viewProj, projection, view);
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view: context.getCurrentTexture().createView(),
+            clearValue: { r: 0.97, g: 0.97, b: 0.98, a: 1.0 },
+            loadOp: 'clear',
+            storeOp: 'store'
+        }],
+        depthStencilAttachment: {
+            view: depthTexture.createView(),
+            depthClearValue: 1.0,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store'
+        }
+    });
+
+    pass.setPipeline(pipeline);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    writeUniforms(groundRenderItem.uniformBuffer, [1, 1, 1, 1]);
+    drawMesh(pass, groundMesh, groundRenderItem.bindGroup);
+
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition draw');
+        const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation draw');
+
+        mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        writeUniforms(boxRenderItems[i].uniformBuffer, [boxTints[i][0], boxTints[i][1], boxTints[i][2], 1]);
+        drawMesh(pass, cubeMesh, boxRenderItems[i].bindGroup);
+    }
+
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+
+    requestAnimationFrame(render);
+}
+
+async function init() {
+    if (!navigator.gpu) {
+        throw new Error('WebGPU is not supported in this browser.');
+    }
+
+    HK = await HavokPhysics();
+
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+        throw new Error('Failed to get GPU adapter.');
+    }
+
+    device = await adapter.requestDevice();
+    context = canvas.getContext('webgpu');
+    format = navigator.gpu.getPreferredCanvasFormat();
+
+    const vs = device.createShaderModule({ code: document.getElementById('vs').textContent });
+    const fs = device.createShaderModule({ code: document.getElementById('fs').textContent });
+
+    pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: vs,
+            entryPoint: 'main',
+            buffers: [
+                { arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 12, attributes: [{ shaderLocation: 1, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 8, attributes: [{ shaderLocation: 2, offset: 0, format: 'float32x2' }] }
+            ]
+        },
+        fragment: {
+            module: fs,
+            entryPoint: 'main',
+            targets: [{ format }]
+        },
+        primitive: {
+            topology: 'triangle-list',
+            cullMode: 'none'
+        },
+        depthStencil: {
+            format: 'depth24plus',
+            depthWriteEnabled: true,
+            depthCompare: 'less'
+        }
+    });
+
+    sampler = device.createSampler({
+        addressModeU: 'repeat',
+        addressModeV: 'repeat',
+        magFilter: 'linear',
+        minFilter: 'linear',
+        mipmapFilter: 'nearest'
+    });
+
+    cubeMesh = createMesh(createBoxGeometry());
+    groundMesh = createMesh(createGroundPlaneData(GROUND_UV_REPEAT));
+
+    whiteTextureView = createSolidTextureView(255, 255, 255, 255);
+    const groundTexture = await loadTexture(GROUND_TEXTURE_FILE);
+    groundTextureView = groundTexture.createView();
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    initPhysics();
+    initRenderItems();
+    requestAnimationFrame(render);
+}
+
+init().catch((err) => {
+    console.error(err);
+});

--- a/examples/webgpu/havok/box/style.css
+++ b/examples/webgpu/havok/box/style.css
@@ -1,0 +1,11 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}


### PR DESCRIPTION
## Summary
- Added Havok-based Stacked Boxes samples for WebGL 1.0, WebGL 2.0, and WebGPU.
- Implemented equivalent scene setup and visual behavior to the existing Oimo.js box samples.

## What was added
- New Havok box examples for:
- WebGL 1.0
- WebGL 2.0
- WebGPU
- Each target includes index.html, index.js, and style.css.

## Implementation details
- Physics
- Uses Havok HP API with HP_Shape_CreateBox for ground and dynamic boxes.
- Creates a 16x16 stacked box layout with per-item tint colors.
- Rendering
- Ground uses grass texture.
- Boxes use white base texture with tint multiplication.
- Camera, background color, and light direction are aligned with the Oimo.js Stacked Boxes samples.

## Validation
- Checked new scripts for editor-reported errors (none found).
