### PR TITLE
feat: add physics collider wireframe debug display to all three.js + Havok examples

### DIFF
--- a/examples/threejs/havok/balls/index.js
+++ b/examples/threejs/havok/balls/index.js
@@ -3,6 +3,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 const dataSet = [
     { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6 },
@@ -17,6 +18,7 @@ let scene, camera, renderer, controls;
 
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -92,6 +94,14 @@ function initPhysics() {
   groundMesh.position.set(0, -2, 0);
   groundMesh.receiveShadow = true;
   scene.add(groundMesh);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(20, 2, 20)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    dbg.position.set(0, -2, 0);
+    scene.add(dbg);
+  }
 
   // Walls
   const wallDefs = [
@@ -107,6 +117,14 @@ function initPhysics() {
     wallMesh.scale.set(size[0], size[1], size[2]);
     wallMesh.position.set(pos[0], pos[1], pos[2]);
     scene.add(wallMesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+      );
+      dbg.position.set(pos[0], pos[1], pos[2]);
+      scene.add(dbg);
+    }
   }
 
   // Balls
@@ -148,6 +166,14 @@ function initPhysics() {
     mesh.castShadow = true;
     scene.add(mesh);
     meshes.push(mesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.WireframeGeometry(new THREE.SphereGeometry(radius, 8, 6)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+      );
+      scene.add(dbg);
+      debugMeshes.push(dbg);
+    }
   }
 }
 
@@ -158,6 +184,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = -5 + Math.random() * 10;

--- a/examples/threejs/havok/box/index.js
+++ b/examples/threejs/havok/box/index.js
@@ -45,12 +45,14 @@ const colorHash = {
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BOX_SIZE = 1;
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -121,6 +123,13 @@ function initPhysics() {
     new THREE.MeshBasicMaterial({ map: grassTex })
   );
   scene.add(groundMesh);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(30, 0.4, 30)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(dbg);
+  }
 
   // Shared box shape
   const bsRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
@@ -155,6 +164,14 @@ function initPhysics() {
       );
       scene.add(mesh);
       meshes.push(mesh);
+      if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+          new THREE.EdgesGeometry(new THREE.BoxGeometry(BOX_SIZE, BOX_SIZE, BOX_SIZE)),
+          new THREE.LineBasicMaterial({ color: 0xff8844 })
+        );
+        scene.add(dbg);
+        debugMeshes.push(dbg);
+      }
     }
   }
 }
@@ -166,6 +183,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = -5 + Math.random() * 10;

--- a/examples/threejs/havok/cone/index.js
+++ b/examples/threejs/havok/cone/index.js
@@ -6,11 +6,13 @@ const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const CONE_COUNT = 200;
 const CONE_HALF_HEIGHT = 2;
 const CONE_RADIUS = 1;
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -140,6 +142,14 @@ function initPhysics() {
   groundMesh.castShadow = true;
   groundMesh.receiveShadow = true;
   scene.add(groundMesh);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    dbg.position.set(0, -2, 0);
+    scene.add(dbg);
+  }
 
   // Walls
   const wallDefs = [
@@ -154,6 +164,14 @@ function initPhysics() {
     wallMesh.scale.set(size[0], size[1], size[2]);
     wallMesh.position.set(pos[0], pos[1], pos[2]);
     scene.add(wallMesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+      );
+      dbg.position.set(pos[0], pos[1], pos[2]);
+      scene.add(dbg);
+    }
   }
 
   const coneShapeId = createConeShape();
@@ -185,6 +203,14 @@ function initPhysics() {
     mesh.receiveShadow = true;
     scene.add(mesh);
     meshes.push(mesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.WireframeGeometry(new THREE.CylinderGeometry(0, CONE_RADIUS, CONE_HALF_HEIGHT * 2, 12)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+      );
+      scene.add(dbg);
+      debugMeshes.push(dbg);
+    }
   }
 }
 
@@ -195,6 +221,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = -5 + Math.random() * 10;

