### PR TITLE
feat: apply GGX PBR shading to Motion_Properties examples (WebGL1, WebGL2, WebGPU)

### DIFF
--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
@@ -18,12 +18,15 @@ uniform mat4 uModel;
 
 varying vec3 vNormal;
 varying vec2 vTexCoord;
+varying vec3 vWorldPos;
 
 void main() {
     mat3 normalMatrix = mat3(uModel);
     vNormal = normalize(normalMatrix * aNormal);
     vTexCoord = aTexCoord;
-    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+    vec4 worldPos = uModel * vec4(aPosition, 1.0);
+    vWorldPos = worldPos.xyz;
+    gl_Position = uViewProj * worldPos;
 }
 </script>
 
@@ -34,20 +37,76 @@ uniform sampler2D uTexture;
 uniform bool uHasTexture;
 uniform vec4 uBaseColor;
 uniform vec3 uLightDir;
+uniform vec3 uEyePos;
+uniform float uMetallic;
+uniform float uRoughness;
 
 varying vec3 vNormal;
 varying vec2 vTexCoord;
+varying vec3 vWorldPos;
+
+const float PI = 3.14159265359;
+
+float DistributionGGX(float NdotH, float roughness) {
+    float a  = roughness * roughness;
+    float a2 = a * a;
+    float d  = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    return a2 / (PI * d * d);
+}
+
+float GeometrySchlickGGX(float NdotX, float roughness) {
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotX / (NdotX * (1.0 - k) + k);
+}
+
+vec3 FresnelSchlick(float cosTheta, vec3 F0) {
+    float f = pow(max(1.0 - cosTheta, 0.0), 5.0);
+    return F0 + (1.0 - F0) * f;
+}
 
 void main() {
     vec3 N = normalize(vNormal);
-    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 L = normalize(uLightDir);
+    vec3 V = normalize(uEyePos - vWorldPos);
+    vec3 H = normalize(L + V);
 
-    vec4 base = uBaseColor;
+    vec4 albedoSample = uBaseColor;
     if (uHasTexture) {
-        base *= texture2D(uTexture, vTexCoord);
+        albedoSample *= texture2D(uTexture, vTexCoord);
     }
+    vec3 albedo = albedoSample.rgb;
 
-    gl_FragColor = vec4(base.rgb * diffuse, base.a);
+    float metallic  = clamp(uMetallic,  0.0, 1.0);
+    float roughness = clamp(uRoughness, 0.05, 1.0);
+
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotH = max(dot(N, H), 0.0);
+    float HdotV = max(dot(H, V), 0.0);
+
+    float D = DistributionGGX(NdotH, roughness);
+    float G = GeometrySchlickGGX(NdotV, roughness) * GeometrySchlickGGX(NdotL, roughness);
+    vec3  F = FresnelSchlick(HdotV, F0);
+
+    vec3 kD = (1.0 - F) * (1.0 - metallic);
+    vec3 specular = D * G * F / (4.0 * NdotV * NdotL + 0.001);
+
+    vec3 Lo = (kD * albedo / PI + specular) * vec3(3.5) * NdotL;
+
+    // Hemisphere ambient (sky / ground)
+    float upBlend = N.y * 0.5 + 0.5;
+    vec3 ambient = mix(vec3(0.08, 0.07, 0.06), vec3(0.10, 0.15, 0.28), upBlend) * albedo;
+
+    vec3 color = ambient + Lo;
+
+    // Reinhard tone mapping + gamma correction
+    color = color / (color + vec3(1.0));
+    color = pow(max(color, vec3(0.0)), vec3(1.0 / 2.2));
+
+    gl_FragColor = vec4(color, albedoSample.a);
 }
 </script>
 

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -550,6 +550,8 @@ async function buildModel(url) {
 
             let texture = null;
             let baseColor = [1, 1, 1, 1];
+            let metallic = 0.0;
+            let roughness = 0.5;
             let doubleSided = false;
 
             if (primitive.material !== undefined) {
@@ -564,11 +566,13 @@ async function buildModel(url) {
                         if (pbr.baseColorTexture) {
                             texture = await loadMaterialTexture(gltf, buffers, baseUrl, pbr.baseColorTexture.index);
                         }
+                        if (pbr.metallicFactor !== undefined)  metallic  = pbr.metallicFactor;
+                        if (pbr.roughnessFactor !== undefined) roughness = pbr.roughnessFactor;
                     }
                 }
             }
 
