### PR TITLE
feat: improve Rhodonite Oimo examples

### DIFF
--- a/examples/rhodonite/oimo/balls/index.js
+++ b/examples/rhodonite/oimo/balls/index.js
@@ -21,7 +21,7 @@ const load = async function() {
     });
 
     resizeCanvas();
-    
+
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
@@ -30,8 +30,7 @@ const load = async function() {
         engine.resizeCanvas(window.innerWidth, window.innerHeight);
     }
 
-    const texturePromises = dataSet.map(data => Rn.Texture.loadFromUrl(engine, data.imageFile));
-    const textures = await Promise.all(texturePromises);
+    const textures = await Promise.all(dataSet.map(d => Rn.Texture.loadFromUrl(engine, d.imageFile)));
 
     const sampler = new Rn.Sampler(engine, {
       magFilter: Rn.TextureParameter.Linear,
@@ -39,18 +38,18 @@ const load = async function() {
       wrapS: Rn.TextureParameter.Repeat,
       wrapT: Rn.TextureParameter.Repeat,
     });
-    
+
     const materialGround = Rn.MaterialHelper.createPbrUberMaterial(engine, {
         isLighting: true
     });
     materialGround.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([0x3D/0xFF, 0x41/0xFF, 0x43/0xFF, 1]));
-    
+
     const materialGroundTrans = Rn.MaterialHelper.createPbrUberMaterial(engine, {
         isLighting: true
     });
     materialGroundTrans.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([0x3D/0xFF, 0x41/0xFF, 0x43/0xFF, 0.6]));
     materialGroundTrans.alphaMode = Rn.AlphaMode.Blend;
-    
+
     // Ground
     const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
@@ -70,18 +69,18 @@ const load = async function() {
     entity1.position = Rn.Vector3.fromCopyArray([0, -20 * PHYSICS_SCALE, 0]);
     entities.push(entity1);
 
-    // Box walls
+    // Box walls (shared transparent material)
     const boxDataSet = [
-        { size:[48, 50,  4], pos:[ 0, 15,-25] }, // front
-        { size:[48, 50,  4], pos:[ 0, 15, 25] }, // back
-        { size:[ 4, 50, 48], pos:[-25, 15, 0] }, // left
-        { size:[ 4, 50, 48], pos:[ 25, 15, 0] }  // right
+        { size:[48, 50,  4], pos:[ 0, 15,-25] },
+        { size:[48, 50,  4], pos:[ 0, 15, 25] },
+        { size:[ 4, 50, 48], pos:[-25, 15, 0] },
+        { size:[ 4, 50, 48], pos:[ 25, 15, 0] }
     ];
 
     for (let i = 0; i < boxDataSet.length; i++) {
         const size = boxDataSet[i].size;
         const pos = boxDataSet[i].pos;
-        
+
         const wallEntity = Rn.MeshHelper.createCube(engine, {
             physics: {
                 use: true,
@@ -101,30 +100,37 @@ const load = async function() {
         entities.push(wallEntity);
     }
 
-    populate(textures, sampler);
+    // Pre-build one material per ball type
+    const materials = dataSet.map((d, idx) => {
+        const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+        mat.setTextureParameter('baseColorTexture', textures[idx], sampler);
+        return mat;
+    });
 
-	// camera
-	const cameraEntity = Rn.createCameraControllerEntity(engine);
+    populate(materials);
+
+    // camera
+    const cameraEntity = Rn.createCameraControllerEntity(engine);
     cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0 * PHYSICS_SCALE, 100 * PHYSICS_SCALE, 160 * PHYSICS_SCALE]);
-	cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.1, 0.0, 0.0]);
-	const cameraComponent = cameraEntity.getCamera();
-	cameraComponent.zNear = 0.1;
-	cameraComponent.zFar = 400;
-	cameraComponent.setFovyAndChangeFocalLength(60);
-	cameraComponent.aspect = window.innerWidth / window.innerHeight;
+    cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.1, 0.0, 0.0]);
+    const cameraComponent = cameraEntity.getCamera();
+    cameraComponent.zNear = 0.1;
+    cameraComponent.zFar = 400;
+    cameraComponent.setFovyAndChangeFocalLength(60);
+    cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
-	// Lights
-	const lightEntity1 = Rn.createLightEntity(engine);
-	const lightComponent1 = lightEntity1.getLight();
-	lightComponent1.type = Rn.LightType.Directional;
-	lightComponent1.intensity = 1.5;
-	lightEntity1.localEulerAngles = Rn.Vector3.fromCopyArray([-Math.PI / 4, Math.PI / 6, 0]);
+    // Lights
+    const lightEntity1 = Rn.createLightEntity(engine);
+    const lightComponent1 = lightEntity1.getLight();
+    lightComponent1.type = Rn.LightType.Directional;
+    lightComponent1.intensity = 1.5;
+    lightEntity1.localEulerAngles = Rn.Vector3.fromCopyArray([-Math.PI / 4, Math.PI / 6, 0]);
 
