### PR TITLE
fix: call loop() inside async init() to avoid renderer undefined error

### DIFF
--- a/examples/threejs/rapier/shogi/index.js
+++ b/examples/threejs/rapier/shogi/index.js
@@ -277,6 +277,7 @@ async function init() {
 
     setInterval(updatePhysics, 1000 / 60);
     window.addEventListener('resize', onWindowResize, false);
+    loop();
 }
 
 function updatePhysics() {
@@ -317,4 +318,3 @@ function onWindowResize() {
 }
 
 init();
-loop();


### PR DESCRIPTION
## Summary

- Fix `Uncaught TypeError: Cannot read properties of undefined (reading 'render')` in `examples/threejs/rapier/shogi/index.js`
- `loop()` was called at module level immediately after `init()`, but since `init()` is `async`, `renderer` was still `undefined` when `loop()` ran
- Move `loop()` call to the end of `init()` (after `setInterval`) so it runs only after `renderer` has been created

## Test plan

- [ ] Open `examples/threejs/rapier/shogi/index.html` and confirm no console errors
- [ ] Confirm 220 shogi pieces fall and animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)