--- a/examples/threejs/havok/domino/index.js
+++ b/examples/threejs/havok/domino/index.js
@@ -44,12 +44,14 @@ const colorHash = {
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -140,6 +142,13 @@ function initPhysics() {
   );
   groundMesh.rotation.x = -Math.PI / 2;
   scene.add(groundMesh);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(100, 0.2, 100)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(dbg);
+  }
 
   const box_size = 2;
   const DOMINO_W = box_size * 0.15;
@@ -182,6 +191,14 @@ function initPhysics() {
       );
       scene.add(mesh);
       meshes.push(mesh);
+      if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+          new THREE.EdgesGeometry(new THREE.BoxGeometry(DOMINO_W, DOMINO_H, DOMINO_D)),
+          new THREE.LineBasicMaterial({ color: 0xff8844 })
+        );
+        scene.add(dbg);
+        debugMeshes.push(dbg);
+      }
     }
   }
 
@@ -200,6 +217,14 @@ function initPhysics() {
     );
     scene.add(mesh);
     meshes.push(mesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.WireframeGeometry(new THREE.SphereGeometry(ballRadius, 8, 6)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+      );
+      scene.add(dbg);
+      debugMeshes.push(dbg);
+    }
   }
 }
 
@@ -210,6 +235,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
   }
 }
 

--- a/examples/threejs/havok/football/index.js
+++ b/examples/threejs/havok/football/index.js
@@ -45,12 +45,14 @@ const colorHash = {
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BALL_SIZE = 1;
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -122,6 +124,13 @@ function initPhysics() {
     new THREE.MeshBasicMaterial({ map: grassTex })
   );
   scene.add(groundMesh);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(20, 0.4, 20)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(dbg);
+  }
 
   const radius = BALL_SIZE / 2;
   const bsRes = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
@@ -155,6 +164,14 @@ function initPhysics() {
       const mesh = new THREE.Mesh(ballGeo, new THREE.MeshLambertMaterial({ color, map: footballTex }));
       scene.add(mesh);
       meshes.push(mesh);
+      if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+          new THREE.WireframeGeometry(new THREE.SphereGeometry(radius, 8, 6)),
+          new THREE.LineBasicMaterial({ color: 0xff8844 })
+        );
+        scene.add(dbg);
+        debugMeshes.push(dbg);
+      }
     }
   }
 }
@@ -166,6 +183,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = -5 + Math.random() * 10;

--- a/examples/threejs/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/threejs/havok/gltf_physics_Basic_Shapes/index.js
@@ -6,6 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -191,7 +192,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     HK.HP_Shape_SetMaterial(shapeId, [df, sf, r, HK.MaterialCombine.MAXIMUM, HK.MaterialCombine.MAXIMUM]);
   }
 
-  return { shapeId, size: size || [1, 1, 1] };
+  return { shapeId, size: size || [1, 1, 1], shapeType: shapeDef.type };
 }
 
 function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, motionDef) {
@@ -317,7 +318,28 @@ function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, mot
     checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity mesh');
   }
 
-  return { shapeId, size };
+  return { shapeId, size, shapeType: 'mesh' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, setMass) {
@@ -565,7 +587,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: position,
       initialRotation: rotation,
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(shapeResult, !!motionDef) : null
     };
     physicsNodes.push(node);
     if (motionDef) dynamicNodes.push(node);
@@ -596,6 +619,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     controls.update();
     renderer.render(scene, camera);

--- a/examples/threejs/havok/gltf_physics_Filtering/index.js
+++ b/examples/threejs/havok/gltf_physics_Filtering/index.js
@@ -6,6 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -181,10 +182,11 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
   if (!shapeDef) throw new Error('No shape definition provided.');
 
   let shapeId;
+  let size;
 
   if (shapeDef.type === 'box' && shapeDef.box) {
     const s = shapeDef.box.size || [1, 1, 1];
-    const size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
+    size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
     const res = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
     checkResult(res[0], 'HP_Shape_CreateBox');
     shapeId = res[1];
@@ -200,6 +202,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateSphere([0, 0, 0], r);
     checkResult(res[0], 'HP_Shape_CreateSphere');
     shapeId = res[1];
+    size = [r * 2, r * 2, r * 2];
   } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
     const cd = shapeDef.capsule;
     const rTop = cd.radiusTop !== undefined ? cd.radiusTop : (cd.radius !== undefined ? cd.radius : 0.5);
