### PR TITLE
chore(webgl-havok): pin Havok URLs across WebGL1/2/WebGPU samples to cx20 hosted libs

### DIFF
--- a/examples/webgl1/havok/balls/index.html
+++ b/examples/webgl1/havok/balls/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Falling Balls Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/balls/index.js
+++ b/examples/webgl1/havok/balls/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 import Module from 'https://esm.run/manifold-3d';
 
 const { mat4, vec3, quat } = glMatrix;
@@ -443,7 +444,14 @@ async function main() {
     textures = await Promise.all(TEXTURE_FILES.map(loadTexture));
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
 
     requestAnimationFrame(render);

--- a/examples/webgl1/havok/box/index.html
+++ b/examples/webgl1/havok/box/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Stacked Boxes Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -422,7 +423,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl1/havok/cone/index.html
+++ b/examples/webgl1/havok/cone/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Falling Cone Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/cone/index.js
+++ b/examples/webgl1/havok/cone/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const CONE_COUNT = 120;
@@ -658,7 +659,14 @@ async function main() {
     coneTexture = await loadTexture(CONE_TEXTURE);
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
     requestAnimationFrame(render);
 }

--- a/examples/webgl1/havok/domino/index.html
+++ b/examples/webgl1/havok/domino/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Domino Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 // forked from gaziya's "Domino  (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
@@ -353,7 +354,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl1/havok/football/index.html
+++ b/examples/webgl1/havok/football/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Falling Football Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -441,7 +442,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl1/havok/gltf/index.html
+++ b/examples/webgl1/havok/gltf/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Falling glTF Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/gltf/index.js
+++ b/examples/webgl1/havok/gltf/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, mat3, vec3, quat } = glMatrix;
 
 const DUCK_GLTF_URL = 'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
