### PR TITLE
fix: Motion_Properties wheel lock and mesh collider fixes

### DIFF
--- a/examples/threejs/rapier/gltf_physics_Motion_Properties/index.js
+++ b/examples/threejs/rapier/gltf_physics_Motion_Properties/index.js
@@ -268,6 +268,31 @@ async function loadModelAndBuildPhysics() {
         const av = motion.angularVelocity;
         bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
       }
+      // inertiaDiagonal: 0 = infinite inertia on that axis → lock rotation on that axis.
+      // Find which world axes correspond to the non-zero (rotatable) principal axes.
+      if (motion.inertiaDiagonal) {
+        const [ix, iy, iz] = motion.inertiaDiagonal;
+        if (ix === 0 || iy === 0 || iz === 0) {
+          let bodyQuat = tmpWorldQuaternion.clone();
+          if (motion.inertiaOrientation) {
+            const io = motion.inertiaOrientation;
+            bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+          }
+          const diag = [ix, iy, iz];
+          const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+          let allowX = false, allowY = false, allowZ = false;
+          for (let j = 0; j < 3; j++) {
+            if (diag[j] !== 0) {
+              const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+              const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+              if (ax >= ay && ax >= az) allowX = true;
+              else if (ay >= ax && ay >= az) allowY = true;
+              else allowZ = true;
+            }
+          }
+          bodyDesc.enabledRotations(allowX, allowY, allowZ);
+        }
+      }
     }
 
     const body = world.createRigidBody(bodyDesc);

--- a/examples/threejs/rapier/gltf_physics_Motion_Properties/index.js
+++ b/examples/threejs/rapier/gltf_physics_Motion_Properties/index.js
@@ -254,6 +254,9 @@ async function loadModelAndBuildPhysics() {
     });
 
     if (motion) {
+      if (motion.mass === 0) {
+        bodyDesc.lockTranslations();
+      }
       if (motion.gravityFactor !== undefined) {
         bodyDesc.setGravityScale(motion.gravityFactor);
       }


### PR DESCRIPTION
## Summary

- Call `bodyDesc.lockTranslations()` when `motion.mass === 0` so the wheel stays fixed in place when objects collide with it
- Call `bodyDesc.enabledRotations()` based on `motion.inertiaDiagonal` to constrain rotation to the intended spin axis only
- Per the KHR_physics_rigid_bodies spec, `mass: 0` means infinite translational mass (position locked, rotation allowed); a zero component in `inertiaDiagonal` means infinite rotational inertia on that axis (rotation locked)

## Changes

- `examples/threejs/rapier/gltf_physics_Motion_Properties/index.js`

## Test plan

- [ ] Open the Motion_Properties example and verify that the `Wheel_InfiniteMassFiniteInertia` object does not translate when hit by other objects, but spins freely on its designated axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)