@@ -211,6 +214,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateCapsule([0, -shaftH, 0], [0, shaftH, 0], sr);
     checkResult(res[0], 'HP_Shape_CreateCapsule');
     shapeId = res[1];
+    size = [sr * 2, shaftH * 2 + sr * 2, sr * 2];
   } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
     const cyd = shapeDef.cylinder;
     const rT = cyd.radiusTop !== undefined ? cyd.radiusTop : (cyd.radius !== undefined ? cyd.radius : 0.5);
@@ -228,12 +232,13 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     } else {
       shapeId = createConvexHullFromPoints(buildFrustumHullPoints(sHH, rB_s, rT_s));
     }
+    size = [maxR * 2, sHH * 2, maxR * 2];
   } else {
     throw new Error('Unsupported KHR_implicit_shapes type: ' + shapeDef.type);
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId };
+  return { shapeId, size: size || [1, 1, 1], shapeType: shapeDef.type };
 }
 
 function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, motionDef) {
@@ -348,7 +353,28 @@ function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, mot
     checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity mesh');
   }
 
-  return { shapeId };
+  return { shapeId, size: [1, 1, 1], shapeType: 'mesh' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, motionDef) {
@@ -609,7 +635,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: position,
       initialRotation: rotation,
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(shapeResult, !!motionDef) : null
     };
     physicsNodes.push(node);
     if (motionDef) dynamicNodes.push(node);
@@ -640,6 +667,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     controls.update();
     renderer.render(scene, camera);

--- a/examples/threejs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/threejs/havok/gltf_physics_JointTypes/index.js
@@ -6,6 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -30;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 // KHR_physics_rigid_bodies axis indices map to Havok ConstraintAxis:
 // linearAxes[i]  → i     (LINEAR_X=0, LINEAR_Y=1, LINEAR_Z=2)
@@ -165,10 +166,11 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
   if (!shapeDef) throw new Error('No shape definition provided.');
 
   let shapeId;
+  let size;
 
   if (shapeDef.type === 'box' && shapeDef.box) {
     const s = shapeDef.box.size || [1, 1, 1];
-    const size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
+    size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
     const res = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
     checkResult(res[0], 'HP_Shape_CreateBox');
     shapeId = res[1];
@@ -184,6 +186,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateSphere([0, 0, 0], r);
     checkResult(res[0], 'HP_Shape_CreateSphere');
     shapeId = res[1];
+    size = [r * 2, r * 2, r * 2];
   } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
     const cd = shapeDef.capsule;
     const rTop = cd.radiusTop !== undefined ? cd.radiusTop : (cd.radius !== undefined ? cd.radius : 0.5);
@@ -195,6 +198,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateCapsule([0, -shaftH, 0], [0, shaftH, 0], sr);
     checkResult(res[0], 'HP_Shape_CreateCapsule');
     shapeId = res[1];
+    size = [sr * 2, shaftH * 2 + sr * 2, sr * 2];
   } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
     const cyd = shapeDef.cylinder;
     const rT = cyd.radiusTop !== undefined ? cyd.radiusTop : (cyd.radius !== undefined ? cyd.radius : 0.5);
@@ -212,12 +216,13 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     } else {
       shapeId = createConvexHullFromPoints(buildFrustumHullPoints(sHH, rB_s, rT_s));
     }
+    size = [maxR * 2, sHH * 2, maxR * 2];
   } else {
     throw new Error('Unsupported KHR_implicit_shapes type: ' + shapeDef.type);
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId };
+  return { shapeId, size: size || [1, 1, 1], shapeType: shapeDef.type };
 }
 
 function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, motionDef) {
@@ -317,7 +322,28 @@ function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, mot
   }
 
   if (!shapeId) return null;
