### PR TITLE
feat(babylonjs): add physics debug wireframe rendering to all samples

### DIFF
--- a/examples/babylonjs/ammo/balls/index.js
+++ b/examples/babylonjs/ammo/balls/index.js
@@ -1,8 +1,34 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -19,6 +45,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/ammo/box/index.js
+++ b/examples/babylonjs/ammo/box/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/ammo/domino/index.js
+++ b/examples/babylonjs/ammo/domino/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -70,6 +96,7 @@ async function init() {
 const createScene = function() {
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/ammo/eraser/index.js
+++ b/examples/babylonjs/ammo/eraser/index.js
@@ -1,11 +1,37 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 // to go quicker
 const v3 = BABYLON.Vector3;
 const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -22,6 +48,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/ammo/football/index.js
+++ b/examples/babylonjs/ammo/football/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/ammo/gltf/index.js
+++ b/examples/babylonjs/ammo/gltf/index.js
@@ -1,7 +1,33 @@
 let engine;
 let scene;
 let canvas;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -23,8 +49,8 @@ const createScene = function() {
 
     const importPromise = BABYLON.SceneLoader.ImportMeshAsync(null, "https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/", "Duck.gltf", scene);
     importPromise.then(function (result) {
-
-        scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.AmmoJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
         scene.getPhysicsEngine().setTimeStep(1 / 30);
         
         scene.forceShowBoundingBoxes = true;

--- a/examples/babylonjs/ammo/marbles/index.js
+++ b/examples/babylonjs/ammo/marbles/index.js
@@ -1,10 +1,36 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -20,7 +46,7 @@ async function init() {
 const createScene = function() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera("camera", 0, Math.PI/180 * 60, 30, BABYLON.Vector3.Zero(), scene);
     camera.setTarget(BABYLON.Vector3.Zero());
     camera.attachControl(canvas, true);

--- a/examples/babylonjs/ammo/minimum/index.js
+++ b/examples/babylonjs/ammo/minimum/index.js
@@ -2,7 +2,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -17,7 +43,8 @@ async function init() {
 
 const createScene = function() {
     scene = new BABYLON.Scene(engine);
-    scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.AmmoJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.AmmoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/cannon/balls/index.js
+++ b/examples/babylonjs/cannon/balls/index.js
@@ -1,8 +1,34 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -19,6 +45,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/cannon/box/index.js
+++ b/examples/babylonjs/cannon/box/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/cannon/domino/index.js
+++ b/examples/babylonjs/cannon/domino/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/cannon/eraser/index.js
+++ b/examples/babylonjs/cannon/eraser/index.js
@@ -1,10 +1,36 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 // to go quicker
 const v3 = BABYLON.Vector3;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -21,6 +47,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/cannon/football/index.js
+++ b/examples/babylonjs/cannon/football/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/cannon/gltf/index.js
+++ b/examples/babylonjs/cannon/gltf/index.js
@@ -1,7 +1,33 @@
 let engine;
 let scene;
 let canvas;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -22,8 +48,8 @@ const createScene = function() {
 
     const importPromise = BABYLON.SceneLoader.ImportMeshAsync(null, "https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/", "Duck.gltf", scene);
     importPromise.then(function (result) {
-
-        scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.CannonJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
         scene.getPhysicsEngine().setTimeStep(1 / 30);
         
         scene.forceShowBoundingBoxes = true;

--- a/examples/babylonjs/cannon/marbles/index.js
+++ b/examples/babylonjs/cannon/marbles/index.js
@@ -1,10 +1,36 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -19,7 +45,7 @@ async function init() {
 const createScene = function() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera("camera", 0, Math.PI/180 * 60, 30, BABYLON.Vector3.Zero(), scene);
     camera.setTarget(BABYLON.Vector3.Zero());
     camera.attachControl(canvas, true);

--- a/examples/babylonjs/cannon/minimum/index.js
+++ b/examples/babylonjs/cannon/minimum/index.js
@@ -2,7 +2,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -16,7 +42,8 @@ async function init() {
 
 const createScene = function() {
     scene = new BABYLON.Scene(engine);
-    scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.CannonJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.CannonJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/havok/balls/index.js
+++ b/examples/babylonjs/havok/balls/index.js
@@ -3,7 +3,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -28,6 +54,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/havok/box/index.js
+++ b/examples/babylonjs/havok/box/index.js
@@ -55,7 +55,33 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -80,6 +106,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/havok/cone/index.js
+++ b/examples/babylonjs/havok/cone/index.js
@@ -5,7 +5,33 @@ let canvas;
 
 const CONE_COUNT = 120;
 const SCALE = 1 / 50;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({
@@ -35,6 +61,7 @@ async function init() {
 function createScene() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.clearColor = new BABYLON.Color4(0.24, 0.25, 0.28, 1.0);
 
     const camera = new BABYLON.ArcRotateCamera(

--- a/examples/babylonjs/havok/domino/index.js
+++ b/examples/babylonjs/havok/domino/index.js
@@ -55,7 +55,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -80,6 +106,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/havok/football/index.js
+++ b/examples/babylonjs/havok/football/index.js
@@ -55,7 +55,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -80,6 +106,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/havok/gltf/index.js
+++ b/examples/babylonjs/havok/gltf/index.js
@@ -2,7 +2,33 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 let engine;
 let scene;
 let canvas;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({
@@ -30,8 +56,8 @@ const createScene = function() {
 
     const importPromise = BABYLON.SceneLoader.ImportMeshAsync(null, "https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/", "Duck.gltf", scene);
     importPromise.then(function (result) {
-
-        scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.HavokPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
         scene.getPhysicsEngine().setTimeStep(1 / 30);
         
         scene.forceShowBoundingBoxes = true;

--- a/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.js
@@ -42,7 +42,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -74,7 +100,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 2.2, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_Filtering/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Filtering/index.js
@@ -42,7 +42,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -74,7 +100,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 2.2, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/babylonjs/havok/gltf_physics_JointTypes/index.js
@@ -42,7 +42,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -74,7 +100,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 2.2, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
@@ -41,7 +41,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -73,7 +99,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', Math.PI / 3, Math.PI / 3, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
@@ -41,7 +41,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -73,7 +99,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', Math.PI / 2, Math.PI / 3, 5.5, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
@@ -42,7 +42,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -74,7 +100,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 2.2, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/gltf_physics_Triggers/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Triggers/index.js
@@ -42,7 +42,33 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({
@@ -74,7 +100,7 @@ async function createScene() {
 
     const hk = new BABYLON.HavokPlugin();
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 2.2, 15, new BABYLON.Vector3(0, 0, 0), scene);
     camera.attachControl(canvas, true);
     camera.wheelDeltaPercentage = 0.005;

--- a/examples/babylonjs/havok/marbles/index.js
+++ b/examples/babylonjs/havok/marbles/index.js
@@ -5,7 +5,33 @@ let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({
@@ -28,7 +54,7 @@ async function init() {
 const createScene = function() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera("camera", 0, Math.PI/180 * 60, 30, BABYLON.Vector3.Zero(), scene);
     camera.setTarget(BABYLON.Vector3.Zero());
     camera.attachControl(canvas, true);

--- a/examples/babylonjs/havok/minimum/index.js
+++ b/examples/babylonjs/havok/minimum/index.js
@@ -3,7 +3,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({
@@ -26,7 +52,8 @@ async function init() {
 const createScene = function() {
     scene = new BABYLON.Scene(engine);
     const hk = new BABYLON.HavokPlugin();
-    scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), hk);
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), hk);
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/havok/shogi/index.js
+++ b/examples/babylonjs/havok/shogi/index.js
@@ -7,7 +7,33 @@ const PHYSICS_SCALE = 1 / 10;
 const PIECE_COUNT = 220;
 const BOX_HALF_EXTENT = 5 * PHYSICS_SCALE;
 const SPAWN_MARGIN = 0.6 * PHYSICS_SCALE;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({
@@ -192,6 +218,7 @@ function randomSpawn() {
 function createScene() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.HavokPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.clearColor = new BABYLON.Color4(0.17, 0.18, 0.22, 1.0);
 
     const camera = new BABYLON.ArcRotateCamera(

--- a/examples/babylonjs/oimo/balls/index.js
+++ b/examples/babylonjs/oimo/balls/index.js
@@ -1,8 +1,34 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -19,6 +45,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0.86, 1.37, 250, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/oimo/box/index.js
+++ b/examples/babylonjs/oimo/box/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/oimo/domino/index.js
+++ b/examples/babylonjs/oimo/domino/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/oimo/eraser/index.js
+++ b/examples/babylonjs/oimo/eraser/index.js
@@ -1,10 +1,36 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 // to go quicker
 const v3 = BABYLON.Vector3;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -21,6 +47,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);

--- a/examples/babylonjs/oimo/football/index.js
+++ b/examples/babylonjs/oimo/football/index.js
@@ -1,4 +1,4 @@
-﻿// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
+// ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
 // ‥‥‥‥‥〓〓〓〓〓〓〓〓〓□□
 // ‥‥‥‥‥■■■□□■□‥■■■
@@ -54,7 +54,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
 
     canvas = document.querySelector("#c");
@@ -71,6 +97,7 @@ const createScene = function() {
 
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", -2.2, 1.0, 500, BABYLON.Vector3.Zero(), scene);

--- a/examples/babylonjs/oimo/gltf/index.js
+++ b/examples/babylonjs/oimo/gltf/index.js
@@ -1,7 +1,33 @@
 let engine;
 let scene;
 let canvas;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -22,8 +48,8 @@ const createScene = function() {
 
     const importPromise = BABYLON.SceneLoader.ImportMeshAsync(null, "https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/", "Duck.gltf", scene);
     importPromise.then(function (result) {
-
-        scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.OimoJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
         scene.getPhysicsEngine().setTimeStep(1 / 30);
         
         scene.forceShowBoundingBoxes = true;

--- a/examples/babylonjs/oimo/marbles/index.js
+++ b/examples/babylonjs/oimo/marbles/index.js
@@ -1,10 +1,36 @@
-﻿let engine;
+let engine;
 let scene;
 let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -19,7 +45,7 @@ async function init() {
 const createScene = function() {
     const scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
-
+    setupPhysicsDebugWireframe(scene);
     const camera = new BABYLON.ArcRotateCamera("camera", 0, Math.PI/180 * 60, 30, BABYLON.Vector3.Zero(), scene);
     camera.setTarget(BABYLON.Vector3.Zero());
     camera.attachControl(canvas, true);

--- a/examples/babylonjs/oimo/minimum/index.js
+++ b/examples/babylonjs/oimo/minimum/index.js
@@ -2,7 +2,33 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
 
+    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                seenImpostors.add(mesh.physicsImpostor);
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                physicsViewer.showBody(mesh.physicsBody);
+                seenBodies.add(mesh.physicsBody);
+            }
+        });
+    });
+}
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);
@@ -16,7 +42,8 @@ async function init() {
 
 const createScene = function() {
     scene = new BABYLON.Scene(engine);
-    scene.enablePhysics(new BABYLON.Vector3(0,-9.8,0), new BABYLON.OimoJSPlugin());
+    scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
+    setupPhysicsDebugWireframe(scene);
     scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
 
     const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0, 10, new BABYLON.Vector3(0, 0, 0), scene);


### PR DESCRIPTION
## Summary

Add setupPhysicsDebugWireframe() helper to all 40 Babylon.js physics samples across the ammo, cannon, havok, and oimo engines.

## Changes

- Added a shared setupPhysicsDebugWireframe(scene) function to each index.js
- Supports both physics APIs:
  - Legacy: PhysicsImpostor + physicsViewer.showImpostor() (ammo / cannon / oimo)
  - New: PhysicsAggregate / physicsBody + physicsViewer.showBody() (havok)
- Uses BABYLON.Debug.PhysicsViewer, guarded by an existence check so it degrades gracefully in builds without the debug module
- Uses WeakSet to track already-registered impostors / bodies and prevent duplicate show calls per render frame
- setupPhysicsDebugWireframe(scene) is called immediately after scene.enablePhysics() in every sample

## Affected samples (40 files)

| Engine | Samples |
|--------|---------|
| ammo   | balls, box, domino, eraser, football, gltf, marbles, minimum |
| cannon | balls, box, domino, eraser, football, gltf, marbles, minimum |
| havok  | balls, box, cone, domino, football, gltf, gltf_physics_Basic_Shapes, gltf_physics_Filtering, gltf_physics_JointTypes, gltf_physics_Materials_Friction, gltf_physics_Materials_Restitution, gltf_physics_Motion_Properties, gltf_physics_Triggers, marbles, minimum, shogi |
| oimo   | balls, box, domino, eraser, football, gltf, marbles, minimum |