### PR TITLE
fix(havok/gltf_physics_Motion_Properties): pass mass=0 and inertiaDiagonal directly to Havok

### DIFF
--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -777,18 +777,11 @@ function setMassPropertyQuat(target, keys, value) {
     return false;
 }
 
-// KHR_physics_rigid_bodies spec: inertiaDiagonal component of 0 means "infinite inertia" (locked axis).
-// Havok cannot accept 0 inertia (causes 1/0=Infinity in the solver and breaks simulation).
-// Replace 0 components with a large value to represent "infinite" inertia.
-const INFINITE_INERTIA = 1e30;
-
+// KHR_physics_rigid_bodies spec: mass=0 and inertiaDiagonal component=0 each mean infinity.
+// Pass these 0 values directly to HP_Body_SetMassProperties — Havok handles them correctly.
 function toHavokInertiaDiagonal(specValue) {
     if (!Array.isArray(specValue)) return specValue;
-    return [
-        specValue[0] === 0 ? INFINITE_INERTIA : specValue[0],
-        specValue[1] === 0 ? INFINITE_INERTIA : specValue[1],
-        specValue[2] === 0 ? INFINITE_INERTIA : specValue[2]
-    ];
+    return [specValue[0], specValue[1], specValue[2]];
 }
 
 function applyMotionMassProperties(bodyId, motionDef) {
@@ -796,11 +789,12 @@ function applyMotionMassProperties(bodyId, motionDef) {
         return;
     }
 
+    const hasMass = motionDef.mass !== undefined;
     const hasInertiaDiagonal = Array.isArray(motionDef.inertiaDiagonal);
     const hasInertiaOrientation = Array.isArray(motionDef.inertiaOrientation);
     const hasCenterOfMass = Array.isArray(motionDef.centerOfMass);
 
-    if (!hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
+    if (!hasMass && !hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
         return;
     }
 
@@ -808,18 +802,20 @@ function applyMotionMassProperties(bodyId, motionDef) {
     checkResult(massPropResult[0], 'HP_Body_GetMassProperties');
     const massProperties = massPropResult[1];
 
-    console.log(`[applyMotionMassProperties] bodyId=${bodyId}`);
-    console.log(`  Input: mass=${motionDef.mass}, inertiaDiagonal=${JSON.stringify(motionDef.inertiaDiagonal)}, centerOfMass=${JSON.stringify(motionDef.centerOfMass)}`);
-
     let changed = false;
 
-    // Havok mass properties structure: [mass, centerOfMass[3], inertiaDiagonal[3], inertiaOrientation[4]]
+    // Havok mass properties structure: [centerOfMass[3], mass, inertiaDiagonal[3], inertiaOrientation[4]]
     if (Array.isArray(massProperties)) {
         console.log(`  massProperties is array, length=${massProperties.length}`);
         let vec3SlotCount = 0;
         for (let i = 0; i < massProperties.length; i++) {
             const slot = massProperties[i];
             if (!Array.isArray(slot)) {
+                // scalar slot = mass
+                if (hasMass) {
+                    massProperties[i] = motionDef.mass;
+                    changed = true;
+                }
                 continue;
             }
 
@@ -1100,7 +1096,9 @@ function createMeshPhysicsShape(node, colliderGeom, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
         console.log(`  Set density=${density} for dynamic body`);
     }
@@ -1189,7 +1187,9 @@ function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
         console.log(`  Set density=${density} for dynamic body (mass=${motionDef.mass}, volume=${volume})`);
     }

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -780,15 +780,11 @@ function setMassPropertyQuat(target, keys, value) {
 // KHR_physics_rigid_bodies spec: inertiaDiagonal component of 0 means "infinite inertia" (locked axis).
 // Havok cannot accept 0 inertia (causes 1/0=Infinity in the solver and breaks simulation).
 // Replace 0 components with a large value to represent "infinite" inertia.
-const INFINITE_INERTIA = 1e30;
-
+// KHR_physics_rigid_bodies spec: mass=0 and inertiaDiagonal component=0 each mean infinity.
+// Pass these 0 values directly to HP_Body_SetMassProperties — Havok handles them correctly.
 function toHavokInertiaDiagonal(specValue) {
     if (!Array.isArray(specValue)) return specValue;
-    return [
-        specValue[0] === 0 ? INFINITE_INERTIA : specValue[0],
-        specValue[1] === 0 ? INFINITE_INERTIA : specValue[1],
-        specValue[2] === 0 ? INFINITE_INERTIA : specValue[2]
-    ];
+    return [specValue[0], specValue[1], specValue[2]];
 }
 
 function applyMotionMassProperties(bodyId, motionDef) {
@@ -796,11 +792,12 @@ function applyMotionMassProperties(bodyId, motionDef) {
         return;
     }
 
+    const hasMass = motionDef.mass !== undefined;
     const hasInertiaDiagonal = Array.isArray(motionDef.inertiaDiagonal);
     const hasInertiaOrientation = Array.isArray(motionDef.inertiaOrientation);
     const hasCenterOfMass = Array.isArray(motionDef.centerOfMass);
 
-    if (!hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
+    if (!hasMass && !hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
         return;
     }
 
@@ -810,12 +807,17 @@ function applyMotionMassProperties(bodyId, motionDef) {
 
     let changed = false;
 
-    // Havok mass properties structure: [mass, centerOfMass[3], inertiaDiagonal[3], inertiaOrientation[4]]
+    // Havok mass properties structure: [centerOfMass[3], mass, inertiaDiagonal[3], inertiaOrientation[4]]
     if (Array.isArray(massProperties)) {
         let vec3SlotCount = 0;
         for (let i = 0; i < massProperties.length; i++) {
             const slot = massProperties[i];
             if (!Array.isArray(slot)) {
+                // scalar slot = mass
+                if (hasMass) {
+                    massProperties[i] = motionDef.mass;
+                    changed = true;
+                }
                 continue;
             }
 
@@ -1094,7 +1096,9 @@ function createMeshPhysicsShape(node, colliderGeom, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
     applyPhysicsMaterial(shapeId, materialDef);
@@ -1176,7 +1180,9 @@ function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
 

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
@@ -747,15 +747,11 @@ function setMassPropertyQuat(target, keys, value) {
 // KHR_physics_rigid_bodies spec: inertiaDiagonal component of 0 means "infinite inertia" (locked axis).
 // Havok cannot accept 0 inertia (causes 1/0=Infinity in the solver and breaks simulation).
 // Replace 0 components with a large value to represent "infinite" inertia.
-const INFINITE_INERTIA = 1e30;
-
+// KHR_physics_rigid_bodies spec: mass=0 and inertiaDiagonal component=0 each mean infinity.
+// Pass these 0 values directly to HP_Body_SetMassProperties — Havok handles them correctly.
 function toHavokInertiaDiagonal(specValue) {
     if (!Array.isArray(specValue)) return specValue;
-    return [
-        specValue[0] === 0 ? INFINITE_INERTIA : specValue[0],
-        specValue[1] === 0 ? INFINITE_INERTIA : specValue[1],
-        specValue[2] === 0 ? INFINITE_INERTIA : specValue[2]
-    ];
+    return [specValue[0], specValue[1], specValue[2]];
 }
 
 function applyMotionMassProperties(bodyId, motionDef) {
@@ -763,11 +759,12 @@ function applyMotionMassProperties(bodyId, motionDef) {
         return;
     }
 
+    const hasMass = motionDef.mass !== undefined;
     const hasInertiaDiagonal = Array.isArray(motionDef.inertiaDiagonal);
     const hasInertiaOrientation = Array.isArray(motionDef.inertiaOrientation);
     const hasCenterOfMass = Array.isArray(motionDef.centerOfMass);
 
-    if (!hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
+    if (!hasMass && !hasInertiaDiagonal && !hasInertiaOrientation && !hasCenterOfMass) {
         return;
     }
 
@@ -777,12 +774,17 @@ function applyMotionMassProperties(bodyId, motionDef) {
 
     let changed = false;
 
-    // Havok mass properties structure: [mass, centerOfMass[3], inertiaDiagonal[3], inertiaOrientation[4]]
+    // Havok mass properties structure: [centerOfMass[3], mass, inertiaDiagonal[3], inertiaOrientation[4]]
     if (Array.isArray(massProperties)) {
         let vec3SlotCount = 0;
         for (let i = 0; i < massProperties.length; i++) {
             const slot = massProperties[i];
             if (!Array.isArray(slot)) {
+                // scalar slot = mass
+                if (hasMass) {
+                    massProperties[i] = motionDef.mass;
+                    changed = true;
+                }
                 continue;
             }
 
@@ -1062,7 +1064,9 @@ function createMeshPhysicsShape(node, colliderGeom, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
     applyPhysicsMaterial(shapeId, materialDef);
@@ -1144,7 +1148,9 @@ function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
     }
 
     if (motionDef) {
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        // density is only used for HP_Shape_BuildMassProperties; mass=0 is overridden in applyMotionMassProperties
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
 


### PR DESCRIPTION
Per KHR_physics_rigid_bodies spec, mass=0 and inertiaDiagonal[i]=0 each mean infinity. These values can be passed directly to HP_Body_SetMassProperties and Havok handles them correctly.

## Problem

Wheel_InfiniteMassFiniteInertia did not rotate when hit by balloons in the WebGL1/2/WebGPU variants.

Root cause (identified by comparing with the working Babylon.js version):

| | Babylon.js (working) | WebGL variants (broken) |
|---|---|---|
| mass | SetMassProperties(mass=0) | density = INFINITE_INERTIA/volume -> large finite mass |
| inertiaDiagonal | [0,1,0] as-is | [0] replaced with 1e6 -> [1e6,1,1e6] |
| angularVelocity | (0,0,2.633) OK rotating | (0,0,0) NG not rotating |

applyMotionMassProperties was also skipping the scalar mass slot with continue, so the mass field was never applied.

## Fix

- applyMotionMassProperties: add hasMass flag; write motionDef.mass into scalar slot
- toHavokInertiaDiagonal: remove 0->INFINITE_INERTIA conversion; pass 0 as-is
- density calc: use 1 when mass=0 (actual mass set via SetMassProperties)
- Remove INFINITE_INERTIA constant

Babylon.js comparison confirmed: mass=0, inertia=[0,1,0] -> angVel=2.633 (rotating wheel)

Applies to webgl1, webgl2, and webgpu variants.