-  return { shapeId };
+  return { shapeId, size: [1, 1, 1], shapeType: 'mesh' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, motionDef) {
@@ -677,7 +703,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: position,
       initialRotation: rotation,
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(shapeResult, !!motionDef) : null
     };
     physicsNodes.push(node);
     if (motionDef) dynamicNodes.push(node);
@@ -741,6 +768,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     controls.update();
     renderer.render(scene, camera);

--- a/examples/threejs/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/threejs/havok/gltf_physics_Materials_Friction/index.js
@@ -6,7 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
-const SHOW_DEBUG_BOXES = false;
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -172,7 +172,28 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId, size };
+  return { shapeId, size, shapeType: 'box' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, setMass) {
@@ -241,22 +262,6 @@ function resetDynamicBodiesIfNeeded() {
     checkResult(HK.HP_Body_SetLinearVelocity(node.bodyId, [0, 0, 0]), 'HP_Body_SetLinearVelocity reset');
     checkResult(HK.HP_Body_SetAngularVelocity(node.bodyId, [0, 0, 0]), 'HP_Body_SetAngularVelocity reset');
   }
-}
-
-function maybeCreateDebugBox(node) {
-  if (!SHOW_DEBUG_BOXES) {
-    return;
-  }
-
-  const wire = new THREE.Mesh(
-    new THREE.BoxGeometry(node.debugSize[0], node.debugSize[1], node.debugSize[2]),
-    new THREE.MeshBasicMaterial({
-      color: node.isDynamic ? 0xff6030 : 0x30e070,
-      wireframe: true
-    })
-  );
-  scene.add(wire);
-  node.debugMesh = wire;
 }
 
 async function loadModelAndBuildPhysics() {
@@ -332,9 +337,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: [tmpWorldPosition.x, tmpWorldPosition.y, tmpWorldPosition.z],
       initialRotation: [tmpWorldQuaternion.x, tmpWorldQuaternion.y, tmpWorldQuaternion.z, tmpWorldQuaternion.w],
-      debugSize: created.size,
       isDynamic: !!motionDef,
-      debugMesh: null
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(created, !!motionDef) : null
     };
 
     physicsNodes.push(node);
@@ -343,8 +347,6 @@ async function loadModelAndBuildPhysics() {
     }
 
     processedNodeIndices.add(association.nodes);
-
-    maybeCreateDebugBox(node);
   });
 }
 
@@ -375,13 +377,11 @@ async function main() {
       accumulator -= FIXED_TIMESTEP;
     }
 