-	const lightEntity2 = Rn.createLightEntity(engine);
-	const lightComponent2 = lightEntity2.getLight();
-	lightComponent2.type = Rn.LightType.Directional;
-	lightComponent2.intensity = 0.8;
-	lightEntity2.localEulerAngles = Rn.Vector3.fromCopyArray([Math.PI / 4, -Math.PI / 6, 0]);
+    const lightEntity2 = Rn.createLightEntity(engine);
+    const lightComponent2 = lightEntity2.getLight();
+    lightComponent2.type = Rn.LightType.Directional;
+    lightComponent2.intensity = 0.8;
+    lightEntity2.localEulerAngles = Rn.Vector3.fromCopyArray([Math.PI / 4, -Math.PI / 6, 0]);
 
     // renderPass
     const renderPass = new Rn.RenderPass(engine);
@@ -136,10 +142,9 @@ const load = async function() {
     // expression
     const expression = new Rn.Expression();
     expression.addRenderPasses([renderPass]);
-	
+
     const draw = function(time) {
         engine.process([expression]);
-
         requestAnimationFrame(draw);
     }
 
@@ -147,9 +152,9 @@ const load = async function() {
 
 }
 
-function populate(textures, sampler) {
+function populate(materials) {
     const max = 200;
-    
+
     for (let i = 0; i < max; i++) {
         const x = -25 + Math.random() * 50;
         const y = 60 + Math.random() * 130;
@@ -159,11 +164,6 @@ function populate(textures, sampler) {
         const pos = Math.floor(Math.random() * dataSet.length);
         const scale = dataSet[pos].scale;
         const radius = (w * scale) / 2;
-
-        let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-            isLighting: true
-        });
-        modelMaterial.setTextureParameter('baseColorTexture', textures[pos], sampler);
 
         const entity = Rn.MeshHelper.createSphere(engine, {
             radius: radius * PHYSICS_SCALE,
@@ -176,7 +176,7 @@ function populate(textures, sampler) {
                 friction: 0.4,
                 restitution: 0.6,
             },
-            material: modelMaterial
+            material: materials[pos]
         });
         entity.tryToSetTag({
             tag: "type",
@@ -186,4 +186,5 @@ function populate(textures, sampler) {
         entities.push(entity);
     }
 }
+
 document.body.onload = load;

--- a/examples/rhodonite/oimo/box/index.js
+++ b/examples/rhodonite/oimo/box/index.js
@@ -40,22 +40,18 @@ let dataSet = [
     "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
 ];
 
-function getRgbColor( c )
-{
-    let colorHash = {
-        "無":[0xDC/0xFF, 0xAA/0xFF, 0x6B/0xFF],
-        "白":[0xff/0xFF, 0xff/0xFF, 0xff/0xFF],
-        "肌":[0xff/0xFF, 0xcc/0xFF, 0xcc/0xFF],
-        "茶":[0x80/0xFF, 0x00/0xFF, 0x00/0xFF],
-        "赤":[0xff/0xFF, 0x00/0xFF, 0x00/0xFF],
-        "黄":[0xff/0xFF, 0xff/0xFF, 0x00/0xFF],
-        "緑":[0x00/0xFF, 0xff/0xFF, 0x00/0xFF],
-        "水":[0x00/0xFF, 0xff/0xFF, 0xff/0xFF],
-        "青":[0x00/0xFF, 0x00/0xFF, 0xff/0xFF],
-        "紫":[0x80/0xFF, 0x00/0xFF, 0x80/0xFF]
-    };
-    return colorHash[ c ];
-}
+const colorHash = {
+    "無": [0xDC/0xFF, 0xAA/0xFF, 0x6B/0xFF],
+    "白": [1, 1, 1],
+    "肌": [0xff/0xFF, 0xcc/0xFF, 0xcc/0xFF],
+    "茶": [0x80/0xFF, 0, 0],
+    "赤": [1, 0, 0],
+    "黄": [1, 1, 0],
+    "緑": [0, 1, 0],
+    "水": [0, 1, 1],
+    "青": [0, 0, 1],
+    "紫": [0x80/0xFF, 0, 0x80/0xFF]
+};
 
 const load = async function() {
     const c = document.getElementById('world');
@@ -66,7 +62,7 @@ const load = async function() {
     });
 
     resizeCanvas();
-    
+
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
@@ -83,7 +79,7 @@ const load = async function() {
       wrapS: Rn.TextureParameter.ClampToEdge,
       wrapT: Rn.TextureParameter.ClampToEdge,
     });
-    
+
     const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
@@ -102,7 +98,15 @@ const load = async function() {
     entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', grassTexture, sampler);
     entities.push(entity1);
 
-    populate();
+    // Pre-build one material per unique color key
+    const matByKey = {};
+    for (const [key, rgb] of Object.entries(colorHash)) {
+        const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+        mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([rgb[0], rgb[1], rgb[2], 1]));
+        matByKey[key] = mat;
+    }
+
+    populate(matByKey);
 
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
@@ -140,7 +144,6 @@ const load = async function() {
 
     const draw = function(time) {
         engine.process([expression]);
-
         requestAnimationFrame(draw);
     }
 
@@ -148,23 +151,15 @@ const load = async function() {
 
 }
 
-function populate() {
+function populate(matByKey) {
     let i = 0;
     for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
             i = x + (15 - y) * 16;
-            const rgbColor = getRgbColor(dataSet[i]);
+            const colorKey = dataSet[i];
             const x1 = (-130 + x * BOX_SIZE * 1.2 + Math.random()) * PHYSICS_SCALE;
             const y1 = (30 + y * BOX_SIZE * 1.2) * PHYSICS_SCALE;
             const z1 = (1.0 * Math.random()) * PHYSICS_SCALE;
-
-            let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-                isLighting: true
-            });
-            modelMaterial.setParameter(
-                'baseColorFactor',
-                Rn.Vector4.fromCopyArray4([rgbColor[0], rgbColor[1], rgbColor[2], 1])
-            );
 
             const entity = Rn.MeshHelper.createCube(engine, {
                 physics: {
@@ -174,14 +169,14 @@ function populate() {
                     friction: 1.0,
                     restitution: 0.0,
                 },
-                material: modelMaterial
+                material: matByKey[colorKey]
             });
             entity.tryToSetTag({
                 tag: "type",
                 value: "box"
             });
             entity.position = Rn.Vector3.fromCopyArray([x1, y1, z1]);
-            entity.scale = Rn.Vector3.fromCopyArray([BOX_SIZE / 1 * PHYSICS_SCALE, BOX_SIZE / 1 * PHYSICS_SCALE, BOX_SIZE / 1 * PHYSICS_SCALE]);
+            entity.scale = Rn.Vector3.fromCopyArray([BOX_SIZE * PHYSICS_SCALE, BOX_SIZE * PHYSICS_SCALE, BOX_SIZE * PHYSICS_SCALE]);
             entities.push(entity);
         }
     }

--- a/examples/rhodonite/oimo/domino/index.js
+++ b/examples/rhodonite/oimo/domino/index.js
@@ -40,22 +40,18 @@ let dataSet = [
     "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
 ];
 
-function getRgbColor( c )
-{
-    let colorHash = {
-        "無":{r:0xDC,g:0xAA,b:0x6B},
-        "白":{r:0xff,g:0xff,b:0xff},
-        "肌":{r:0xff,g:0xcc,b:0xcc},
-        "茶":{r:0x80,g:0x00,b:0x00},
-        "赤":{r:0xff,g:0x00,b:0x00},
-        "黄":{r:0xff,g:0xff,b:0x00},
-        "緑":{r:0x00,g:0xff,b:0x00},
-        "水":{r:0x00,g:0xff,b:0xff},
-        "青":{r:0x00,g:0x00,b:0xff},
-        "紫":{r:0x80,g:0x00,b:0x80}
-    };
-    return colorHash[ c ];
-}
+const colorHash = {
+    "無": [0xDC/0xff, 0xAA/0xff, 0x6B/0xff],
+    "白": [1, 1, 1],
+    "肌": [1, 0xcc/0xff, 0xcc/0xff],
+    "茶": [0x80/0xff, 0, 0],
+    "赤": [1, 0, 0],
+    "黄": [1, 1, 0],
+    "緑": [0, 1, 0],
+    "水": [0, 1, 1],
+    "青": [0, 0, 1],
+    "紫": [0x80/0xff, 0, 0x80/0xff]
+};
 
 const load = async function() {
     const c = document.getElementById('world');
@@ -66,7 +62,7 @@ const load = async function() {
     });
 
     resizeCanvas();
-    
+
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
@@ -83,7 +79,7 @@ const load = async function() {
       wrapS: Rn.TextureParameter.ClampToEdge,
       wrapT: Rn.TextureParameter.ClampToEdge,
     });
-    
+
     const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
@@ -101,7 +97,19 @@ const load = async function() {
     entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', texture, sampler);
     entities.push(entity1);
 
-    populate(texture, sampler);
+    // Pre-build one material per unique color key
+    const matByKey = {};
+    for (const [key, rgb] of Object.entries(colorHash)) {
+        const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+        mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([rgb[0], rgb[1], rgb[2], 1]));
+        mat.setTextureParameter('diffuseColorTexture', texture, sampler);
+        matByKey[key] = mat;
+    }
+    const ballMat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+    ballMat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([1, 0, 0, 1]));
+    ballMat.setTextureParameter('diffuseColorTexture', texture, sampler);
+
+    populate(matByKey, ballMat);
 
     const startTime = Date.now();
 
@@ -139,7 +147,6 @@ const load = async function() {
 
     const draw = function(time) {
         engine.process([expression]);
-
         requestAnimationFrame(draw);
     }
 
@@ -147,27 +154,16 @@ const load = async function() {
 
 }
 
-function populate(texture, sampler) {
-    let max = 256;
-    let w = DOT_SIZE * 0.2;
-    let h = DOT_SIZE * 1.5;
-    let d = DOT_SIZE;
+function populate(matByKey, ballMat) {
+    const w = DOT_SIZE * 0.2;
+    const h = DOT_SIZE * 1.5;
+    const d = DOT_SIZE;
 
-    let i;
-    let x, y, z;
-    for (z = 0; z < 16; z++) {
-        for (x = 0; x < 16; x++) {
-            i = x + (z) * 16;
-            let c = getRgbColor(dataSet[i]);
-            y = 1;
-
-            let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-                isLighting: true
-            });
-            modelMaterial.setParameter(
-                'baseColorFactor',
-                Rn.Vector4.fromCopyArray4([c.r / 0xff, c.g / 0xff, c.b / 0xff, 1])
-            );
+    for (let z = 0; z < 16; z++) {
+        for (let x = 0; x < 16; x++) {
+            const i = x + z * 16;
+            const colorKey = dataSet[i];
+            const y = 1;
 
             const entity = Rn.MeshHelper.createCube(engine, {
                 physics: {
@@ -177,7 +173,7 @@ function populate(texture, sampler) {
                     friction: 0.5,
                     restitution: 0.2,
                 },
-                material: modelMaterial
+                material: matByKey[colorKey]
             });
             entity.tryToSetTag({
                 tag: "type",
@@ -185,28 +181,19 @@ function populate(texture, sampler) {
             });
             entity.position = Rn.Vector3.fromCopyArray([(-8 + x) * DOT_SIZE * PHYSICS_SCALE, y * DOT_SIZE * PHYSICS_SCALE, (-8 + z) * DOT_SIZE * 1.2 * PHYSICS_SCALE]);
             entity.scale = Rn.Vector3.fromCopyArray([w * PHYSICS_SCALE, h * PHYSICS_SCALE, d * PHYSICS_SCALE]);
-            entity.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', texture, sampler);
             entities.push(entity);
-
         }
     }
 
-    for (i = 0; i < 16; i++) {
-        w = DOT_SIZE;
-        h = DOT_SIZE;
-        d = DOT_SIZE;
-        x = 0;
-        y = 2;
-        z = i;
-        let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-            isLighting: true
-        });
-        modelMaterial.setParameter(
-            'baseColorFactor',
-            Rn.Vector4.fromCopyArray4([1, 0, 0, 1])
-        );
+    for (let i = 0; i < 16; i++) {
+        const bw = DOT_SIZE;
+        const bh = DOT_SIZE;
+        const bd = DOT_SIZE;
+        const x = 0;
+        const y = 2;
+        const z = i;
 
- 		const entity = Rn.MeshHelper.createCube(engine, {
+        const entity = Rn.MeshHelper.createCube(engine, {
             physics: {
                 use: true,
                 move: true,
@@ -214,17 +201,15 @@ function populate(texture, sampler) {
                 friction: 0.5,
                 restitution: 0.2,
             },
-            material: modelMaterial
+            material: ballMat
         });
         entity.tryToSetTag({
             tag: "type",
             value: "cube"
         });
         entity.position = Rn.Vector3.fromCopyArray([(-8.4 + x) * DOT_SIZE * PHYSICS_SCALE, y * DOT_SIZE * PHYSICS_SCALE, (-8 + z) * DOT_SIZE * 1.2 * PHYSICS_SCALE]);
-        entity.scale = Rn.Vector3.fromCopyArray([w * PHYSICS_SCALE, h * PHYSICS_SCALE, d * PHYSICS_SCALE]);
-        entity.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', texture, sampler);
+        entity.scale = Rn.Vector3.fromCopyArray([bw * PHYSICS_SCALE, bh * PHYSICS_SCALE, bd * PHYSICS_SCALE]);
         entities.push(entity);
-
     }
 }
 

--- a/examples/rhodonite/oimo/football/index.js
+++ b/examples/rhodonite/oimo/football/index.js
@@ -40,22 +40,18 @@ let dataSet = [
     "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
 ];
 
-function getRgbColor( c )
-{
-    let colorHash = {
-        "無":[0xDC/0xFF, 0xAA/0xFF, 0x6B/0xFF],
-        "白":[0xff/0xFF, 0xff/0xFF, 0xff/0xFF],
-        "肌":[0xff/0xFF, 0xcc/0xFF, 0xcc/0xFF],
-        "茶":[0x80/0xFF, 0x00/0xFF, 0x00/0xFF],
-        "赤":[0xff/0xFF, 0x00/0xFF, 0x00/0xFF],
-        "黄":[0xff/0xFF, 0xff/0xFF, 0x00/0xFF],
-        "緑":[0x00/0xFF, 0xff/0xFF, 0x00/0xFF],
-        "水":[0x00/0xFF, 0xff/0xFF, 0xff/0xFF],
-        "青":[0x00/0xFF, 0x00/0xFF, 0xff/0xFF],
-        "紫":[0x80/0xFF, 0x00/0xFF, 0x80/0xFF]
-    };
-    return colorHash[ c ];
-}
+const colorHash = {
+    "無": [0xDC/0xFF, 0xAA/0xFF, 0x6B/0xFF],
+    "白": [1, 1, 1],
+    "肌": [0xff/0xFF, 0xcc/0xFF, 0xcc/0xFF],
+    "茶": [0x80/0xFF, 0, 0],
+    "赤": [1, 0, 0],
+    "黄": [1, 1, 0],
+    "緑": [0, 1, 0],
+    "水": [0, 1, 1],
+    "青": [0, 0, 1],
+    "紫": [0x80/0xFF, 0, 0x80/0xFF]
+};
 
 const load = async function() {
     const c = document.getElementById('world');
@@ -66,7 +62,7 @@ const load = async function() {
     });
 
     resizeCanvas();
-    
+
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
@@ -84,7 +80,7 @@ const load = async function() {
       wrapS: Rn.TextureParameter.Repeat,
       wrapT: Rn.TextureParameter.Repeat,
     });
-    
+
     const entity1 = Rn.MeshHelper.createCube(engine, {
         physics: {
             use: true,
@@ -103,7 +99,16 @@ const load = async function() {
     entity1.getMesh().mesh.getPrimitiveAt(0).material.setTextureParameter('diffuseColorTexture', grassTexture, sampler);
     entities.push(entity1);
 
-    populate(footballTexture, sampler);
+    // Pre-build one material per unique color key (color factor + football texture)
+    const matByKey = {};
+    for (const [key, rgb] of Object.entries(colorHash)) {
+        const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+        mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([rgb[0], rgb[1], rgb[2], 1]));
+        mat.setTextureParameter('baseColorTexture', footballTexture, sampler);
+        matByKey[key] = mat;
+    }
+
+    populate(matByKey);
 
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
@@ -141,7 +146,6 @@ const load = async function() {
 
     const draw = function(time) {
         engine.process([expression]);
-
         requestAnimationFrame(draw);
     }
 
@@ -149,24 +153,15 @@ const load = async function() {
 
 }
 
-function populate(texture, sampler) {
+function populate(matByKey) {
     let i = 0;
     for (let y = 0; y < 16; y++) {
         for (let x = 0; x < 16; x++) {
             i = x + (15 - y) * 16;
-            const rgbColor = getRgbColor(dataSet[i]);
+            const colorKey = dataSet[i];
             const x1 = (-130 + x * BALL_SIZE * 1.2 + Math.random()) * PHYSICS_SCALE;
             const y1 = (30 + y * BALL_SIZE * 1.2) * PHYSICS_SCALE;
             const z1 = (1.0 * Math.random()) * PHYSICS_SCALE;
-
-            let modelMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-                isLighting: true
-            });
-            modelMaterial.setParameter(
-                'baseColorFactor',
-                Rn.Vector4.fromCopyArray4([rgbColor[0], rgbColor[1], rgbColor[2], 1])
-            );
-            modelMaterial.setTextureParameter('baseColorTexture', texture, sampler);
 
             const entity = Rn.MeshHelper.createSphere(engine, {
                 radius: BALL_SIZE / 2 * PHYSICS_SCALE,
@@ -179,7 +174,7 @@ function populate(texture, sampler) {
                     friction: 0.4,
                     restitution: 0.6,
                 },
-                material: modelMaterial
+                material: matByKey[colorKey]
             });
             entity.tryToSetTag({
                 tag: "type",

--- a/examples/rhodonite/oimo/minimum/index.js
+++ b/examples/rhodonite/oimo/minimum/index.js
@@ -76,6 +76,7 @@ const load = async function() {
     // camera
     const cameraEntity = Rn.createCameraControllerEntity(engine);
     cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0, 3, 6]);
+    cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.4, 0, 0]);
     const cameraComponent = cameraEntity.getCamera();
     cameraComponent.zNear = 0.1;
     cameraComponent.zFar = 100;

--- a/examples/rhodonite/oimo/minimum/index.js
+++ b/examples/rhodonite/oimo/minimum/index.js
@@ -49,7 +49,7 @@ const load = async function() {
         tag: "type",
         value: "ground"
     });
-    entity1.scale = Rn.Vector3.fromCopyArray([2, 0.05, 2]);
+    entity1.scale = Rn.Vector3.fromCopyArray([4, 0.1, 4]);
     entities.push(entity1);
 
     // Cube
@@ -68,7 +68,7 @@ const load = async function() {
         value: "cube"
     });
     entity2.position = Rn.Vector3.fromCopyArray([0, 2, 0]);
-    entity2.scale = Rn.Vector3.fromCopyArray([0.5, 0.5, 0.5]);
+    entity2.scale = Rn.Vector3.fromCopyArray([1, 1, 1]);
     entities.push(entity2);
 
     const startTime = Date.now();

--- a/examples/rhodonite/oimo/shogi/index.js
+++ b/examples/rhodonite/oimo/shogi/index.js
@@ -18,7 +18,7 @@ const load = async function() {
     });
 
     resizeCanvas();
-    
+
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
@@ -28,14 +28,14 @@ const load = async function() {
     }
 
     // Initialize physics world
-    world = new OIMO.World({ 
-        timestep: 1/60, 
-        iterations: 8, 
+    world = new OIMO.World({
+        timestep: 1/60,
+        iterations: 8,
         broadphase: 2,
-        worldscale: 1, 
+        worldscale: 1,
         random: true,
         info: false,
-        gravity: [0, -9.8, 0] 
+        gravity: [0, -9.8, 0]
     });
 
     // Create ground (physics) - Oimo.js size is full width, not half
@@ -57,7 +57,7 @@ const load = async function() {
       wrapS: Rn.TextureParameter.Repeat,
       wrapT: Rn.TextureParameter.Repeat,
     });
-    
+
     // Create ground visual (match physics size - Rhodonite Cube uses half-extent)
     const groundEntity = Rn.createMeshEntity(engine);
     const groundPrimitive = new Rn.Cube(engine);
@@ -67,7 +67,7 @@ const load = async function() {
     const groundMaterial = Rn.MaterialHelper.createPbrUberMaterial(engine, {
         isLighting: true
     });
-    groundMaterial.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray([0.4, 0.6, 0.4, 1.0]));
+    groundMaterial.setParameter('baseColorFactor', Rn.Vector3.fromCopyArray([0.4, 0.6, 0.4, 1.0]));
     groundPrimitive.material = groundMaterial;
     const groundMesh = new Rn.Mesh(engine);
     groundMesh.addPrimitive(groundPrimitive);
@@ -115,15 +115,15 @@ const load = async function() {
     const draw = function(time) {
         // Update physics
         world.step();
-        
+
         // Update shogi piece positions from physics
         for (let i = 0; i < shogiPieces.length; i++) {
             const body = oimoBodies[i];
             const entity = shogiPieces[i];
-            
+
             const pos = body.getPosition();
             const quat = body.getQuaternion();
-            
+
             // If piece falls below the ground, reset it to above
             if (pos.y < -10) {
                 const newX = (Math.random() - 0.5) * 5;
@@ -132,7 +132,7 @@ const load = async function() {
                 body.resetPosition(newX, newY, newZ);
                 body.resetRotation(Math.random() * 360, Math.random() * 360, Math.random() * 360);
             }
-            
+
             entity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos.x, pos.y, pos.z]);
             entity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([quat.x, quat.y, quat.z, quat.w]);
         }
@@ -222,7 +222,7 @@ function populate(shogiTexture, sampler) {
     const backNz = -0.9, backNy = 0.3;  // 背面は少し上向き
     const rightNx = 0.9, rightNy = 0.3; // 右面は少し上向き
     const leftNx = -0.9, leftNy = 0.3;  // 左面は少し上向き
-    
+
     const normals = new Float32Array([
         // Front face (4 vertices) - 前面（少し上向きに傾斜）
          0, frontNy, frontNz,  0, frontNy, frontNz,  0, frontNy, frontNz,  0, frontNy, frontNz,
@@ -258,31 +258,31 @@ function populate(shogiTexture, sampler) {
         0.25,         0.5, // v4
         0.25 +0.25/8, 1.0, // v7
         0.5  -0.25/8, 1.0, // v6
-        
+
         // Top face
         0.75, 0.5, // v2
         0.5,  0.5, // v3
         0.5,  0.0, // v7
         0.75, 0.0, // v6
-        
+
         // Bottom face
         0.0,  0.5, // v0
         0.25, 0.5, // v1
         0.25, 1.0, // v5
         0.0,  1.0, // v4
-        
+
         // Right face
         0.0,  0.5, // v1
         0.0,  0.0, // v2
         0.25, 0.0, // v6
         0.25, 0.5, // v5
-        
+
         // Left face
         0.5,  0.5, // v0
         0.5,  0.0, // v3
         0.25, 0.0, // v7
         0.25, 0.5, // v4
-        
+
         // Front2 face
         0.75,  0.0, // v3
         1.0,   0.0, // v2
@@ -321,6 +321,21 @@ function populate(shogiTexture, sampler) {
     const pieceH = h * PHYSICS_SCALE;
     const pieceD = d * PHYSICS_SCALE;
 
+    // Build shared mesh once
+    const material = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
+    material.setTextureParameter('baseColorTexture', shogiTexture, sampler);
+
+    const primitive = Rn.Primitive.createPrimitive(engine, {
+        indices: indices,
+        attributeSemantics: [Rn.VertexAttribute.Position.XYZ, Rn.VertexAttribute.Normal.XYZ, Rn.VertexAttribute.Texcoord0.XY],
+        attributes: [positions, normals, texcoords],
+        material: material,
+        primitiveMode: Rn.PrimitiveMode.Triangles
+    });
+
+    const sharedMesh = new Rn.Mesh(engine);
+    sharedMesh.addPrimitive(primitive);
+
     for (let i = 0; i < max; i++) {
         // Random position above the ground (within ground bounds)
         const x = (Math.random() - 0.5) * 5;
@@ -338,38 +353,18 @@ function populate(shogiTexture, sampler) {
         });
         oimoBodies.push(body);
 
-        // Create material for each piece with lighting enabled
-        const material = Rn.MaterialHelper.createPbrUberMaterial(engine, {
-            isLighting: true
-        });
-        material.setTextureParameter('baseColorTexture', shogiTexture, sampler);
-
-        // Create mesh with custom geometry
-        const primitive = Rn.Primitive.createPrimitive(engine, {
-            indices: indices,
-            attributeSemantics: [Rn.VertexAttribute.Position.XYZ, Rn.VertexAttribute.Normal.XYZ, Rn.VertexAttribute.Texcoord0.XY],
-            attributes: [positions, normals, texcoords],
-            material: material,
-            primitiveMode: Rn.PrimitiveMode.Triangles
-        });
-
-        const mesh = new Rn.Mesh(engine);
-        mesh.addPrimitive(primitive);
-
         const entity = Rn.createMeshEntity(engine);
-        const meshComponent = entity.getMesh();
-        meshComponent.setMesh(mesh);
-
+        entity.getMesh().setMesh(sharedMesh);
         entity.tryToSetTag({
             tag: "type",
             value: "shogi"
         });
-        
+
         // Initial position will be updated by physics
         entity.getTransform().localPosition = Rn.Vector3.fromCopyArray([x, y, z]);
         entity.getTransform().localScale = Rn.Vector3.fromCopyArray([
-            PHYSICS_SCALE, 
-            PHYSICS_SCALE, 
+            PHYSICS_SCALE,
+            PHYSICS_SCALE,
             PHYSICS_SCALE
         ]);
 


### PR DESCRIPTION
## Summary

- Optimize draw calls in all Rhodonite + Oimo examples via shared material/mesh
- Align `minimum` example floor and camera with the Rhodonite + Havok minimum example

## Changes

### Performance optimization

| Example | Before | After |
|---------|--------|-------|
| `domino` | 272 materials (256 dominos + 16 balls) | 11 materials (10 color keys + 1 ball) |
| `box` | 256 materials | 10 materials (1 per color key) |
| `football` | 256 materials | 10 materials (1 per color key, with football texture) |
| `balls` | 200 materials | 5 materials (1 per ball type) |
| `shogi` | 300 materials + 300 primitives + 300 meshes | 1 shared mesh + material |

### minimum example alignment with Havok minimum

- Ground scale: `[2, 0.05, 2]` → `[4, 0.1, 4]`
- Cube scale: `[0.5, 0.5, 0.5]` → `[1, 1, 1]`
- Camera Euler angles: added `[-0.4, 0, 0]` (downward tilt, same as Havok minimum)

## Technical approach

- **domino/box/football/balls**: Use Rhodonite's built-in Oimo integration (`MeshHelper.createCube/createSphere({ physics: {...} })`), so mesh sharing is not possible. Pre-build one material per unique color key and pass it to each entity creation call.
- **shogi**: Uses `OIMO.World` directly with manual transform updates, so the full mesh can be shared. All 300 pieces call `entity.getMesh().setMesh(sharedMesh)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)