### PR TITLE
chore(babylonjs-havok): pin Babylon/Havok URLs and glTF loader

### DIFF
--- a/examples/babylonjs/havok/balls/index.html
+++ b/examples/babylonjs/havok/balls/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Falling Balls Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/balls/index.js
+++ b/examples/babylonjs/havok/balls/index.js
@@ -1,4 +1,5 @@
-﻿let engine;
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
@@ -6,7 +7,14 @@ const PHYSICS_SCALE = 1/100;
 async function init() {
 
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/box/index.html
+++ b/examples/babylonjs/havok/box/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Stacked Boxes Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/box/index.js
+++ b/examples/babylonjs/havok/box/index.js
@@ -1,4 +1,5 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -58,7 +59,14 @@ const PHYSICS_SCALE = 1/10;
 async function init() {
 
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/cone/index.html
+++ b/examples/babylonjs/havok/cone/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>Babylon.js + Havok physics Falling Cone Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/cone/index.js
+++ b/examples/babylonjs/havok/cone/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
@@ -7,7 +8,14 @@ const SCALE = 1 / 50;
 
 async function init() {
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     engine = new BABYLON.Engine(canvas, true);
     globalThis.engine = engine;

--- a/examples/babylonjs/havok/domino/index.html
+++ b/examples/babylonjs/havok/domino/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Domino Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/domino/index.js
+++ b/examples/babylonjs/havok/domino/index.js
@@ -1,4 +1,5 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -58,7 +59,14 @@ const PHYSICS_SCALE = 1/10;
 async function init() {
 
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/football/index.html
+++ b/examples/babylonjs/havok/football/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Falling Football Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/football/index.js
+++ b/examples/babylonjs/havok/football/index.js
@@ -1,4 +1,5 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -58,7 +59,14 @@ const PHYSICS_SCALE = 1/10;
 async function init() {
 
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/gltf/index.html
+++ b/examples/babylonjs/havok/gltf/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics + glTF Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/loaders/babylon.glTF2FileLoader.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylonjs.loaders.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/gltf/index.js
+++ b/examples/babylonjs/havok/gltf/index.js
@@ -1,10 +1,18 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
 
 async function init() {
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>Babylon.js + Havok glTF Physics Materials Friction Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/loaders/babylon.glTF2FileLoader.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylonjs.loaders.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
@@ -15,7 +16,7 @@ function ensureRigidBodyLoader() {
     if (!rigidBodyLoaderPromise) {
         rigidBodyLoaderPromise = new Promise((resolve, reject) => {
             const script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/npm/babylon-gltf-rigid-body-loader@latest';
+            script.src = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon-gltf-rigid-body-loader.js';
             script.onload = resolve;
             script.onerror = () => reject(new Error('Failed to load babylon-gltf-rigid-body-loader.'));
             document.head.appendChild(script);
@@ -43,7 +44,14 @@ function registerPhysicsExtensions() {
 
 async function init() {
     canvas = document.querySelector('#c');
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     await ensureRigidBodyLoader();
     registerPhysicsExtensions();
 

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>Babylon.js + Havok glTF Physics Materials Restitution Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/loaders/babylon.glTF2FileLoader.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylonjs.loaders.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
@@ -15,7 +16,7 @@ function ensureRigidBodyLoader() {
     if (!rigidBodyLoaderPromise) {
         rigidBodyLoaderPromise = new Promise((resolve, reject) => {
             const script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/npm/babylon-gltf-rigid-body-loader@latest';
+            script.src = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon-gltf-rigid-body-loader.js';
             script.onload = resolve;
             script.onerror = () => reject(new Error('Failed to load babylon-gltf-rigid-body-loader.'));
             document.head.appendChild(script);
@@ -43,7 +44,14 @@ function registerPhysicsExtensions() {
 
 async function init() {
     canvas = document.querySelector('#c');
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     await ensureRigidBodyLoader();
     registerPhysicsExtensions();
 

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>Babylon.js + Havok glTF Physics Motion Properties Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/loaders/babylon.glTF2FileLoader.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylonjs.loaders.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
@@ -6,6 +6,8 @@ let physicsExtensionsRegistered = false;
 
 const MODEL_ROOT = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/';
 const MODEL_FILE = 'MotionProperties.glb';
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+const RIGID_BODY_LOADER_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon-gltf-rigid-body-loader.js';
 
 function ensureRigidBodyLoader() {
     if (window.GLTFRigidBodyLoader) {
@@ -15,7 +17,7 @@ function ensureRigidBodyLoader() {
     if (!rigidBodyLoaderPromise) {
         rigidBodyLoaderPromise = new Promise((resolve, reject) => {
             const script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/npm/babylon-gltf-rigid-body-loader@latest';
+            script.src = RIGID_BODY_LOADER_URL;
             script.onload = resolve;
             script.onerror = () => reject(new Error('Failed to load babylon-gltf-rigid-body-loader.'));
             document.head.appendChild(script);
@@ -43,7 +45,14 @@ function registerPhysicsExtensions() {
 
 async function init() {
     canvas = document.querySelector('#c');
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     await ensureRigidBodyLoader();
     registerPhysicsExtensions();
 

--- a/examples/babylonjs/havok/marbles/index.html
+++ b/examples/babylonjs/havok/marbles/index.html
@@ -3,9 +3,9 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Falling Marbles Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/loaders/babylon.glTF2FileLoader.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylonjs.loaders.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/marbles/index.js
+++ b/examples/babylonjs/havok/marbles/index.js
@@ -1,4 +1,5 @@
-﻿let engine;
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
+let engine;
 let scene;
 let canvas;
 
@@ -7,7 +8,14 @@ const PHYSICS_SCALE = 1/10;
 
 async function init() {
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/minimum/index.html
+++ b/examples/babylonjs/havok/minimum/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Minimum Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/minimum/index.js
+++ b/examples/babylonjs/havok/minimum/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
@@ -5,7 +6,14 @@ const PHYSICS_SCALE = 1/10;
 
 async function init() {
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     engine = new BABYLON.Engine(canvas, true);
 
     scene = createScene();

--- a/examples/babylonjs/havok/shogi/index.html
+++ b/examples/babylonjs/havok/shogi/index.html
@@ -3,8 +3,8 @@
 <head>
   <title>[WIP] Babylon.js + Havok physics Falling Shogi Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <script src="https://cdn.babylonjs.com/babylon.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/babylon.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/babylonjs/havok/shogi/index.js
+++ b/examples/babylonjs/havok/shogi/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let engine;
 let scene;
 let canvas;
@@ -9,7 +10,14 @@ const SPAWN_MARGIN = 0.6 * PHYSICS_SCALE;
 
 async function init() {
     canvas = document.querySelector("#c");
-    globalThis.HK = await HavokPhysics();
+    globalThis.HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     engine = new BABYLON.Engine(canvas, true);
     globalThis.engine = engine;


### PR DESCRIPTION
## Summary
- replace Babylon.js/Havok CDN references in Babylon.js Havok examples with cx20 hosted dev URLs
- pin glTF Physics rigid-body loader to hosted 0.6.0-compatible build instead of npm @latest
- set explicit Havok wasm resolution via locateFile to use hosted HavokPhysics.wasm

## Scope
- examples/babylonjs/havok/**

## Validation
- searched for remaining `cdn.babylonjs.com` and `babylon-gltf-rigid-body-loader@latest` under examples/babylonjs/havok (none)
- checked workspace problems for examples/babylonjs/havok (no errors)