-    if (SHOW_DEBUG_BOXES) {
+    if (SHOW_DEBUG_COLLIDERS) {
       for (const node of physicsNodes) {
-        if (!node.debugMesh) {
-          continue;
-        }
-        node.object.updateWorldMatrix(true, false);
-        node.object.matrixWorld.decompose(tmpWorldPosition, tmpWorldQuaternion, tmpWorldScale);
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
         node.debugMesh.position.copy(tmpWorldPosition);
         node.debugMesh.quaternion.copy(tmpWorldQuaternion);
       }

--- a/examples/threejs/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/threejs/havok/gltf_physics_Materials_Restitution/index.js
@@ -6,6 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -130,13 +131,16 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
 
   const avgScale = (Math.abs(worldScale.x) + Math.abs(worldScale.y) + Math.abs(worldScale.z)) / 3;
   let shapeId;
+  let size;
+  let shapeType;
 
   if (shapeDef.type === 'box' && shapeDef.box) {
-    const size = [
+    size = [
       Math.abs(shapeDef.box.size[0] * worldScale.x),
       Math.abs(shapeDef.box.size[1] * worldScale.y),
       Math.abs(shapeDef.box.size[2] * worldScale.z)
     ];
+    shapeType = 'box';
     const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
     checkResult(created[0], 'HP_Shape_CreateBox');
     shapeId = created[1];
@@ -147,6 +151,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     }
   } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
     const radius = shapeDef.sphere.radius * avgScale;
+    shapeType = 'sphere';
+    size = [radius * 2, radius * 2, radius * 2];
     const created = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
     checkResult(created[0], 'HP_Shape_CreateSphere');
     shapeId = created[1];
@@ -162,6 +168,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     const sXZ = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
     const sr = Math.max((rTop + rBot) * 0.5 * sXZ, 0.0001);
     const shaftH = Math.max(h * Math.abs(worldScale.y) * 0.5, 0);
+    shapeType = 'capsule';
+    size = [sr * 2, shaftH * 2 + sr * 2, sr * 2];
     const created = HK.HP_Shape_CreateCapsule([0, -shaftH, 0], [0, shaftH, 0], sr);
     checkResult(created[0], 'HP_Shape_CreateCapsule');
     shapeId = created[1];
@@ -173,6 +181,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     const sXZ = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
     const sHH = Math.max(cH * Math.abs(worldScale.y) * 0.5, 0.0001);
     const sr = Math.max(Math.max(rT, rB) * sXZ, 0.0001);
+    shapeType = 'cylinder';
+    size = [sr * 2, sHH * 2, sr * 2];
     if (typeof HK.HP_Shape_CreateCylinder === 'function') {
       const created = HK.HP_Shape_CreateCylinder([0, -sHH, 0], [0, sHH, 0], sr);
       checkResult(created[0], 'HP_Shape_CreateCylinder');
@@ -187,7 +197,28 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId };
+  return { shapeId, size, shapeType };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, setMass) {
@@ -322,7 +353,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: [tmpWorldPosition.x, tmpWorldPosition.y, tmpWorldPosition.z],
       initialRotation: [tmpWorldQuaternion.x, tmpWorldQuaternion.y, tmpWorldQuaternion.z, tmpWorldQuaternion.w],
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(created, !!motionDef) : null
     };
 
     physicsNodes.push(node);
@@ -356,6 +388,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     controls.update();
     renderer.render(scene, camera);

--- a/examples/threejs/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/threejs/havok/gltf_physics_Motion_Properties/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const RESET_Y_THRESHOLD_TOP = 50;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -210,13 +211,16 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
 
   const avgScale = (Math.abs(worldScale.x) + Math.abs(worldScale.y) + Math.abs(worldScale.z)) / 3;
   let shapeId;
+  let size;
+  let shapeType;
 
   if (shapeDef.type === 'box' && shapeDef.box) {
-    const size = [
+    size = [
       Math.abs(shapeDef.box.size[0] * worldScale.x),
       Math.abs(shapeDef.box.size[1] * worldScale.y),
       Math.abs(shapeDef.box.size[2] * worldScale.z)
     ];
+    shapeType = 'box';
     const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
     checkResult(created[0], 'HP_Shape_CreateBox');
     shapeId = created[1];
@@ -227,6 +231,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     }
   } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
     const radius = shapeDef.sphere.radius * avgScale;
+    shapeType = 'sphere';
+    size = [radius * 2, radius * 2, radius * 2];
     const created = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
     checkResult(created[0], 'HP_Shape_CreateSphere');
     shapeId = created[1];
@@ -242,6 +248,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     const sXZ = Math.max(Math.abs(worldScale.x), Math.abs(worldScale.z));
     const sr = Math.max((rTop + rBot) * 0.5 * sXZ, 0.0001);
     const shaftH = Math.max(h * Math.abs(worldScale.y) * 0.5, 0);
+    shapeType = 'capsule';
+    size = [sr * 2, shaftH * 2 + sr * 2, sr * 2];
     const created = HK.HP_Shape_CreateCapsule([0, -shaftH, 0], [0, shaftH, 0], sr);
     checkResult(created[0], 'HP_Shape_CreateCapsule');
     shapeId = created[1];
@@ -255,6 +263,8 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
     const rB_s = rB * sXZ;
     const sHH = Math.max(cH * Math.abs(worldScale.y) * 0.5, 0.0001);
     const maxR = Math.max(rT_s, rB_s, 0.0001);
+    shapeType = 'cylinder';
+    size = [maxR * 2, sHH * 2, maxR * 2];
     if (Math.abs(rT_s - rB_s) < 0.001 * maxR && typeof HK.HP_Shape_CreateCylinder === 'function') {
       const created = HK.HP_Shape_CreateCylinder([0, -sHH, 0], [0, sHH, 0], maxR);
       checkResult(created[0], 'HP_Shape_CreateCylinder');
@@ -267,7 +277,7 @@ function createPhysicsShape(worldScale, shapeDef, motionDef, materialDef) {
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId };
+  return { shapeId, size, shapeType };
 }
 
 function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, motionDef) {
@@ -386,7 +396,28 @@ function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, mot
     checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity mesh');
   }
 