-            primitives.push({ ...gpu, bbox, texture, baseColor, doubleSided });
+            primitives.push({ ...gpu, bbox, texture, baseColor, metallic, roughness, doubleSided });
         }
 
         let meshBbox = primitives[0].bbox;
@@ -645,6 +649,8 @@ function drawPrimitive(primitive, modelMatrix) {
 
     gl.uniformMatrix4fv(uniforms.model, false, modelMatrix);
     gl.uniform4fv(uniforms.baseColor, primitive.baseColor);
+    gl.uniform1f(uniforms.metallic,  primitive.metallic  !== undefined ? primitive.metallic  : 0.0);
+    gl.uniform1f(uniforms.roughness, primitive.roughness !== undefined ? primitive.roughness : 0.5);
 
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, primitive.texture || whiteTexture);
@@ -1316,6 +1322,7 @@ function renderFrame(timeSec) {
     gl.useProgram(program);
     gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
     gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, 0.35]);
+    gl.uniform3fv(uniforms.eyePos, eye);
 
     drawModel();
     drawPhysicsDebug();
@@ -1347,12 +1354,15 @@ async function main() {
     };
 
     uniforms = {
-        viewProj: gl.getUniformLocation(program, 'uViewProj'),
-        model: gl.getUniformLocation(program, 'uModel'),
-        texture: gl.getUniformLocation(program, 'uTexture'),
+        viewProj:   gl.getUniformLocation(program, 'uViewProj'),
+        model:      gl.getUniformLocation(program, 'uModel'),
+        texture:    gl.getUniformLocation(program, 'uTexture'),
         hasTexture: gl.getUniformLocation(program, 'uHasTexture'),
-        baseColor: gl.getUniformLocation(program, 'uBaseColor'),
-        lightDir: gl.getUniformLocation(program, 'uLightDir')
+        baseColor:  gl.getUniformLocation(program, 'uBaseColor'),
+        lightDir:   gl.getUniformLocation(program, 'uLightDir'),
+        eyePos:     gl.getUniformLocation(program, 'uEyePos'),
+        metallic:   gl.getUniformLocation(program, 'uMetallic'),
+        roughness:  gl.getUniformLocation(program, 'uRoughness')
     };
 
     lineAttribs = {

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -1321,7 +1321,7 @@ function renderFrame(timeSec) {
 
     gl.useProgram(program);
     gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
-    gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, 0.35]);
+    gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, -0.35]);
     gl.uniform3fv(uniforms.eyePos, eye);
 
     drawModel();

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
@@ -20,12 +20,15 @@ uniform mat4 uModel;
 
 out vec3 vNormal;
 out vec2 vTexCoord;
+out vec3 vWorldPos;
 
 void main() {
     mat3 normalMatrix = mat3(uModel);
     vNormal = normalize(normalMatrix * aNormal);
     vTexCoord = aTexCoord;
-    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+    vec4 worldPos = uModel * vec4(aPosition, 1.0);
+    vWorldPos = worldPos.xyz;
+    gl_Position = uViewProj * worldPos;
 }
 </script>
 
@@ -38,21 +41,75 @@ uniform sampler2D uTexture;
 uniform bool uHasTexture;
 uniform vec4 uBaseColor;
 uniform vec3 uLightDir;
+uniform vec3 uEyePos;
+uniform float uMetallic;
+uniform float uRoughness;
 
 in vec3 vNormal;
 in vec2 vTexCoord;
+in vec3 vWorldPos;
 out vec4 outColor;
