### PR TITLE
feat: align all three.js + rapier examples to rapier3d-compat@0.17.3

### DIFF
--- a/examples/threejs/rapier/balls/index.js
+++ b/examples/threejs/rapier/balls/index.js
@@ -1,6 +1,6 @@
 ﻿import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 // three.js 用変数
 let camera, scene, light, renderer, container, content;
@@ -79,8 +79,7 @@ async function init() {
     controls.autoRotate = true;
 
     // Rapier の物理ワールド初期化
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     initRapierPhysics();
 
@@ -121,8 +120,8 @@ function initRapierPhysics() {
         const { size, pos, rot } = boxDataSet[i];
         const colliderDesc = RAPIER.ColliderDesc.cuboid(size[0] / 2, size[1] / 2, size[2] / 2);
         const bodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(pos[0], pos[1], pos[2]);
-        world.createRigidBody(bodyDesc);
-        world.createCollider(colliderDesc, bodyDesc);
+        const body = world.createRigidBody(bodyDesc);
+        world.createCollider(colliderDesc, body);
 
         addStaticBox(size, pos, rot, true);
     }

--- a/examples/threejs/rapier/box/index.js
+++ b/examples/threejs/rapier/box/index.js
@@ -1,6 +1,6 @@
 ﻿import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let loader;
 let texture_grass;
@@ -85,8 +85,7 @@ async function init() {
     initLights();
 
     // Rapier の物理ワールド初期化
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     // initGround を Rapier の初期化後に呼び出す
     initGround();

--- a/examples/threejs/rapier/cone/index.js
+++ b/examples/threejs/rapier/cone/index.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let camera, scene, light, renderer, container;
 let controls;
@@ -63,8 +63,7 @@ async function init() {
     controls.autoRotate = true;
 
     // Rapier physics world
-    const gravity = new RAPIER.Vector3(0, -9.8, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -9.8, z: 0 });
 
     // Ground
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -2, 0);

--- a/examples/threejs/rapier/domino/index.js
+++ b/examples/threejs/rapier/domino/index.js
@@ -1,6 +1,6 @@
 ﻿import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
@@ -73,8 +73,7 @@ async function init() {
     controls.autoRotate = true;
 
     // Rapier の物理ワールド初期化
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     initLights();
     initGround();

--- a/examples/threejs/rapier/football/index.js
+++ b/examples/threejs/rapier/football/index.js
@@ -1,6 +1,6 @@
 ﻿import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let loader;
 let texture_grass;
@@ -88,8 +88,7 @@ async function init() {
     initLights();
 
     // Rapier の物理ワールド初期化
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     // ground を初期化
     initGround();

--- a/examples/threejs/rapier/gltf/index.js
+++ b/examples/threejs/rapier/gltf/index.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let world, body;
 let camera, scene, renderer, duck, plane;
@@ -91,8 +91,7 @@ async function init() {
     controls = new OrbitControls(camera, renderer.domElement);
 
     // Rapier physics
-    const gravity = new RAPIER.Vector3(0, -9.8, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -9.8, z: 0 });
 
     // Ground
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -5, 0);

--- a/examples/threejs/rapier/gltf_physics_Basic_Shapes/index.js
+++ b/examples/threejs/rapier/gltf_physics_Basic_Shapes/index.js
@@ -251,6 +251,32 @@ async function loadModelAndBuildPhysics() {
       const av = motion.angularVelocity;
       bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
     }
+    if (motion.mass === 0) {
+      bodyDesc.lockTranslations();
+    }
+    if (motion.inertiaDiagonal) {
+      const [ix, iy, iz] = motion.inertiaDiagonal;
+      if (ix === 0 || iy === 0 || iz === 0) {
+        let bodyQuat = tmpWorldQuaternion.clone();
+        if (motion.inertiaOrientation) {
+          const io = motion.inertiaOrientation;
+          bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+        }
+        const diag = [ix, iy, iz];
+        const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+        let allowX = false, allowY = false, allowZ = false;
+        for (let j = 0; j < 3; j++) {
+          if (diag[j] !== 0) {
+            const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+            const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+            if (ax >= ay && ax >= az) allowX = true;
+            else if (ay >= ax && ay >= az) allowY = true;
+            else allowZ = true;
+          }
+        }
+        bodyDesc.enabledRotations(allowX, allowY, allowZ);
+      }
+    }
 
     const body = world.createRigidBody(bodyDesc);
 
@@ -303,7 +329,8 @@ async function loadModelAndBuildPhysics() {
       initialQuaternion: {
         x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
         z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
-      }
+      },
+      motion
     });
     dynamicNodes.push(physicsNodes[physicsNodes.length - 1]);
     processedNodeIndices.add(nodeIndex);
@@ -359,6 +386,46 @@ async function loadModelAndBuildPhysics() {
       z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
     });
 