-  return { shapeId };
+  return { shapeId, size: [1, 1, 1], shapeType: 'mesh' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, motionDef) {
@@ -551,7 +582,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: position,
       initialRotation: rotation,
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(created, !!motionDef) : null
     };
 
     physicsNodes.push(node);
@@ -585,6 +617,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     controls.update();
     renderer.render(scene, camera);

--- a/examples/threejs/havok/gltf_physics_Triggers/index.js
+++ b/examples/threejs/havok/gltf_physics_Triggers/index.js
@@ -6,6 +6,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK;
 let worldId;
@@ -121,10 +122,11 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
   if (!shapeDef) throw new Error('No shape definition provided.');
 
   let shapeId;
+  let size;
 
   if (shapeDef.type === 'box' && shapeDef.box) {
     const s = shapeDef.box.size || [1, 1, 1];
-    const size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
+    size = [Math.abs(s[0] * worldScale.x), Math.abs(s[1] * worldScale.y), Math.abs(s[2] * worldScale.z)];
     const res = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
     checkResult(res[0], 'HP_Shape_CreateBox');
     shapeId = res[1];
@@ -140,6 +142,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateSphere([0, 0, 0], r);
     checkResult(res[0], 'HP_Shape_CreateSphere');
     shapeId = res[1];
+    size = [r * 2, r * 2, r * 2];
   } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
     const cd = shapeDef.capsule;
     const rTop = cd.radiusTop !== undefined ? cd.radiusTop : (cd.radius !== undefined ? cd.radius : 0.5);
@@ -151,6 +154,7 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
     const res = HK.HP_Shape_CreateCapsule([0, -shaftH, 0], [0, shaftH, 0], sr);
     checkResult(res[0], 'HP_Shape_CreateCapsule');
     shapeId = res[1];
+    size = [sr * 2, shaftH * 2 + sr * 2, sr * 2];
   } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
     const cyd = shapeDef.cylinder;
     const rT = cyd.radiusTop !== undefined ? cyd.radiusTop : (cyd.radius !== undefined ? cyd.radius : 0.5);
@@ -168,12 +172,13 @@ function createImplicitShape(worldScale, shapeDef, motionDef, materialDef) {
       checkResult(res[0], 'HP_Shape_CreateBox (cyl fallback)');
       shapeId = res[1];
     }
+    size = [maxR * 2, sHH * 2, maxR * 2];
   } else {
     throw new Error('Unsupported KHR_implicit_shapes type: ' + shapeDef.type);
   }
 
   applyPhysicsMaterial(shapeId, materialDef);