+
+const float PI = 3.14159265359;
+
+float DistributionGGX(float NdotH, float roughness) {
+    float a  = roughness * roughness;
+    float a2 = a * a;
+    float d  = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    return a2 / (PI * d * d);
+}
+
+float GeometrySchlickGGX(float NdotX, float roughness) {
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotX / (NdotX * (1.0 - k) + k);
+}
+
+vec3 FresnelSchlick(float cosTheta, vec3 F0) {
+    float f = pow(max(1.0 - cosTheta, 0.0), 5.0);
+    return F0 + (1.0 - F0) * f;
+}
 
 void main() {
     vec3 N = normalize(vNormal);
-    float diffuse = max(dot(N, normalize(uLightDir)), 0.25);
+    vec3 L = normalize(uLightDir);
+    vec3 V = normalize(uEyePos - vWorldPos);
+    vec3 H = normalize(L + V);
 
-    vec4 base = uBaseColor;
+    vec4 albedoSample = uBaseColor;
     if (uHasTexture) {
-        base *= texture(uTexture, vTexCoord);
+        albedoSample *= texture(uTexture, vTexCoord);
     }
+    vec3 albedo = albedoSample.rgb;
 
-    outColor = vec4(base.rgb * diffuse, base.a);
+    float metallic  = clamp(uMetallic,  0.0, 1.0);
+    float roughness = clamp(uRoughness, 0.05, 1.0);
+
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotH = max(dot(N, H), 0.0);
+    float HdotV = max(dot(H, V), 0.0);
+
+    float D = DistributionGGX(NdotH, roughness);
+    float G = GeometrySchlickGGX(NdotV, roughness) * GeometrySchlickGGX(NdotL, roughness);
+    vec3  F = FresnelSchlick(HdotV, F0);
+
+    vec3 kD = (1.0 - F) * (1.0 - metallic);
+    vec3 specular = D * G * F / (4.0 * NdotV * NdotL + 0.001);
+
+    vec3 Lo = (kD * albedo / PI + specular) * vec3(3.5) * NdotL;
+
+    float upBlend = N.y * 0.5 + 0.5;
+    vec3 ambient = mix(vec3(0.08, 0.07, 0.06), vec3(0.10, 0.15, 0.28), upBlend) * albedo;
+
+    vec3 color = ambient + Lo;
+
+    color = color / (color + vec3(1.0));
+    color = pow(max(color, vec3(0.0)), vec3(1.0 / 2.2));
+
+    outColor = vec4(color, albedoSample.a);
 }
 </script>
 

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -550,6 +550,8 @@ async function buildModel(url) {
 
             let texture = null;
             let baseColor = [1, 1, 1, 1];
+            let metallic = 0.0;
+            let roughness = 0.5;
             let doubleSided = false;
 
             if (primitive.material !== undefined) {
@@ -564,11 +566,13 @@ async function buildModel(url) {
                         if (pbr.baseColorTexture) {
                             texture = await loadMaterialTexture(gltf, buffers, baseUrl, pbr.baseColorTexture.index);
                         }
+                        if (pbr.metallicFactor  !== undefined) metallic  = pbr.metallicFactor;
+                        if (pbr.roughnessFactor !== undefined) roughness = pbr.roughnessFactor;
                     }
                 }
             }
 
-            primitives.push({ ...gpu, bbox, texture, baseColor, doubleSided });
+            primitives.push({ ...gpu, bbox, texture, baseColor, metallic, roughness, doubleSided });
         }
 
         let meshBbox = primitives[0].bbox;
@@ -645,6 +649,8 @@ function drawPrimitive(primitive, modelMatrix) {
 
     gl.uniformMatrix4fv(uniforms.model, false, modelMatrix);
     gl.uniform4fv(uniforms.baseColor, primitive.baseColor);
+    gl.uniform1f(uniforms.metallic,  primitive.metallic  !== undefined ? primitive.metallic  : 0.0);
+    gl.uniform1f(uniforms.roughness, primitive.roughness !== undefined ? primitive.roughness : 0.5);
 
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, primitive.texture || whiteTexture);
@@ -1327,6 +1333,7 @@ function renderFrame(timeSec) {
     gl.useProgram(program);
     gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
     gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, 0.35]);
+    gl.uniform3fv(uniforms.eyePos, eye);
 
     drawModel();
     drawPhysicsDebug();