@@ -910,7 +911,14 @@ async function main() {
     gl.enable(gl.DEPTH_TEST);
     gl.enable(gl.CULL_FACE);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     groundMesh = createGroundMesh();
     groundTexture = createSolidTexture(255, 255, 255, 255);

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Materials Friction glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
@@ -989,7 +990,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Materials Restitution glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
@@ -1010,7 +1011,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Motion Properties glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/MotionProperties.glb';
@@ -1250,7 +1251,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/marbles/index.html
+++ b/examples/webgl1/havok/marbles/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Falling Marbles (glTF) Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/marbles/index.js
+++ b/examples/webgl1/havok/marbles/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MARBLES_GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
@@ -1066,7 +1067,14 @@ async function main() {
 
     gl.enable(gl.DEPTH_TEST);
     gl.enable(gl.CULL_FACE);
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initSkybox();
 
     groundMesh = createGroundMesh();

--- a/examples/webgl1/havok/minimum/index.html
+++ b/examples/webgl1/havok/minimum/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 1.0 + Havok Minimum Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/minimum/index.js
+++ b/examples/webgl1/havok/minimum/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const canvas = document.getElementById('c');
 const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
 
@@ -330,7 +331,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl1/havok/shogi/index.html
+++ b/examples/webgl1/havok/shogi/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 1.0 + Havok Falling Shogi Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl1/havok/shogi/index.js
+++ b/examples/webgl1/havok/shogi/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
 const SHOW_DEBUG_WIREFRAME = false;
@@ -564,7 +565,14 @@ function render() {
 }
 
 async function initHavokAndStart() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     createDebugWireframeBoxMesh();
     bodys = initPhysics();
     data2buf();

--- a/examples/webgl2/havok/balls/index.html
+++ b/examples/webgl2/havok/balls/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Falling Balls Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/balls/index.js
+++ b/examples/webgl2/havok/balls/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 import Module from 'https://esm.run/manifold-3d';
 
 const { mat4, vec3, quat } = glMatrix;
@@ -442,7 +443,14 @@ async function main() {
     textures = await Promise.all(TEXTURE_FILES.map(loadTexture));
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
 
     requestAnimationFrame(render);

--- a/examples/webgl2/havok/box/index.html
+++ b/examples/webgl2/havok/box/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Stacked Boxes Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -407,7 +408,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl2/havok/cone/index.html
+++ b/examples/webgl2/havok/cone/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Falling Cone Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/cone/index.js
+++ b/examples/webgl2/havok/cone/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const CONE_COUNT = 140;
@@ -484,7 +485,14 @@ async function main() {
     coneTexture = await loadTexture(CONE_TEXTURE);
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
     requestAnimationFrame(render);
 }

--- a/examples/webgl2/havok/domino/index.html
+++ b/examples/webgl2/havok/domino/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Domino Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/domino/index.js
+++ b/examples/webgl2/havok/domino/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 // forked from gaziya's "Domino  (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
@@ -352,7 +353,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl2/havok/football/index.html
+++ b/examples/webgl2/havok/football/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Falling Football Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -424,7 +425,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl2/havok/gltf/index.html
+++ b/examples/webgl2/havok/gltf/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Falling glTF Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/gltf/index.js
+++ b/examples/webgl2/havok/gltf/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const DUCK_GLTF_URL = 'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
@@ -890,7 +891,14 @@ async function main() {
     gl.enable(gl.DEPTH_TEST);
     gl.enable(gl.CULL_FACE);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     groundMesh = createGroundMesh();
     groundTexture = createSolidTexture(255, 255, 255, 255);

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Materials Friction glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
@@ -989,7 +990,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Materials Restitution glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
@@ -1010,7 +1011,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Motion Properties glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/MotionProperties.glb';
@@ -1235,7 +1236,14 @@ async function main() {
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/marbles/index.html
+++ b/examples/webgl2/havok/marbles/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Falling Marbles (glTF) Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/marbles/index.js
+++ b/examples/webgl2/havok/marbles/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MARBLES_GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
@@ -1048,7 +1049,14 @@ async function main() {
 
     gl.enable(gl.DEPTH_TEST);
     gl.enable(gl.CULL_FACE);
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initSkybox();
 
     groundMesh = createGroundMesh();

--- a/examples/webgl2/havok/minimum/index.html
+++ b/examples/webgl2/havok/minimum/index.html
@@ -4,7 +4,7 @@
   <title>WebGL 2.0 + Havok Minimum Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/minimum/index.js
+++ b/examples/webgl2/havok/minimum/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const canvas = document.getElementById('c');
 const gl = canvas.getContext('webgl2');
 
@@ -331,7 +332,14 @@ function render(timeMs) {
 }
 
 async function init() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl2/havok/shogi/index.html
+++ b/examples/webgl2/havok/shogi/index.html
@@ -4,7 +4,7 @@
     <title>WebGL 2.0 + Havok Falling Shogi Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgl2/havok/shogi/index.js
+++ b/examples/webgl2/havok/shogi/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("webgl2");
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -494,7 +495,14 @@ function render() {
 }
 
 async function initHavokAndStart() {
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     bodys = initPhysics();
     data2buf();
     startPhysicsLoop();

--- a/examples/webgpu/havok/balls/index.html
+++ b/examples/webgpu/havok/balls/index.html
@@ -4,7 +4,7 @@
   <title>WebGPU + Havok Falling Balls Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/balls/index.js
+++ b/examples/webgpu/havok/balls/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 import Module from 'https://esm.run/manifold-3d';
 
 const { mat4, vec3, quat } = glMatrix;
@@ -476,7 +477,14 @@ async function main() {
     textureViews = textures.map((texture) => texture.createView());
     whiteTextureView = createSolidTextureView(255, 255, 255, 255);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
     initRenderItems();
 

--- a/examples/webgpu/havok/box/index.html
+++ b/examples/webgpu/havok/box/index.html
@@ -4,7 +4,7 @@
   <title>WebGPU + Havok Stacked Boxes Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -423,7 +424,14 @@ async function init() {
         throw new Error('WebGPU is not supported in this browser.');
     }
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {

--- a/examples/webgpu/havok/cone/index.html
+++ b/examples/webgpu/havok/cone/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Falling Cone Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/cone/index.js
+++ b/examples/webgpu/havok/cone/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const CONE_COUNT = 160;
@@ -528,7 +529,14 @@ async function main() {
     resize();
     window.addEventListener('resize', resize);
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     initPhysics();
     initRenderItems();
     requestAnimationFrame(render);

--- a/examples/webgpu/havok/domino/index.html
+++ b/examples/webgpu/havok/domino/index.html
@@ -4,7 +4,7 @@
   <title>WebGPU + Havok Domino Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/domino/index.js
+++ b/examples/webgpu/havok/domino/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 // forked from gaziya's "Domino  (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
@@ -389,7 +390,14 @@ async function init() {
         throw new Error('WebGPU is not supported in this browser.');
     }
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {

--- a/examples/webgpu/havok/football/index.html
+++ b/examples/webgpu/havok/football/index.html
@@ -4,7 +4,7 @@
   <title>WebGPU + Havok Falling Football Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4 } = glMatrix;
 
 const DOT_ROWS = [
@@ -418,7 +419,14 @@ async function init() {
         throw new Error('WebGPU is not supported in this browser.');
     }
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {

--- a/examples/webgpu/havok/gltf/index.html
+++ b/examples/webgpu/havok/gltf/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Falling glTF Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/gltf/index.js
+++ b/examples/webgpu/havok/gltf/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const DUCK_GLTF_URL = 'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
@@ -821,7 +822,14 @@ async function main() {
     }
 
     device = await adapter.requestDevice();
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     context = canvas.getContext('webgpu');
     format = navigator.gpu.getPreferredCanvasFormat();
 

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Materials Friction glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
@@ -982,7 +983,14 @@ async function main() {
     }
 
     device = await adapter.requestDevice();
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     context = canvas.getContext('webgpu');
     format = navigator.gpu.getPreferredCanvasFormat();
 

--- a/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Materials Restitution glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
@@ -1003,7 +1004,14 @@ async function main() {
     }
 
     device = await adapter.requestDevice();
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     context = canvas.getContext('webgpu');
     format = navigator.gpu.getPreferredCanvasFormat();
 

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Motion Properties glTF Physics Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/MotionProperties.glb';
@@ -1229,7 +1230,14 @@ async function main() {
     }
 
     device = await adapter.requestDevice();
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     context = canvas.getContext('webgpu');
     format = navigator.gpu.getPreferredCanvasFormat();
 

--- a/examples/webgpu/havok/marbles/index.html
+++ b/examples/webgpu/havok/marbles/index.html
@@ -4,7 +4,7 @@
     <title>WebGPU + Havok Falling Marbles (glTF) Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://unpkg.com/gl-matrix@3.4.4/gl-matrix-min.js"></script>
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/marbles/index.js
+++ b/examples/webgpu/havok/marbles/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const { mat4, vec3, quat } = glMatrix;
 
 const MARBLES_GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
@@ -960,7 +961,14 @@ async function main() {
     }
 
     device = await adapter.requestDevice();
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     context = canvas.getContext('webgpu');
     format = navigator.gpu.getPreferredCanvasFormat();
 

--- a/examples/webgpu/havok/minimum/index.html
+++ b/examples/webgpu/havok/minimum/index.html
@@ -4,7 +4,7 @@
   <title>WebGPU + Havok Minimum Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
-  <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+  <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/minimum/index.js
+++ b/examples/webgpu/havok/minimum/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const vertexShaderWGSL = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 
@@ -342,7 +343,14 @@ async function init() {
         throw new Error('WebGPU is not supported in this browser.');
     }
 
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
 
     const adapter = await navigator.gpu.requestAdapter();
     if (!adapter) {

--- a/examples/webgpu/havok/shogi/index.html
+++ b/examples/webgpu/havok/shogi/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>WebGPU + Havok Falling Shogi Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-    <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
+    <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
 

--- a/examples/webgpu/havok/shogi/index.js
+++ b/examples/webgpu/havok/shogi/index.js
@@ -1,3 +1,4 @@
+const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const vertexShaderWGSL   = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 const groundVertWGSL     = document.getElementById('gvs').textContent;
@@ -393,7 +394,14 @@ async function init() {
     depthTexture = createDepthTexture();
 
     // Physics
-    HK = await HavokPhysics();
+    HK = await HavokPhysics({
+        locateFile: function (path) {
+            if (path && path.endsWith('.wasm')) {
+                return HAVOK_WASM_URL;
+            }
+            return path;
+        }
+    });
     const worldResult = HK.HP_World_Create();
     checkResult(worldResult[0], 'HP_World_Create');
     worldId = worldResult[1];


### PR DESCRIPTION
## Summary
- replace Havok CDN references in WebGL1/2/WebGPU examples with cx20 hosted dev URLs
- set explicit Havok wasm resolution via locateFile to use hosted HavokPhysics.wasm across all frameworks

## Scope
- examples/webgl1/havok/**
- examples/webgl2/havok/**
- examples/webgpu/havok/**

## Validation
- searched for remaining `cdn.babylonjs.com` under all target directories (none)
- checked workspace problems for all target directories (no errors)