+    if (motion) {
+      if (motion.mass === 0) {
+        bodyDesc.lockTranslations();
+      }
+      if (motion.gravityFactor !== undefined) {
+        bodyDesc.setGravityScale(motion.gravityFactor);
+      }
+      if (motion.linearVelocity) {
+        const lv = motion.linearVelocity;
+        bodyDesc.setLinvel(lv[0], lv[1], lv[2]);
+      }
+      if (motion.angularVelocity) {
+        const av = motion.angularVelocity;
+        bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
+      }
+      if (motion.inertiaDiagonal) {
+        const [ix, iy, iz] = motion.inertiaDiagonal;
+        if (ix === 0 || iy === 0 || iz === 0) {
+          let bodyQuat = tmpWorldQuaternion.clone();
+          if (motion.inertiaOrientation) {
+            const io = motion.inertiaOrientation;
+            bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+          }
+          const diag = [ix, iy, iz];
+          const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+          let allowX = false, allowY = false, allowZ = false;
+          for (let j = 0; j < 3; j++) {
+            if (diag[j] !== 0) {
+              const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+              const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+              if (ax >= ay && ax >= az) allowX = true;
+              else if (ay >= ax && ay >= az) allowY = true;
+              else allowZ = true;
+            }
+          }
+          bodyDesc.enabledRotations(allowX, allowY, allowZ);
+        }
+      }
+    }
+
     const body = world.createRigidBody(bodyDesc);
     world.createCollider(colliderDesc, body);
 
@@ -369,7 +436,8 @@ async function loadModelAndBuildPhysics() {
       initialQuaternion: {
         x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
         z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
-      }
+      },
+      motion
     };
     physicsNodes.push(node);
     if (motion) dynamicNodes.push(node);
@@ -395,8 +463,12 @@ function resetDynamicBodiesIfNeeded() {
     }
     node.body.setTranslation(node.initialPosition, true);
     node.body.setRotation(node.initialQuaternion, true);
-    node.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-    node.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+
+    const lv = node.motion?.linearVelocity;
+    node.body.setLinvel(lv ? { x: lv[0], y: lv[1], z: lv[2] } : { x: 0, y: 0, z: 0 }, true);
+
+    const av = node.motion?.angularVelocity;
+    node.body.setAngvel(av ? { x: av[0], y: av[1], z: av[2] } : { x: 0, y: 0, z: 0 }, true);
   }
 }
 

--- a/examples/threejs/rapier/gltf_physics_Materials_Friction/index.js
+++ b/examples/threejs/rapier/gltf_physics_Materials_Friction/index.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
 const FIXED_TIMESTEP = 1 / 60;
@@ -50,6 +50,109 @@ async function fetchGltfJsonFromGlb(url) {
   }
 
   throw new Error('GLB JSON chunk is missing.');
