### PR TITLE
Feat/havok falling balls webgl webgpu

### DIFF
--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -63,6 +63,9 @@ const DOMINO_COUNT = 256;
 const DOMINO_W = 2;
 const DOMINO_H = 4;
 const DOMINO_D = 0.6;
+const GROUND_HALF_HEIGHT = 0.2;
+const GROUND_Y = -GROUND_HALF_HEIGHT;
+const DOMINO_START_CLEARANCE = 0.05;
 
 let HK;
 let worldId;
@@ -270,9 +273,9 @@ function initPhysics() {
     checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
 
     // Ground
-    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [100, 0.2, 100]);
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [100, GROUND_HALF_HEIGHT, 100]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
-    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -0.1, 0], IDENTITY_QUATERNION, false);
+    createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, GROUND_Y, 0], IDENTITY_QUATERNION, false);
 
     // Domino shape (shared across all domino bodies)
     const dominoShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [DOMINO_W, DOMINO_H, DOMINO_D]);
@@ -287,7 +290,7 @@ function initPhysics() {
 
     for (let i = 0; i < DOMINO_COUNT; i++) {
         const x = (Math.floor(i / 16) - 8) * 3;
-        const y = DOMINO_H / 2;
+        const y = GROUND_Y + GROUND_HALF_HEIGHT + DOMINO_H + DOMINO_START_CLEARANCE;
         const z = (8 - (i % 16)) * 3;
 
         // First piece in each column (i % 16 === 0) is tilted to trigger the chain
@@ -335,7 +338,7 @@ function render(timeMs) {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 
     // Draw ground
-    drawBox([0, -0.1, 0], IDENTITY_QUATERNION, [100, 0.2, 100], [0.5, 0.45, 0.4]);
+    drawBox([0, GROUND_Y, 0], IDENTITY_QUATERNION, [100, GROUND_HALF_HEIGHT, 100], [0.5, 0.45, 0.4]);
 
     // Draw dominos
     for (let i = 0; i < DOMINO_COUNT; i++) {

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -343,12 +343,14 @@ function initPhysics() {
 
     const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     groundBodyId = createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
 
     const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
     checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
     const ballShapeId = ballShapeResult[1];
     checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+    HK.HP_Shape_SetMaterial(ballShapeId, [0.4, 0.4, 0.75, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
 
     for (let y = 0; y < DOT_ROWS.length; y++) {
         const row = DOT_ROWS[y];

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -341,7 +341,7 @@ function initPhysics() {
     checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
     checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
 
-    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 2, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
     HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     groundBodyId = createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
@@ -466,7 +466,7 @@ async function init() {
     uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);
-    planeMesh = createPlaneGeometry(60, 6);
+    planeMesh = createPlaneGeometry(30, 6);
 
     footballTexture = await loadTexture(FOOTBALL_TEXTURE);
     grassTexture = await loadTexture(GROUND_TEXTURE);

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -324,12 +324,14 @@ function initPhysics() {
 
     const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
 
     const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
     checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
     const ballShapeId = ballShapeResult[1];
     checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+    HK.HP_Shape_SetMaterial(ballShapeId, [0.4, 0.4, 0.75, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
 
     for (let y = 0; y < DOT_ROWS.length; y++) {
         const row = DOT_ROWS[y];

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -322,7 +322,7 @@ function initPhysics() {
     checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
     checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
 
-    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 2, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
     HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
@@ -449,7 +449,7 @@ async function init() {
     uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);
-    planeMesh = createPlaneGeometry(60, 6);
+    planeMesh = createPlaneGeometry(30, 6);
 
     footballTexture = await loadTexture(FOOTBALL_TEXTURE);
     grassTexture = await loadTexture(GROUND_TEXTURE);

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -289,7 +289,7 @@ function initPhysics() {
     checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
     checkResult(HK.HP_World_SetIdealStepTime(worldId, 1 / 60), 'HP_World_SetIdealStepTime');
 
-    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
+    const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 2, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
     HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
@@ -465,7 +465,7 @@ async function init() {
     });
 
     sphereMesh = createMesh(createSphereGeometry(0.5, 18, 24));
-    planeMesh = createMesh(createPlaneGeometry(60, 6));
+    planeMesh = createMesh(createPlaneGeometry(30, 6));
 
     footballTextureView = await loadTextureView(FOOTBALL_TEXTURE);
     grassTextureView = await loadTextureView(GROUND_TEXTURE);

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -291,12 +291,14 @@ function initPhysics() {
 
     const groundShapeResult = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30]);
     checkResult(groundShapeResult[0], 'HP_Shape_CreateBox (ground)');
+    HK.HP_Shape_SetMaterial(groundShapeResult[1], [0.6, 0.6, 0.3, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
     createBody(groundShapeResult[1], HK.MotionType.STATIC, [0, -2, 0], IDENTITY_QUATERNION, false);
 
     const ballShapeResult = HK.HP_Shape_CreateSphere([0, 0, 0], 0.5);
     checkResult(ballShapeResult[0], 'HP_Shape_CreateSphere (ball)');
     const ballShapeId = ballShapeResult[1];
     checkResult(HK.HP_Shape_SetDensity(ballShapeId, 1), 'HP_Shape_SetDensity');
+    HK.HP_Shape_SetMaterial(ballShapeId, [0.4, 0.4, 0.75, HK.MaterialCombine.MINIMUM, HK.MaterialCombine.MAXIMUM]);
 
     for (let y = 0; y < DOT_ROWS.length; y++) {
         const row = DOT_ROWS[y];


### PR DESCRIPTION
This pull request updates the physics and rendering setup for the domino and football Havok demo examples across WebGL1, WebGL2, and WebGPU. The main changes involve standardizing ground and object dimensions, improving physical realism with new material properties, and ensuring consistent rendering with the updated physics.

**Physics and Material Improvements:**

* Increased ground thickness from 0.4 to 2 units and updated the ground's Y position to match the new half-height in all football demos (`examples/webgl1/havok/football/index.js`, `examples/webgl2/havok/football/index.js`, `examples/webgpu/havok/football/index.js`). [[1]](diffhunk://#diff-b038a9ebdf7acbb430951dd131822e8bace8150dd632fc61d9aa47dc9a77c709L344-R353) [[2]](diffhunk://#diff-21cbe29eac28ac5fc3a81a74659af4bd724dea8498df8a4c060a5115c1fcb1f6L325-R334) [[3]](diffhunk://#diff-e758fd6db11231dd842307fdcf1749a3262c6d300d49b939c663ebe0594d6b92L292-R301)
* Added material properties to both the ground and ball shapes for more realistic interactions in all football demos. [[1]](diffhunk://#diff-b038a9ebdf7acbb430951dd131822e8bace8150dd632fc61d9aa47dc9a77c709L344-R353) [[2]](diffhunk://#diff-21cbe29eac28ac5fc3a81a74659af4bd724dea8498df8a4c060a5115c1fcb1f6L325-R334) [[3]](diffhunk://#diff-e758fd6db11231dd842307fdcf1749a3262c6d300d49b939c663ebe0594d6b92L292-R301)

**Rendering and Geometry Adjustments:**

* Reduced the ground plane mesh width from 60 to 30 units to match the new ground size in all football demos (`examples/webgl1/havok/football/index.js`, `examples/webgl2/havok/football/index.js`, `examples/webgpu/havok/football/index.js`). [[1]](diffhunk://#diff-b038a9ebdf7acbb430951dd131822e8bace8150dd632fc61d9aa47dc9a77c709L467-R469) [[2]](diffhunk://#diff-21cbe29eac28ac5fc3a81a74659af4bd724dea8498df8a4c060a5115c1fcb1f6L450-R452) [[3]](diffhunk://#diff-e758fd6db11231dd842307fdcf1749a3262c6d300d49b939c663ebe0594d6b92L466-R468)

**Domino Demo Consistency:**

* Introduced constants (`GROUND_HALF_HEIGHT`, `GROUND_Y`, `DOMINO_START_CLEARANCE`) in the domino demo and updated ground and domino placement logic to use these, ensuring the simulation and rendering are consistent. [[1]](diffhunk://#diff-b0f2d1fb199eb7411ccd0419573cce1fc7ee8aa2696674e91ce644a98028b4d5R66-R68) [[2]](diffhunk://#diff-b0f2d1fb199eb7411ccd0419573cce1fc7ee8aa2696674e91ce644a98028b4d5L273-R278) [[3]](diffhunk://#diff-b0f2d1fb199eb7411ccd0419573cce1fc7ee8aa2696674e91ce644a98028b4d5L290-R293) [[4]](diffhunk://#diff-b0f2d1fb199eb7411ccd0419573cce1fc7ee8aa2696674e91ce644a98028b4d5L338-R341)

These changes collectively improve the physical accuracy and visual consistency of the demos.