-  return { shapeId };
+  return { shapeId, size: size || [1, 1, 1], shapeType: shapeDef.type };
 }
 
 function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, motionDef) {
@@ -273,7 +278,28 @@ function createMeshShape(colliderScale, geomDef, meshIndexToGeos, jsonNodes, mot
   }
 
   if (!shapeId) return null;
-  return { shapeId };
+  return { shapeId, size: [1, 1, 1], shapeType: 'mesh' };
+}
+
+function createDebugMesh(shapeInfo, isDynamic) {
+  const color = isDynamic ? 0xff8844 : 0x44ee88;
+  const mat = new THREE.LineBasicMaterial({ color });
+  const [w, h, d] = shapeInfo.size;
+  let geo;
+  if (shapeInfo.shapeType === 'sphere') {
+    geo = new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6));
+  } else if (shapeInfo.shapeType === 'capsule') {
+    const r = w / 2;
+    const shaftLen = Math.max(h - w, 0);
+    geo = new THREE.WireframeGeometry(new THREE.CapsuleGeometry(r, shaftLen, 4, 8));
+  } else if (shapeInfo.shapeType === 'cylinder') {
+    geo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(w / 2, w / 2, h, 12));
+  } else {
+    geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d));
+  }
+  const mesh = new THREE.LineSegments(geo, mat);
+  scene.add(mesh);
+  return mesh;
 }
 
 function createBody(shapeId, motionType, position, rotation, motionDef) {
@@ -513,7 +539,8 @@ async function loadModelAndBuildPhysics() {
       bodyId,
       initialPosition: position,
       initialRotation: rotation,
-      isDynamic: !!motionDef
+      isDynamic: !!motionDef,
+      debugMesh: SHOW_DEBUG_COLLIDERS ? createDebugMesh(shapeResult, !!motionDef) : null
     };
     physicsNodes.push(node);
     if (motionDef) dynamicNodes.push(node);
@@ -544,6 +571,15 @@ async function main() {
       resetDynamicBodiesIfNeeded();
       updatePhysicsTransforms();
       accumulator -= FIXED_TIMESTEP;
+    }
+    if (SHOW_DEBUG_COLLIDERS) {
+      for (const node of physicsNodes) {
+        if (!node.debugMesh) continue;
+        node.object.getWorldPosition(tmpWorldPosition);
+        node.object.getWorldQuaternion(tmpWorldQuaternion);
+        node.debugMesh.position.copy(tmpWorldPosition);
+        node.debugMesh.quaternion.copy(tmpWorldQuaternion);
+      }
     }
     checkTriggerOverlaps();
     controls.update();

--- a/examples/threejs/havok/marbles/index.js
+++ b/examples/threejs/havok/marbles/index.js
@@ -6,11 +6,13 @@ import { HDRCubeTextureLoader } from 'three/addons/loaders/HDRCubeTextureLoader.
 const GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -101,6 +103,14 @@ function initPhysics() {
   groundMesh.receiveShadow = true;
   scene.add(groundMesh);
   createStaticBox([40, 4, 40], [0, -2, 0]);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    dbg.position.set(0, -2, 0);
+    scene.add(dbg);
+  }
 
   const wallMat = new THREE.MeshLambertMaterial({ color: 0x3D4143, transparent: true, opacity: 0.4 });
   const wallDefs = [
@@ -114,6 +124,14 @@ function initPhysics() {
     const wallMesh = new THREE.Mesh(new THREE.BoxGeometry(size[0], size[1], size[2]), wallMat);
     wallMesh.position.set(pos[0], pos[1], pos[2]);
     scene.add(wallMesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+      );
+      dbg.position.set(pos[0], pos[1], pos[2]);
+      scene.add(dbg);
+    }
   }
 }
 
@@ -165,6 +183,14 @@ function loadMarbles() {
 
       meshes.push(mesh);
       bodyIds.push(bodyId);
+      if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+          new THREE.WireframeGeometry(new THREE.SphereGeometry(physicsRadius, 8, 6)),
+          new THREE.LineBasicMaterial({ color: 0xff8844 })
+        );
+        scene.add(dbg);
+        debugMeshes.push(dbg);
+      }
     });
 
     setInterval(updatePhysics, 1000 / 60);
@@ -179,6 +205,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = (Math.random() - 0.5) * 8;

--- a/examples/threejs/havok/minimum/index.js
+++ b/examples/threejs/havok/minimum/index.js
@@ -3,11 +3,13 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 let meshGround, meshCube;
 let groundBodyId, cubeBodyId;