+}
+
+function buildColliderDesc(shapeDef, worldScale, friction, restitution) {
+  if (!shapeDef) return null;
+
+  let colliderDesc = null;
+
+  if (shapeDef.type === 'box' && shapeDef.box) {
+    const size = shapeDef.box.size || [1, 1, 1];
+    colliderDesc = RAPIER.ColliderDesc.cuboid(
+      Math.max(Math.abs(size[0] * worldScale.x) * 0.5, 0.0001),
+      Math.max(Math.abs(size[1] * worldScale.y) * 0.5, 0.0001),
+      Math.max(Math.abs(size[2] * worldScale.z) * 0.5, 0.0001)
+    );
+  } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
+    const baseRadius = shapeDef.sphere.radius !== undefined ? shapeDef.sphere.radius : 0.5;
+    const maxScale = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.y), Math.abs(worldScale.z));
+    colliderDesc = RAPIER.ColliderDesc.ball(Math.max(baseRadius * maxScale, 0.0001));
+  } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
+    const cd = shapeDef.capsule;
+    const avgRadius = ((cd.radiusTop ?? 0.5) + (cd.radiusBottom ?? 0.5)) * 0.5;
+    const scaleXZ = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
+    colliderDesc = RAPIER.ColliderDesc.capsule(
+      Math.max((cd.height ?? 1.0) * Math.abs(worldScale.y) * 0.5, 0),
+      Math.max(avgRadius * scaleXZ, 0.0001)
+    );
+  } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
+    const cd = shapeDef.cylinder;
+    const maxRadius = Math.max(cd.radiusTop ?? 0.5, cd.radiusBottom ?? 0.5);
+    const scaleXZ = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
+    colliderDesc = RAPIER.ColliderDesc.cylinder(
+      Math.max((cd.height ?? 1.0) * Math.abs(worldScale.y) * 0.5, 0.0001),
+      Math.max(maxRadius * scaleXZ, 0.0001)
+    );
+  } else {
+    return null;
+  }
+
+  colliderDesc.setFriction(friction);
+  colliderDesc.setRestitution(restitution);
+  colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+  return colliderDesc;
+}
+
+function getMeshColliderDesc(object, worldScale) {
+  let posAttr = null;
+  let indexArray = null;
+  object.traverse((child) => {
+    if (posAttr !== null) return;
+    if (!child.isMesh || !child.geometry) return;
+    const attr = child.geometry.getAttribute('position');
+    if (!attr) return;
+    posAttr = attr;
+    indexArray = child.geometry.index ? child.geometry.index.array : null;
+  });
+  if (!posAttr) return null;
+  const count = posAttr.count;
+  const scaledPos = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    scaledPos[i * 3]     = posAttr.getX(i) * worldScale.x;
+    scaledPos[i * 3 + 1] = posAttr.getY(i) * worldScale.y;
+    scaledPos[i * 3 + 2] = posAttr.getZ(i) * worldScale.z;
+  }
+  let indices;
+  if (indexArray) {
+    indices = new Uint32Array(indexArray);
+  } else {
+    indices = new Uint32Array(count);
+    for (let i = 0; i < count; i++) indices[i] = i;
+  }
+  return RAPIER.ColliderDesc.trimesh(scaledPos, indices);
+}
+
+function getConvexPoints(object, worldScale) {
+  let posAttr = null;
+  object.traverse((child) => {
+    if (posAttr !== null) return;
+    if (!child.isMesh || !child.geometry) return;
+    posAttr = child.geometry.getAttribute('position');
+  });
+  if (!posAttr) return null;
+  const count = posAttr.count;
+  const points = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    points[i * 3]     = posAttr.getX(i) * worldScale.x;
+    points[i * 3 + 1] = posAttr.getY(i) * worldScale.y;
+    points[i * 3 + 2] = posAttr.getZ(i) * worldScale.z;
+  }
+  return points;
+}
+
+function collectCompoundChildren(nodeIndex, gltfJson, result, excluded) {
+  const nd = gltfJson.nodes[nodeIndex];
+  for (const childIndex of (nd.children || [])) {
+    const childNd = gltfJson.nodes[childIndex];
+    const childExt = childNd?.extensions?.KHR_physics_rigid_bodies;
+    if (childExt?.motion) continue;
+    if (childExt?.collider?.geometry) {
+      result.push(childIndex);
+      excluded.add(childIndex);
+    }
+    collectCompoundChildren(childIndex, gltfJson, result, excluded);
+  }
 }
 
 function setObjectWorldTransform(object, worldPosition, worldQuaternion) {
@@ -101,36 +204,141 @@ async function loadModelAndBuildPhysics() {
   const scenePhysics = gltfJson.extensions?.KHR_physics_rigid_bodies || {};
   const materialDefs = scenePhysics.physicsMaterials || [];
 
+  // Pass 1: compound bodies — parent has motion but no self-collider; children supply colliders
   for (let nodeIndex = 0; nodeIndex < gltfJson.nodes.length; nodeIndex++) {
-    if (processedNodeIndices.has(nodeIndex)) {
-      continue;
+    const nodeDef = gltfJson.nodes[nodeIndex];
+    const physicsExt = nodeDef?.extensions?.KHR_physics_rigid_bodies;
+    if (!physicsExt?.motion || physicsExt.collider?.geometry) continue;
+
+    const childIndices = [];
+    collectCompoundChildren(nodeIndex, gltfJson, childIndices, processedNodeIndices);
+    if (childIndices.length === 0) continue;
+
+    const parentObject = await gltf.parser.getDependency('node', nodeIndex);
+    if (!parentObject) continue;
+
+    parentObject.updateWorldMatrix(true, false);
+    parentObject.matrixWorld.decompose(tmpWorldPosition, tmpWorldQuaternion, tmpWorldScale);
+
+    const motion = physicsExt.motion;
+    const bodyDesc = RAPIER.RigidBodyDesc.dynamic();
+    bodyDesc.setTranslation(tmpWorldPosition.x, tmpWorldPosition.y, tmpWorldPosition.z);
+    bodyDesc.setRotation({
+      x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
+      z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
+    });
+
+    if (motion.mass === 0) bodyDesc.lockTranslations();
+    if (motion.gravityFactor !== undefined) bodyDesc.setGravityScale(motion.gravityFactor);
+    if (motion.linearVelocity) {
+      const lv = motion.linearVelocity;
+      bodyDesc.setLinvel(lv[0], lv[1], lv[2]);
     }
+    if (motion.angularVelocity) {
+      const av = motion.angularVelocity;
+      bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
+    }
+    if (motion.inertiaDiagonal) {
+      const [ix, iy, iz] = motion.inertiaDiagonal;
+      if (ix === 0 || iy === 0 || iz === 0) {
+        let bodyQuat = tmpWorldQuaternion.clone();
+        if (motion.inertiaOrientation) {
+          const io = motion.inertiaOrientation;
+          bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+        }
+        const diag = [ix, iy, iz];
+        const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+        let allowX = false, allowY = false, allowZ = false;
+        for (let j = 0; j < 3; j++) {
+          if (diag[j] !== 0) {
+            const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+            const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+            if (ax >= ay && ax >= az) allowX = true;
+            else if (ay >= ax && ay >= az) allowY = true;
+            else allowZ = true;
+          }
+        }
+        bodyDesc.enabledRotations(allowX, allowY, allowZ);
+      }
+    }
+
+    const body = world.createRigidBody(bodyDesc);
+
+    const parentInvQuat = tmpWorldQuaternion.clone().invert();
+    const parentPos = tmpWorldPosition.clone();
+
+    for (const childIndex of childIndices) {
+      const childNd = gltfJson.nodes[childIndex];
+      const childExt = childNd.extensions.KHR_physics_rigid_bodies;
+      const shapeIndex = childExt.collider.geometry.shape;
+      const shapeDef = shapeIndex !== undefined ? shapeDefs[shapeIndex] : null;
+
+      const childObject = await gltf.parser.getDependency('node', childIndex);
+      if (!childObject) continue;
+
+      childObject.updateWorldMatrix(true, false);
+      const childWorldPos = new THREE.Vector3();
+      const childWorldQuat = new THREE.Quaternion();
+      const childWorldScale = new THREE.Vector3();
+      childObject.matrixWorld.decompose(childWorldPos, childWorldQuat, childWorldScale);
+
+      const matIdx = childExt.collider.physicsMaterial;
+      const matDef = matIdx !== undefined ? materialDefs[matIdx] : null;
+      const friction = matDef?.dynamicFriction !== undefined ? matDef.dynamicFriction : 0.5;
+      const restitution = matDef?.restitution !== undefined ? matDef.restitution : 0.0;
+
+      let colliderDesc;
+      if (shapeDef) {
+        colliderDesc = buildColliderDesc(shapeDef, childWorldScale, friction, restitution);
+      } else {
+        const points = getConvexPoints(childObject, childWorldScale);
+        if (points) {
+          colliderDesc = RAPIER.ColliderDesc.convexHull(points);
+          if (colliderDesc) {
+            colliderDesc.setFriction(friction).setRestitution(restitution);
+            colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+          }
+        }
+      }
+      if (!colliderDesc) continue;
+
+      const relPos = childWorldPos.clone().sub(parentPos).applyQuaternion(parentInvQuat);
+      const relQuat = parentInvQuat.clone().multiply(childWorldQuat);
+      colliderDesc.setTranslation(relPos.x, relPos.y, relPos.z);
+      colliderDesc.setRotation({ x: relQuat.x, y: relQuat.y, z: relQuat.z, w: relQuat.w });
+      world.createCollider(colliderDesc, body);
+    }
+
+    physicsNodes.push({
+      object: parentObject,
+      body,
+      initialPosition: { x: tmpWorldPosition.x, y: tmpWorldPosition.y, z: tmpWorldPosition.z },
+      initialQuaternion: {
+        x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
+        z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
+      },
+      motion
+    });
+    dynamicNodes.push(physicsNodes[physicsNodes.length - 1]);
+    processedNodeIndices.add(nodeIndex);
+  }
+
+  // Pass 2: single-body nodes
+  for (let nodeIndex = 0; nodeIndex < gltfJson.nodes.length; nodeIndex++) {
+    if (processedNodeIndices.has(nodeIndex)) continue;
 
     const nodeDef = gltfJson.nodes[nodeIndex];
     const physicsExt = nodeDef?.extensions?.KHR_physics_rigid_bodies;
-    if (!physicsExt || !physicsExt.collider?.geometry) {
-      continue;
-    }
+    if (!physicsExt || !physicsExt.collider?.geometry) continue;
+
+    const shapeIndex = physicsExt.collider.geometry.shape;
+    const shapeDef = shapeIndex !== undefined ? shapeDefs[shapeIndex] : null;
 
     const object = await gltf.parser.getDependency('node', nodeIndex);
-    if (!object) {
-      continue;
-    }
-
-    const shapeDef = shapeDefs[physicsExt.collider.geometry.shape];
-    if (!shapeDef || shapeDef.type !== 'box' || !shapeDef.box) {
-      continue;
-    }
+    if (!object) continue;
 
     object.updateWorldMatrix(true, false);
     object.matrixWorld.decompose(tmpWorldPosition, tmpWorldQuaternion, tmpWorldScale);
-
-    const size = shapeDef.box.size || [1, 1, 1];
-    const halfExtents = [
-      Math.abs(size[0] * tmpWorldScale.x) * 0.5,
-      Math.abs(size[1] * tmpWorldScale.y) * 0.5,
-      Math.abs(size[2] * tmpWorldScale.z) * 0.5
-    ];
 
     const motion = physicsExt.motion || null;
     const materialDef = physicsExt.collider.physicsMaterial !== undefined
@@ -139,6 +347,29 @@ async function loadModelAndBuildPhysics() {
 
     const friction = materialDef?.dynamicFriction !== undefined ? materialDef.dynamicFriction : 0.5;
     const restitution = materialDef?.restitution !== undefined ? materialDef.restitution : 0.0;
+
+    let colliderDesc;
+    if (shapeDef) {
+      colliderDesc = buildColliderDesc(shapeDef, tmpWorldScale, friction, restitution);
+    } else if (physicsExt.collider.geometry.mesh !== undefined) {
+      if (motion) {
+        const points = getConvexPoints(object, tmpWorldScale);
+        if (points) {
+          colliderDesc = RAPIER.ColliderDesc.convexHull(points);
+          if (colliderDesc) {
+            colliderDesc.setFriction(friction).setRestitution(restitution);
+            colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+          }
+        }
+      } else {
+        colliderDesc = getMeshColliderDesc(object, tmpWorldScale);
+        if (colliderDesc) {
+          colliderDesc.setFriction(friction).setRestitution(restitution);
+          colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+        }
+      }
+    }
+    if (!colliderDesc) continue;
 
     const bodyDesc = motion
       ? RAPIER.RigidBodyDesc.dynamic()
@@ -151,14 +382,44 @@ async function loadModelAndBuildPhysics() {
       w: tmpWorldQuaternion.w
     });
 
-    const body = world.createRigidBody(bodyDesc);
+    if (motion) {
+      if (motion.mass === 0) bodyDesc.lockTranslations();
+      if (motion.gravityFactor !== undefined) bodyDesc.setGravityScale(motion.gravityFactor);
+      if (motion.linearVelocity) {
+        const lv = motion.linearVelocity;
+        bodyDesc.setLinvel(lv[0], lv[1], lv[2]);
+      }
+      if (motion.angularVelocity) {
+        const av = motion.angularVelocity;
+        bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
+      }
+      if (motion.inertiaDiagonal) {
+        const [ix, iy, iz] = motion.inertiaDiagonal;
+        if (ix === 0 || iy === 0 || iz === 0) {
+          let bodyQuat = tmpWorldQuaternion.clone();
+          if (motion.inertiaOrientation) {
+            const io = motion.inertiaOrientation;
+            bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+          }
+          const diag = [ix, iy, iz];
+          const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+          let allowX = false, allowY = false, allowZ = false;
+          for (let j = 0; j < 3; j++) {
+            if (diag[j] !== 0) {
+              const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+              const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+              if (ax >= ay && ax >= az) allowX = true;
+              else if (ay >= ax && ay >= az) allowY = true;
+              else allowZ = true;
+            }
+          }
+          bodyDesc.enabledRotations(allowX, allowY, allowZ);
+        }
+      }
+    }
 
-    world.createCollider(
-      RAPIER.ColliderDesc.cuboid(halfExtents[0], halfExtents[1], halfExtents[2])
-        .setFriction(friction)
-        .setRestitution(restitution),
-      body
-    );
+    const body = world.createRigidBody(bodyDesc);
+    world.createCollider(colliderDesc, body);
 
     const node = {
       object,
@@ -169,7 +430,8 @@ async function loadModelAndBuildPhysics() {
         y: tmpWorldQuaternion.y,
         z: tmpWorldQuaternion.z,
         w: tmpWorldQuaternion.w
-      }
+      },
+      motion
     };
 
     physicsNodes.push(node);
@@ -199,8 +461,12 @@ function resetDynamicBodiesIfNeeded() {
     }
     node.body.setTranslation(node.initialPosition, true);
     node.body.setRotation(node.initialQuaternion, true);
-    node.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-    node.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+
+    const lv = node.motion?.linearVelocity;
+    node.body.setLinvel(lv ? { x: lv[0], y: lv[1], z: lv[2] } : { x: 0, y: 0, z: 0 }, true);
+
+    const av = node.motion?.angularVelocity;
+    node.body.setAngvel(av ? { x: av[0], y: av[1], z: av[2] } : { x: 0, y: 0, z: 0 }, true);
   }
 }
 
@@ -249,8 +515,7 @@ async function main() {
 
   window.addEventListener('resize', onWindowResize);
 
-  const gravity = new RAPIER.Vector3(0, -9.8, 0);
-  world = new RAPIER.World(gravity);
+  world = new RAPIER.World({ x: 0, y: -9.8, z: 0 });
   world.timestep = FIXED_TIMESTEP;
 
   await loadModelAndBuildPhysics();

--- a/examples/threejs/rapier/gltf_physics_Materials_Restitution/index.js
+++ b/examples/threejs/rapier/gltf_physics_Materials_Restitution/index.js
@@ -94,6 +94,67 @@ function buildColliderDesc(shapeDef, worldScale, friction, restitution) {
   return colliderDesc;
 }
 
+function getMeshColliderDesc(object, worldScale) {
+  let posAttr = null;
+  let indexArray = null;
+  object.traverse((child) => {
+    if (posAttr !== null) return;
+    if (!child.isMesh || !child.geometry) return;
+    const attr = child.geometry.getAttribute('position');
+    if (!attr) return;
+    posAttr = attr;
+    indexArray = child.geometry.index ? child.geometry.index.array : null;
+  });
+  if (!posAttr) return null;
+  const count = posAttr.count;
+  const scaledPos = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    scaledPos[i * 3]     = posAttr.getX(i) * worldScale.x;
+    scaledPos[i * 3 + 1] = posAttr.getY(i) * worldScale.y;
+    scaledPos[i * 3 + 2] = posAttr.getZ(i) * worldScale.z;
+  }
+  let indices;
+  if (indexArray) {
+    indices = new Uint32Array(indexArray);
+  } else {
+    indices = new Uint32Array(count);
+    for (let i = 0; i < count; i++) indices[i] = i;
+  }
+  return RAPIER.ColliderDesc.trimesh(scaledPos, indices);
+}
+
+function getConvexPoints(object, worldScale) {
+  let posAttr = null;
+  object.traverse((child) => {
+    if (posAttr !== null) return;
+    if (!child.isMesh || !child.geometry) return;
+    posAttr = child.geometry.getAttribute('position');
+  });
+  if (!posAttr) return null;
+  const count = posAttr.count;
+  const points = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    points[i * 3]     = posAttr.getX(i) * worldScale.x;
+    points[i * 3 + 1] = posAttr.getY(i) * worldScale.y;
+    points[i * 3 + 2] = posAttr.getZ(i) * worldScale.z;
+  }
+  return points;
+}
+
+function collectCompoundChildren(nodeIndex, gltfJson, result, excluded) {
+  const nd = gltfJson.nodes[nodeIndex];
+  for (const childIndex of (nd.children || [])) {
+    const childNd = gltfJson.nodes[childIndex];
+    const childExt = childNd?.extensions?.KHR_physics_rigid_bodies;
+    if (childExt?.motion) continue;
+    if (childExt?.collider?.geometry) {
+      result.push(childIndex);
+      excluded.add(childIndex);
+    }
+    collectCompoundChildren(childIndex, gltfJson, result, excluded);
+  }
+}
+
 function setObjectWorldTransform(object, worldPosition, worldQuaternion) {
   if (!object.parent) {
     object.position.copy(worldPosition);
@@ -143,31 +204,138 @@ async function loadModelAndBuildPhysics() {
   const scenePhysics = gltfJson.extensions?.KHR_physics_rigid_bodies || {};
   const materialDefs = scenePhysics.physicsMaterials || [];
 
+  // Pass 1: compound bodies — parent has motion but no self-collider; children supply colliders
   for (let nodeIndex = 0; nodeIndex < gltfJson.nodes.length; nodeIndex++) {
-    if (processedNodeIndices.has(nodeIndex)) {
-      continue;
+    const nodeDef = gltfJson.nodes[nodeIndex];
+    const physicsExt = nodeDef?.extensions?.KHR_physics_rigid_bodies;
+    if (!physicsExt?.motion || physicsExt.collider?.geometry) continue;
+
+    const childIndices = [];
+    collectCompoundChildren(nodeIndex, gltfJson, childIndices, processedNodeIndices);
+    if (childIndices.length === 0) continue;
+
+    const parentObject = await gltf.parser.getDependency('node', nodeIndex);
+    if (!parentObject) continue;
+
+    parentObject.updateWorldMatrix(true, false);
+    parentObject.matrixWorld.decompose(tmpWorldPosition, tmpWorldQuaternion, tmpWorldScale);
+
+    const motion = physicsExt.motion;
+    const bodyDesc = RAPIER.RigidBodyDesc.dynamic();
+    bodyDesc.setTranslation(tmpWorldPosition.x, tmpWorldPosition.y, tmpWorldPosition.z);
+    bodyDesc.setRotation({
+      x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
+      z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
+    });
+
+    if (motion.mass === 0) bodyDesc.lockTranslations();
+    if (motion.gravityFactor !== undefined) bodyDesc.setGravityScale(motion.gravityFactor);
+    if (motion.linearVelocity) {
+      const lv = motion.linearVelocity;
+      bodyDesc.setLinvel(lv[0], lv[1], lv[2]);
     }
+    if (motion.angularVelocity) {
+      const av = motion.angularVelocity;
+      bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
+    }
+    if (motion.inertiaDiagonal) {
+      const [ix, iy, iz] = motion.inertiaDiagonal;
+      if (ix === 0 || iy === 0 || iz === 0) {
+        let bodyQuat = tmpWorldQuaternion.clone();
+        if (motion.inertiaOrientation) {
+          const io = motion.inertiaOrientation;
+          bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+        }
+        const diag = [ix, iy, iz];
+        const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+        let allowX = false, allowY = false, allowZ = false;
+        for (let j = 0; j < 3; j++) {
+          if (diag[j] !== 0) {
+            const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+            const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+            if (ax >= ay && ax >= az) allowX = true;
+            else if (ay >= ax && ay >= az) allowY = true;
+            else allowZ = true;
+          }
+        }
+        bodyDesc.enabledRotations(allowX, allowY, allowZ);
+      }
+    }
+
+    const body = world.createRigidBody(bodyDesc);
+
+    const parentInvQuat = tmpWorldQuaternion.clone().invert();
+    const parentPos = tmpWorldPosition.clone();
+
+    for (const childIndex of childIndices) {
+      const childNd = gltfJson.nodes[childIndex];
+      const childExt = childNd.extensions.KHR_physics_rigid_bodies;
+      const shapeIndex = childExt.collider.geometry.shape;
+      const shapeDef = shapeIndex !== undefined ? shapeDefs[shapeIndex] : null;
+
+      const childObject = await gltf.parser.getDependency('node', childIndex);
+      if (!childObject) continue;
+
+      childObject.updateWorldMatrix(true, false);
+      const childWorldPos = new THREE.Vector3();
+      const childWorldQuat = new THREE.Quaternion();
+      const childWorldScale = new THREE.Vector3();
+      childObject.matrixWorld.decompose(childWorldPos, childWorldQuat, childWorldScale);
+
+      const matIdx = childExt.collider.physicsMaterial;
+      const matDef = matIdx !== undefined ? materialDefs[matIdx] : null;
+      const friction = matDef?.dynamicFriction !== undefined ? matDef.dynamicFriction : 0.5;
+      const restitution = matDef?.restitution !== undefined ? matDef.restitution : 0.0;
+
+      let colliderDesc;
+      if (shapeDef) {
+        colliderDesc = buildColliderDesc(shapeDef, childWorldScale, friction, restitution);
+      } else {
+        const points = getConvexPoints(childObject, childWorldScale);
+        if (points) {
+          colliderDesc = RAPIER.ColliderDesc.convexHull(points);
+          if (colliderDesc) {
+            colliderDesc.setFriction(friction).setRestitution(restitution);
+            colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+          }
+        }
+      }
+      if (!colliderDesc) continue;
+
+      const relPos = childWorldPos.clone().sub(parentPos).applyQuaternion(parentInvQuat);
+      const relQuat = parentInvQuat.clone().multiply(childWorldQuat);
+      colliderDesc.setTranslation(relPos.x, relPos.y, relPos.z);
+      colliderDesc.setRotation({ x: relQuat.x, y: relQuat.y, z: relQuat.z, w: relQuat.w });
+      world.createCollider(colliderDesc, body);
+    }
+
+    physicsNodes.push({
+      object: parentObject,
+      body,
+      initialPosition: { x: tmpWorldPosition.x, y: tmpWorldPosition.y, z: tmpWorldPosition.z },
+      initialQuaternion: {
+        x: tmpWorldQuaternion.x, y: tmpWorldQuaternion.y,
+        z: tmpWorldQuaternion.z, w: tmpWorldQuaternion.w
+      },
+      motion
+    });
+    dynamicNodes.push(physicsNodes[physicsNodes.length - 1]);
+    processedNodeIndices.add(nodeIndex);
+  }
+
+  // Pass 2: single-body nodes
+  for (let nodeIndex = 0; nodeIndex < gltfJson.nodes.length; nodeIndex++) {
+    if (processedNodeIndices.has(nodeIndex)) continue;
 
     const nodeDef = gltfJson.nodes[nodeIndex];
     const physicsExt = nodeDef?.extensions?.KHR_physics_rigid_bodies;
-    if (!physicsExt || !physicsExt.collider?.geometry) {
-      continue;
-    }
-
-    const object = await gltf.parser.getDependency('node', nodeIndex);
-    if (!object) {
-      continue;
-    }
+    if (!physicsExt || !physicsExt.collider?.geometry) continue;
 
     const shapeIndex = physicsExt.collider.geometry.shape;
-    if (shapeIndex === undefined) {
-      continue;
-    }
+    const shapeDef = shapeIndex !== undefined ? shapeDefs[shapeIndex] : null;
 
-    const shapeDef = shapeDefs[shapeIndex];
-    if (!shapeDef) {
-      continue;
-    }
+    const object = await gltf.parser.getDependency('node', nodeIndex);
+    if (!object) continue;
 
     object.updateWorldMatrix(true, false);
     object.matrixWorld.decompose(tmpWorldPosition, tmpWorldQuaternion, tmpWorldScale);
@@ -180,10 +348,28 @@ async function loadModelAndBuildPhysics() {
     const friction = materialDef?.dynamicFriction !== undefined ? materialDef.dynamicFriction : 0.5;
     const restitution = materialDef?.restitution !== undefined ? materialDef.restitution : 0.0;
 
-    const colliderDesc = buildColliderDesc(shapeDef, tmpWorldScale, friction, restitution);
-    if (!colliderDesc) {
-      continue;
+    let colliderDesc;
+    if (shapeDef) {
+      colliderDesc = buildColliderDesc(shapeDef, tmpWorldScale, friction, restitution);
+    } else if (physicsExt.collider.geometry.mesh !== undefined) {
+      if (motion) {
+        const points = getConvexPoints(object, tmpWorldScale);
+        if (points) {
+          colliderDesc = RAPIER.ColliderDesc.convexHull(points);
+          if (colliderDesc) {
+            colliderDesc.setFriction(friction).setRestitution(restitution);
+            colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+          }
+        }
+      } else {
+        colliderDesc = getMeshColliderDesc(object, tmpWorldScale);
+        if (colliderDesc) {
+          colliderDesc.setFriction(friction).setRestitution(restitution);
+          colliderDesc.setRestitutionCombineRule(RAPIER.CoefficientCombineRule.Max);
+        }
+      }
     }
+    if (!colliderDesc) continue;
 
     const bodyDesc = motion
       ? RAPIER.RigidBodyDesc.dynamic()
@@ -195,6 +381,42 @@ async function loadModelAndBuildPhysics() {
       z: tmpWorldQuaternion.z,
       w: tmpWorldQuaternion.w
     });
+
+    if (motion) {
+      if (motion.mass === 0) bodyDesc.lockTranslations();
+      if (motion.gravityFactor !== undefined) bodyDesc.setGravityScale(motion.gravityFactor);
+      if (motion.linearVelocity) {
+        const lv = motion.linearVelocity;
+        bodyDesc.setLinvel(lv[0], lv[1], lv[2]);
+      }
+      if (motion.angularVelocity) {
+        const av = motion.angularVelocity;
+        bodyDesc.setAngvel({ x: av[0], y: av[1], z: av[2] });
+      }
+      if (motion.inertiaDiagonal) {
+        const [ix, iy, iz] = motion.inertiaDiagonal;
+        if (ix === 0 || iy === 0 || iz === 0) {
+          let bodyQuat = tmpWorldQuaternion.clone();
+          if (motion.inertiaOrientation) {
+            const io = motion.inertiaOrientation;
+            bodyQuat.multiply(new THREE.Quaternion(io[0], io[1], io[2], io[3]));
+          }
+          const diag = [ix, iy, iz];
+          const localAxes = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+          let allowX = false, allowY = false, allowZ = false;
+          for (let j = 0; j < 3; j++) {
+            if (diag[j] !== 0) {
+              const v = new THREE.Vector3(...localAxes[j]).applyQuaternion(bodyQuat);
+              const ax = Math.abs(v.x), ay = Math.abs(v.y), az = Math.abs(v.z);
+              if (ax >= ay && ax >= az) allowX = true;
+              else if (ay >= ax && ay >= az) allowY = true;
+              else allowZ = true;
+            }
+          }
+          bodyDesc.enabledRotations(allowX, allowY, allowZ);
+        }
+      }
+    }
 
     const body = world.createRigidBody(bodyDesc);
     world.createCollider(colliderDesc, body);
@@ -208,7 +430,8 @@ async function loadModelAndBuildPhysics() {
         y: tmpWorldQuaternion.y,
         z: tmpWorldQuaternion.z,
         w: tmpWorldQuaternion.w
-      }
+      },
+      motion
     };
 
     physicsNodes.push(node);
@@ -238,8 +461,12 @@ function resetDynamicBodiesIfNeeded() {
     }
     node.body.setTranslation(node.initialPosition, true);
     node.body.setRotation(node.initialQuaternion, true);
-    node.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-    node.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+
+    const lv = node.motion?.linearVelocity;
+    node.body.setLinvel(lv ? { x: lv[0], y: lv[1], z: lv[2] } : { x: 0, y: 0, z: 0 }, true);
+
+    const av = node.motion?.angularVelocity;
+    node.body.setAngvel(av ? { x: av[0], y: av[1], z: av[2] } : { x: 0, y: 0, z: 0 }, true);
   }
 }
 

--- a/examples/threejs/rapier/marbles/index.js
+++ b/examples/threejs/rapier/marbles/index.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { HDRCubeTextureLoader } from 'three/addons/loaders/HDRCubeTextureLoader.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 const GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
 
@@ -83,8 +83,7 @@ async function init() {
     }
 
     // Rapier physics world
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     // Ground physics body
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -2, 0);

--- a/examples/threejs/rapier/minimum/index.js
+++ b/examples/threejs/rapier/minimum/index.js
@@ -1,6 +1,6 @@
 ﻿import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let container;
 let camera, scene, renderer;
@@ -10,8 +10,7 @@ let controls;
 
 async function initRapier() {
     await RAPIER.init();
-    const gravity = new RAPIER.Vector3(0, -9.81, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
 
     const groundColliderDesc = RAPIER.ColliderDesc.cuboid(2, 0.05, 2).setRestitution(0.1).setFriction(0.5);
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, 0, 0);
@@ -23,9 +22,11 @@ async function initRapier() {
     boxBody = world.createRigidBody(boxBodyDesc);
     world.createCollider(boxColliderDesc, boxBody);
 
-    const rotationAxis = new RAPIER.Vector3(1, 0, 1);
-    const angle = Math.PI * 10 / 180;
-    boxBody.setRotation(rotationAxis, angle);
+    const rotQuat = new THREE.Quaternion().setFromAxisAngle(
+        new THREE.Vector3(1, 0, 1).normalize(),
+        Math.PI * 10 / 180
+    );
+    boxBody.setRotation({ x: rotQuat.x, y: rotQuat.y, z: rotQuat.z, w: rotQuat.w }, true);
 }
 
 function initThree() {

--- a/examples/threejs/rapier/shogi/index.js
+++ b/examples/threejs/rapier/shogi/index.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.12.0';
+import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
 let camera, scene, light, renderer, container;
 let controls;
@@ -213,8 +213,7 @@ async function init() {
     controls.autoRotate = true;
 
     // Rapier physics world
-    const gravity = new RAPIER.Vector3(0, -10, 0);
-    world = new RAPIER.World(gravity);
+    world = new RAPIER.World({ x: 0, y: -10, z: 0 });
 
     // Ground
     const groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -2, 0);


### PR DESCRIPTION
## Summary

- Upgrade all three.js + Rapier examples from `rapier3d-compat@0.12.0` to `@0.17.3`
- Replace the removed `new RAPIER.World(new RAPIER.Vector3(x, y, z))` constructor with the object literal `new RAPIER.World({x, y, z})` syntax throughout
- Align the four `gltf_physics_*` examples with the full feature set established in `Motion_Properties`

## Changes by category

### Simple examples (domino, football, box, balls, marbles, shogi, cone, gltf, minimum)
- Import updated to `@0.17.3`
- World constructor updated to object literal syntax
- **minimum**: fix `setRotation` to use `THREE.Quaternion.setFromAxisAngle` instead of the removed axis-angle overload
- **balls**: fix wall collider bug — `createCollider` was passed `bodyDesc` instead of the `RigidBody` returned by `createRigidBody`

### gltf_physics_Basic_Shapes
- Add `lockTranslations()` for `motion.mass === 0` (infinite translational mass) in both passes
- Add `enabledRotations()` based on `motion.inertiaDiagonal` zero components in both passes
- Add full motion properties (`gravityFactor`, `linearVelocity`, `angularVelocity`) to Pass 2 single-body nodes
- Store `motion` on node objects and restore initial velocities on reset

### gltf_physics_Materials_Restitution
- Add `getMeshColliderDesc`, `getConvexPoints`, `collectCompoundChildren` helpers
- Restructure `loadModelAndBuildPhysics` into two-pass (compound bodies + single bodies)
- Add full motion properties including `lockTranslations` and `enabledRotations`
- Handle mesh-based colliders (`convexHull` for dynamic, `trimesh` for static) with `CoefficientCombineRule.Max`
- Store `motion` on node objects and restore initial velocities on reset

### gltf_physics_Materials_Friction
- Full rewrite aligned with the updated `Materials_Restitution` structure
- Two-pass physics loading, all implicit shape types, mesh collider support, compound body support, full motion properties, and `CoefficientCombineRule.Max` on all colliders

## Test plan
- [ ] Verify all simple examples load and simulate correctly in the browser
- [ ] Verify `minimum` — box falls and bounces with correct initial rotation
- [ ] Verify `gltf_physics_Basic_Shapes` — car drives, Suzanne moves, wheel rotates only on Y axis
- [ ] Verify `gltf_physics_Materials_Restitution` — balls bounce at correct restitution levels
- [ ] Verify `gltf_physics_Materials_Friction` — objects slide/stop at correct friction levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)