@@ -1358,12 +1365,15 @@ async function main() {
     };
 
     uniforms = {
-        viewProj: gl.getUniformLocation(program, 'uViewProj'),
-        model: gl.getUniformLocation(program, 'uModel'),
-        texture: gl.getUniformLocation(program, 'uTexture'),
+        viewProj:   gl.getUniformLocation(program, 'uViewProj'),
+        model:      gl.getUniformLocation(program, 'uModel'),
+        texture:    gl.getUniformLocation(program, 'uTexture'),
         hasTexture: gl.getUniformLocation(program, 'uHasTexture'),
-        baseColor: gl.getUniformLocation(program, 'uBaseColor'),
-        lightDir: gl.getUniformLocation(program, 'uLightDir')
+        baseColor:  gl.getUniformLocation(program, 'uBaseColor'),
+        lightDir:   gl.getUniformLocation(program, 'uLightDir'),
+        eyePos:     gl.getUniformLocation(program, 'uEyePos'),
+        metallic:   gl.getUniformLocation(program, 'uMetallic'),
+        roughness:  gl.getUniformLocation(program, 'uRoughness')
     };
 
     lineAttribs = {

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -1332,7 +1332,7 @@ function renderFrame(timeSec) {
 
     gl.useProgram(program);
     gl.uniformMatrix4fv(uniforms.viewProj, false, viewProj);
-    gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, 0.35]);
+    gl.uniform3fv(uniforms.lightDir, [0.45, 1.0, -0.35]);
     gl.uniform3fv(uniforms.eyePos, eye);
 
     drawModel();

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
@@ -10,54 +10,114 @@
 
 <script id="vs" type="x-shader/x-vertex">
 struct Uniforms {
-    viewProj : mat4x4<f32>,
-    model : mat4x4<f32>,
+    viewProj  : mat4x4<f32>,
+    model     : mat4x4<f32>,
     baseColor : vec4<f32>,
+    eyePos    : vec3<f32>,
+    metallic  : f32,
+    roughness : f32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms : Uniforms;
 
 struct VSOut {
     @builtin(position) Position : vec4<f32>,
-    @location(0) normal : vec3<f32>,
-    @location(1) uv : vec2<f32>,
+    @location(0) normal   : vec3<f32>,
+    @location(1) uv       : vec2<f32>,
+    @location(2) worldPos : vec3<f32>,
 };
 
 @vertex
 fn main(
     @location(0) position : vec3<f32>,
-    @location(1) normal : vec3<f32>,
-    @location(2) uv : vec2<f32>
+    @location(1) normal   : vec3<f32>,
+    @location(2) uv       : vec2<f32>
 ) -> VSOut {
     var out : VSOut;
-    out.Position = uniforms.viewProj * uniforms.model * vec4<f32>(position, 1.0);
-    out.normal = normalize((uniforms.model * vec4<f32>(normal, 0.0)).xyz);
-    out.uv = uv;
+    let worldPos = uniforms.model * vec4<f32>(position, 1.0);
+    out.worldPos = worldPos.xyz;
+    out.Position = uniforms.viewProj * worldPos;
+    out.normal   = normalize((uniforms.model * vec4<f32>(normal, 0.0)).xyz);
+    out.uv       = uv;
     return out;
 }
 </script>
 
 <script id="fs" type="x-shader/x-fragment">
 struct Uniforms {
-    viewProj : mat4x4<f32>,
-    model : mat4x4<f32>,
+    viewProj  : mat4x4<f32>,
+    model     : mat4x4<f32>,
     baseColor : vec4<f32>,
+    eyePos    : vec3<f32>,
+    metallic  : f32,
+    roughness : f32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms : Uniforms;
 @group(0) @binding(1) var samp : sampler;
-@group(0) @binding(2) var tex : texture_2d<f32>;
+@group(0) @binding(2) var tex  : texture_2d<f32>;
+
+const PI : f32 = 3.14159265359;
+const LIGHT_DIR : vec3<f32> = vec3<f32>(0.45, 1.0, 0.35);
+
+fn distributionGGX(NdotH: f32, roughness: f32) -> f32 {
+    let a  = roughness * roughness;
+    let a2 = a * a;
+    let d  = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    return a2 / (PI * d * d);
+}
+
+fn geometrySchlickGGX(NdotX: f32, roughness: f32) -> f32 {
+    let r = roughness + 1.0;
+    let k = (r * r) / 8.0;
+    return NdotX / (NdotX * (1.0 - k) + k);
+}
+
+fn fresnelSchlick(cosTheta: f32, F0: vec3<f32>) -> vec3<f32> {
+    let f = pow(max(1.0 - cosTheta, 0.0), 5.0);
+    return F0 + (1.0 - F0) * f;
+}
 
 @fragment
 fn main(
-    @location(0) normal : vec3<f32>,
-    @location(1) uv : vec2<f32>
+    @location(0) normal   : vec3<f32>,
+    @location(1) uv       : vec2<f32>,
+    @location(2) worldPos : vec3<f32>
 ) -> @location(0) vec4<f32> {
-    let lightDir = normalize(vec3<f32>(0.6, 1.0, 0.5));
-    let diffuse = max(dot(normalize(normal), lightDir), 0.25);
-    let texColor = textureSample(tex, samp, uv);
-    let base = uniforms.baseColor * texColor;
-    return vec4<f32>(base.rgb * diffuse, base.a);
+    let N = normalize(normal);
+    let L = normalize(LIGHT_DIR);
+    let V = normalize(uniforms.eyePos - worldPos);
+    let H = normalize(L + V);
+
+    let albedoSample = uniforms.baseColor * textureSample(tex, samp, uv);
+    let albedo = albedoSample.rgb;
+
+    let metallic  = clamp(uniforms.metallic,  0.0, 1.0);
+    let roughness = clamp(uniforms.roughness, 0.05, 1.0);
+
+    let F0 = mix(vec3<f32>(0.04), albedo, metallic);
+
+    let NdotL = max(dot(N, L), 0.0);
+    let NdotV = max(dot(N, V), 0.0);
+    let NdotH = max(dot(N, H), 0.0);
+    let HdotV = max(dot(H, V), 0.0);
+
+    let D = distributionGGX(NdotH, roughness);
+    let G = geometrySchlickGGX(NdotV, roughness) * geometrySchlickGGX(NdotL, roughness);
+    let F = fresnelSchlick(HdotV, F0);
+
+    let kD      = (1.0 - F) * (1.0 - metallic);
+    let specular = D * G * F / (4.0 * NdotV * NdotL + 0.001);
+    let Lo       = (kD * albedo / PI + specular) * vec3<f32>(3.5) * NdotL;
+
+    let upBlend = N.y * 0.5 + 0.5;
+    let ambient = mix(vec3<f32>(0.08, 0.07, 0.06), vec3<f32>(0.10, 0.15, 0.28), upBlend) * albedo;
+
+    var color = ambient + Lo;
+    color = color / (color + vec3<f32>(1.0));
+    color = pow(max(color, vec3<f32>(0.0)), vec3<f32>(1.0 / 2.2));
+
+    return vec4<f32>(color, albedoSample.a);
 }
 </script>
 

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
@@ -58,7 +58,7 @@ struct Uniforms {
 @group(0) @binding(2) var tex  : texture_2d<f32>;
 
 const PI : f32 = 3.14159265359;
-const LIGHT_DIR : vec3<f32> = vec3<f32>(0.45, 1.0, 0.35);
+const LIGHT_DIR : vec3<f32> = vec3<f32>(0.45, 1.0, -0.35);
 
 fn distributionGGX(NdotH: f32, roughness: f32) -> f32 {
     let a  = roughness * roughness;

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
@@ -464,7 +464,7 @@ function expandToTriangles(positions, normals, uvs, indices) {
 
 function createTriangleRenderItem(textureView) {
     const uniformBuffer = device.createBuffer({
-        size: 144,
+        size: 176,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
 
@@ -480,10 +480,14 @@ function createTriangleRenderItem(textureView) {
     return { uniformBuffer, bindGroup };
 }
 
-function writeTriangleUniforms(buffer, modelMatrix, baseColor) {
-    device.queue.writeBuffer(buffer, 0, viewProj);
-    device.queue.writeBuffer(buffer, 64, modelMatrix);
+function writeTriangleUniforms(buffer, modelMatrix, baseColor, eyePos, metallic, roughness) {
+    device.queue.writeBuffer(buffer, 0,   viewProj);
+    device.queue.writeBuffer(buffer, 64,  modelMatrix);
     device.queue.writeBuffer(buffer, 128, new Float32Array(baseColor));
+    // offset 144: eyePos(vec3) + metallic(f32)
+    device.queue.writeBuffer(buffer, 144, new Float32Array([eyePos[0], eyePos[1], eyePos[2], metallic]));
+    // offset 160: roughness(f32)
+    device.queue.writeBuffer(buffer, 160, new Float32Array([roughness]));
 }
 
 function writeLineUniforms(buffer, modelMatrix, color) {
@@ -566,6 +570,8 @@ async function buildDuckModel(url) {
 
             let textureView = whiteTextureView;
             let baseColor = [1, 1, 1, 1];
+            let metallic  = 0.0;
+            let roughness = 0.5;
             if (primitive.material !== undefined) {
                 const material = gltf.materials[primitive.material];
                 if (material && material.pbrMetallicRoughness) {
@@ -576,11 +582,13 @@ async function buildDuckModel(url) {
                     if (pbr.baseColorTexture) {
                         textureView = textureViews[pbr.baseColorTexture.index] || whiteTextureView;
                     }
+                    if (pbr.metallicFactor  !== undefined) metallic  = pbr.metallicFactor;
+                    if (pbr.roughnessFactor !== undefined) roughness = pbr.roughnessFactor;
                 }
             }
 
             const renderItem = createTriangleRenderItem(textureView);
-            primitives.push({ mesh, renderItem, baseColor, bbox });
+            primitives.push({ mesh, renderItem, baseColor, metallic, roughness, bbox });
         }
 
         let meshBbox = primitives[0].bbox;
@@ -1289,7 +1297,7 @@ function drawDuckNodes(pass) {
         if (node.mesh !== undefined) {
             const mesh = duckModel.meshes[node.mesh];
             for (const prim of mesh.primitives) {
-                writeTriangleUniforms(prim.renderItem.uniformBuffer, worldMat, prim.baseColor);
+                writeTriangleUniforms(prim.renderItem.uniformBuffer, worldMat, prim.baseColor, currentEyePos, prim.metallic ?? 0.0, prim.roughness ?? 0.5);
                 drawTriangleMesh(pass, prim.mesh, prim.renderItem.bindGroup);
             }
         }
@@ -1317,6 +1325,7 @@ function render(timeMs) {
         cameraCenter[1] + cameraHeight,
         cameraCenter[2] - cameraRadius
     );
+    const currentEyePos = eye;
     mat4.lookAt(view, eye, cameraCenter, [0, 1, 0]);
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 2000);
     mat4.multiply(viewProj, projection, view);

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
@@ -34,6 +34,8 @@ let duckModel = null;
 const physicsNodes = [];
 const dynamicNodes = [];
 
+let eyePos = vec3.create();
+
 let debugBoxMesh;
 let debugLineUniformBuffer;
 let debugLineBindGroup;
@@ -988,29 +990,34 @@ function createMeshPhysicsShape(node, colliderGeom, motionDef, materialDef) {
     }
 
     const posFloat32 = new Float32Array(allPositions);
+    const numVertices = allPositions.length / 3;
     let shapeId;
 
-    if (isConvex) {
-        const created = HK.HP_Shape_CreateConvexHull(posFloat32);
-        checkResult(created[0], 'HP_Shape_CreateConvexHull');
-        // Try to get shapeId - might be in created[1] directly OR created[1][0]
-        let rawShapeId = Array.isArray(created[1]) && created[1].length > 0 ? created[1][0] : created[1];
-        // Convert BigInt to number if needed
-        if (typeof rawShapeId === 'bigint') {
-            rawShapeId = Number(rawShapeId);
+    // Havok WASM expects native heap memory offsets, not JavaScript TypedArrays.
+    const posBytes = posFloat32.length * 4;
+    const posOffset = HK._malloc(posBytes);
+    new Float32Array(HK.HEAPU8.buffer, posOffset, posFloat32.length).set(posFloat32);
+    try {
+        if (isConvex) {
+            const created = HK.HP_Shape_CreateConvexHull(posOffset, numVertices);
+            checkResult(created[0], 'HP_Shape_CreateConvexHull');
+            shapeId = created[1];
+        } else {
+            const numTriangles = allIndices.length / 3;
+            const triBytes = allIndices.length * 4;
+            const triOffset = HK._malloc(triBytes);
+            const triView = new Int32Array(HK.HEAPU8.buffer, triOffset, allIndices.length);
+            for (let i = 0; i < allIndices.length; i++) triView[i] = allIndices[i];
+            try {
+                const created = HK.HP_Shape_CreateMesh(posOffset, numVertices, triOffset, numTriangles);
+                checkResult(created[0], 'HP_Shape_CreateMesh');
+                shapeId = created[1];
+            } finally {
+                HK._free(triOffset);
+            }
         }
-        shapeId = rawShapeId;
-    } else {
-        const indicesUint32 = new Uint32Array(allIndices);
-        const created = HK.HP_Shape_CreateMesh(posFloat32, indicesUint32);
-        checkResult(created[0], 'HP_Shape_CreateMesh');
-        // Try to get shapeId - might be in created[1] directly OR created[1][0]
-        let rawShapeId = Array.isArray(created[1]) && created[1].length > 0 ? created[1][0] : created[1];
-        // Convert BigInt to number if needed
-        if (typeof rawShapeId === 'bigint') {
-            rawShapeId = Number(rawShapeId);
-        }
-        shapeId = rawShapeId;
+    } finally {
+        HK._free(posOffset);
     }
 
     let minX = Infinity, minY = Infinity, minZ = Infinity;
@@ -1023,7 +1030,7 @@ function createMeshPhysicsShape(node, colliderGeom, motionDef, materialDef) {
     let size = [maxX - minX, maxY - minY, maxZ - minZ];
     let volume = Math.max((maxX - minX) * (maxY - minY) * (maxZ - minZ), 0.0001);
 
-    if (!shapeId || shapeId <= 0 || shapeId === undefined || shapeId === null) {
+    if (shapeId == null) {
         console.warn(`  [WARN] Invalid shapeId=${shapeId}! Mesh shape creation FAILED.`);
         console.warn(`    This Havok WASM version may not support mesh shapes. Creating fallback approximation shape...`);
 
@@ -1297,7 +1304,7 @@ function drawDuckNodes(pass) {
         if (node.mesh !== undefined) {
             const mesh = duckModel.meshes[node.mesh];
             for (const prim of mesh.primitives) {
-                writeTriangleUniforms(prim.renderItem.uniformBuffer, worldMat, prim.baseColor, currentEyePos, prim.metallic ?? 0.0, prim.roughness ?? 0.5);
+                writeTriangleUniforms(prim.renderItem.uniformBuffer, worldMat, prim.baseColor, eyePos, prim.metallic ?? 0.0, prim.roughness ?? 0.5);
                 drawTriangleMesh(pass, prim.mesh, prim.renderItem.bindGroup);
             }
         }
@@ -1325,7 +1332,7 @@ function render(timeMs) {
         cameraCenter[1] + cameraHeight,
         cameraCenter[2] - cameraRadius
     );
-    const currentEyePos = eye;
+    vec3.copy(eyePos, eye);
     mat4.lookAt(view, eye, cameraCenter, [0, 1, 0]);
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 2000);
     mat4.multiply(viewProj, projection, view);


### PR DESCRIPTION
## Overview
Apply GGX Cook-Torrance PBR shading to the `gltf_physics_Motion_Properties` example across WebGL1, WebGL2, and WebGPU variants.

## Changes

### WebGL1
- Added `vWorldPos` varying and GGX PBR fragment shader (GLSL 1.0)
- Reads `metallicFactor` / `roughnessFactor` from `pbrMetallicRoughness`
- Sets `uEyePos`, `uMetallic`, `uRoughness` uniforms per frame / per primitive

### WebGL2
- Same PBR changes as WebGL1 with GLSL 3.00 es syntax (`in/out`, `texture()`)

### WebGPU
- Updated WGSL `Uniforms` struct to 176 bytes (added `eyePos`, `metallic`, `roughness`)
- Full GGX PBR in WGSL fragment shader
- Fixed `ReferenceError`: moved `eyePos` to module scope, updated via `vec3.copy` in `render()`
- Fixed `createMeshPhysicsShape`: use `HK._malloc` / `HEAPU8` / `HK._free` heap pointer pattern instead of passing TypedArrays to `HP_Shape_CreateConvexHull` / `HP_Shape_CreateMesh`

### All variants
- Fixed light direction Z component (`+0.35` -> `-0.35`) so camera-facing surfaces receive direct PBR lighting (NdotL > 0)