+let debugGround, debugCube;
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -76,6 +78,13 @@ function initPhysics() {
   HK.HP_Body_SetPosition(groundBodyId, [0, 0, 0]);
   HK.HP_Body_SetOrientation(groundBodyId, IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, groundBodyId, false);
+  if (SHOW_DEBUG_COLLIDERS) {
+    debugGround = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
+  }
 
   // Cube (dynamic)
   const csRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [1, 1, 1]);
@@ -94,6 +103,14 @@ function initPhysics() {
   );
   HK.HP_Body_SetOrientation(cubeBodyId, [rotQuat.x, rotQuat.y, rotQuat.z, rotQuat.w]);
   HK.HP_World_AddBody(worldId, cubeBodyId, false);
+  if (SHOW_DEBUG_COLLIDERS) {
+    debugCube = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+      new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
+  }
 }
 
 function updatePhysics() {
@@ -102,6 +119,10 @@ function updatePhysics() {
   const [, ori] = HK.HP_Body_GetOrientation(cubeBodyId);
   meshCube.position.set(pos[0], pos[1], pos[2]);
   meshCube.quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+  if (SHOW_DEBUG_COLLIDERS && debugCube) {
+    debugCube.position.set(pos[0], pos[1], pos[2]);
+    debugCube.quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+  }
 }
 
 function animate() {

--- a/examples/threejs/havok/shogi/index.js
+++ b/examples/threejs/havok/shogi/index.js
@@ -4,11 +4,13 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const PIECE_COUNT = 220;
+const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 const meshes = [];
 const bodyIds = [];
+const debugMeshes = [];
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -158,6 +160,14 @@ function initPhysics() {
   const wallMat = new THREE.MeshLambertMaterial({ color: 0x3D4143, transparent: true, opacity: 0.4 });
 
   createStaticBox([40, 4, 40], [0, -2, 0], groundMat);
+  if (SHOW_DEBUG_COLLIDERS) {
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    dbg.position.set(0, -2, 0);
+    scene.add(dbg);
+  }
 
   const wallData = [
     { size: [10, 10,  1], pos: [ 0, 5, -5] },
@@ -167,6 +177,14 @@ function initPhysics() {
   ];
   for (const { size, pos } of wallData) {
     createStaticBox(size, pos, wallMat);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+      );
+      dbg.position.set(pos[0], pos[1], pos[2]);
+      scene.add(dbg);
+    }
   }
 
   const pieceW = 1.6;
@@ -204,6 +222,14 @@ function initPhysics() {
     mesh.receiveShadow = true;
     scene.add(mesh);
     meshes.push(mesh);
+    if (SHOW_DEBUG_COLLIDERS) {
+      const dbg = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(pieceW, pieceH, pieceD * 1.4)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+      );
+      scene.add(dbg);
+      debugMeshes.push(dbg);
+    }
   }
 }
 
@@ -214,6 +240,10 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+      debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
+      debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
+    }
 
     if (pos[1] < -10) {
       const x = (Math.random() - 0.5) * 8;


### PR DESCRIPTION
## Summary

- Add `SHOW_DEBUG_COLLIDERS = true` flag to all 15 three.js + Havok examples
- Dynamic bodies render with **orange** wireframes (`0xff8844`), static bodies with **green** wireframes (`0x44ee88`)
- Shape-appropriate geometry: `EdgesGeometry` for boxes/cylinders, `WireframeGeometry` for spheres/capsules; mesh/convex-hull shapes fall back to a box wireframe

## Affected examples

**Simple (manual bodies):** minimum, box, balls, cone, domino, football, marbles, shogi

**glTF Physics (`createImplicitShape`):** gltf_physics_Basic_Shapes, gltf_physics_Filtering, gltf_physics_JointTypes, gltf_physics_Triggers

**glTF Physics (`createPhysicsShape`):** gltf_physics_Materials_Friction, gltf_physics_Materials_Restitution, gltf_physics_Motion_Properties

## Test plan

- [ ] Open each example in browser and verify colored wireframes appear over physics shapes
- [ ] Confirm dynamic body wireframes (orange) follow object movement each frame
- [ ] Confirm static body wireframes (green) remain in place
- [ ] Verify no regressions in physics simulation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)