### PR TITLE
feat: add physics debug wireframe rendering to all WebGL1, WebGL2, and WebGPU Havok samples

### DIFF
--- a/examples/webgl1/havok/balls/index.html
+++ b/examples/webgl1/havok/balls/index.html
@@ -42,6 +42,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/havok/balls/index.js
+++ b/examples/webgl1/havok/balls/index.js
@@ -26,6 +26,12 @@ let cubeMesh;
 let textures = [];
 let whiteTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 let HK;
 let worldId;
 let balls = [];
@@ -66,6 +72,99 @@ function createProgram(glCtx, vsSource, fsSource) {
         throw new Error(glCtx.getProgramInfoLog(prog));
     }
     return prog;
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), Math.sin(a), 0);
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(0, Math.sin(a), Math.cos(a));
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), 0, Math.sin(a));
+    }
+    const indices = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = ring * SEG;
+        for (let i = 0; i < SEG; i++) {
+            indices.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    const model = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [20, 2, 20]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugSphereMesh.ibo);
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+
+    for (const item of balls) {
+        const posResult = HK.HP_Body_GetPosition(item.bodyId);
+        checkResult(posResult[0], 'HP_Body_GetPosition debug');
+        const r = item.radius;
+        mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, posResult[1], [r, r, r]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
 }
 
 function sphericalUV(x, y, z) {
@@ -390,6 +489,8 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -425,6 +526,20 @@ async function main() {
         alpha:    gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl1/havok/box/index.html
+++ b/examples/webgl1/havok/box/index.html
@@ -42,6 +42,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -45,6 +45,11 @@ let groundMesh;
 let groundTexture;
 let whiteTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
 const boxBodyIds = [];
 const boxTints = [];
 
@@ -192,6 +197,57 @@ function getTintColor(code) {
         'b': [0.0, 0.0, 1.0]
     };
     return map[code] || [1, 1, 1];
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition debug');
+        const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
+        mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
 }
 
 function createBoxGeometry() {
@@ -419,6 +475,8 @@ function render(timeMs) {
         drawMesh(cubeMesh, whiteTexture, boxTints[i], model);
     }
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -459,6 +517,18 @@ async function init() {
 
     gl.useProgram(program);
     gl.uniform1i(uniforms.texture, 0);
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     cubeMesh = createBoxGeometry();
     groundMesh = createGroundPlaneData(GROUND_UV_REPEAT);

--- a/examples/webgl1/havok/cone/index.js
+++ b/examples/webgl1/havok/cone/index.js
@@ -5,7 +5,7 @@ const CONE_COUNT = 120;
 const BASKET_HALF = 3.0;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const CONE_TEXTURE = '../../../../assets/textures/carrot.jpg';
-const SHOW_DEBUG_PHYSICS = false;
+const SHOW_DEBUG_PHYSICS = true;
 const CONE_HULL_SEGMENTS = 16;
 
 let canvas;

--- a/examples/webgl1/havok/domino/index.html
+++ b/examples/webgl1/havok/domino/index.html
@@ -35,6 +35,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -80,6 +80,11 @@ let uniformProjection;
 let uniformModelView;
 let uniformColor;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
 let vertexBuffer;
 let normalBuffer;
 let indexBuffer;
@@ -89,6 +94,7 @@ const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const modelMatrix = mat4.create();
 const modelViewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
 
 function enumToNumber(value) {
     if (typeof value === 'number') {
@@ -178,6 +184,59 @@ function createProgram(vsSource, fsSource) {
         throw new Error(gl.getProgramInfoLog(shaderProgram));
     }
     return shaderProgram;
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, GROUND_Y, 0], [100, GROUND_HALF_HEIGHT, 100]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+    for (let i = 0; i < DOMINO_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(dominoBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition debug');
+        const rotResult = HK.HP_Body_GetOrientation(dominoBodyIds[i]);
+        checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
+        mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [DOMINO_W, DOMINO_H, DOMINO_D]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
 }
 
 function createBoxGeometry() {
@@ -350,6 +409,8 @@ function render(timeMs) {
         drawBox(posResult[1], rotResult[1], [DOMINO_W, DOMINO_H, DOMINO_D], dominoColors[i]);
     }
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -378,6 +439,18 @@ async function init() {
     uniformProjection = gl.getUniformLocation(program, 'pjMatrix');
     uniformModelView = gl.getUniformLocation(program, 'mvMatrix');
     uniformColor = gl.getUniformLocation(program, 'uColor');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     createBoxGeometry();
     initPhysics();

--- a/examples/webgl1/havok/football/index.html
+++ b/examples/webgl1/havok/football/index.html
@@ -42,6 +42,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -51,6 +51,12 @@ let uniformTint;
 let uniformLightDir;
 let uniformAlpha;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 let sphereMesh;
 let planeMesh;
 let footballTexture;
@@ -166,6 +172,90 @@ function loadTexture(url) {
         };
         img.src = url;
     });
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), Math.sin(a), 0);
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(0, Math.sin(a), Math.cos(a));
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), 0, Math.sin(a));
+    }
+    const indices = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = ring * SEG;
+        for (let i = 0; i < SEG; i++) {
+            indices.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2, 0], [30, 2, 30]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugSphereMesh.ibo);
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        checkResult(posResult[0], 'HP_Body_GetPosition debug');
+        mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, posResult[1], [0.5, 0.5, 0.5]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
 }
 
 function createSphereGeometry(radius, latSegments, lonSegments) {
@@ -438,6 +528,8 @@ function render(timeMs) {
         );
     }
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -472,6 +564,19 @@ async function init() {
     uniformTint = gl.getUniformLocation(program, 'uTint');
     uniformLightDir = gl.getUniformLocation(program, 'uLightDir');
     uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);
     planeMesh = createPlaneGeometry(30, 6);

--- a/examples/webgl1/havok/marbles/index.html
+++ b/examples/webgl1/havok/marbles/index.html
@@ -239,6 +239,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/havok/marbles/index.js
+++ b/examples/webgl1/havok/marbles/index.js
@@ -20,6 +20,12 @@ let skyboxAttribs;
 let skyboxUniforms;
 let skyboxVbo;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 let HK;
 let worldId;
 const marbles = [];
@@ -32,6 +38,92 @@ const viewNoTranslation = mat4.create();
 let groundMesh;
 let groundTexture;
 let envCubeTexture = null;
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), Math.sin(a), 0);
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(0, Math.sin(a), Math.cos(a));
+    }
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), 0, Math.sin(a));
+    }
+    const indices = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = ring * SEG;
+        for (let i = 0; i < SEG; i++) {
+            indices.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    const model = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -5, 0], [80, 4, 80]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugSphereMesh.ibo);
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+
+    for (const marble of marbles) {
+        const posResult = HK.HP_Body_GetPosition(marble.body);
+        checkResult(posResult[0], 'HP_Body_GetPosition debug');
+        const r = marble.radius;
+        mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, posResult[1], [r, r, r]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+}
 
 function rand(min, max) {
     return min + Math.random() * (max - min);
@@ -1013,6 +1105,8 @@ function render(timeMs) {
     drawGround();
     drawMarbles();
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -1028,6 +1122,19 @@ async function main() {
     const vsSource = document.getElementById('vs').textContent;
     const fsSource = document.getElementById('fs').textContent;
     program = createProgram(vsSource, fsSource);
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     attribs = {
         position: gl.getAttribLocation(program, 'aPosition'),

--- a/examples/webgl1/havok/minimum/index.html
+++ b/examples/webgl1/havok/minimum/index.html
@@ -31,6 +31,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/havok/minimum/index.js
+++ b/examples/webgl1/havok/minimum/index.js
@@ -19,6 +19,11 @@ let uniformProjection;
 let uniformModelView;
 let uniformTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
 let boxVertexBuffer;
 let boxUvBuffer;
 let boxIndexBuffer;
@@ -30,6 +35,7 @@ const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const modelMatrix = mat4.create();
 const modelViewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
 
 function enumToNumber(value) {
     if (typeof value === 'number') {
@@ -120,6 +126,57 @@ function createProgram(vsSource, fsSource) {
         throw new Error(gl.getProgramInfoLog(shaderProgram));
     }
     return shaderProgram;
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    return { vbo, ibo, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.vbo);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.ibo);
+
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2.5, 0], [20, 1, 20]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    const posResult = HK.HP_Body_GetPosition(cubeBodyId);
+    checkResult(posResult[0], 'HP_Body_GetPosition debug');
+    const rotResult = HK.HP_Body_GetOrientation(cubeBodyId);
+    checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
+    mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [5, 5, 5]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 }
 
 function createBoxGeometry() {
@@ -327,6 +384,8 @@ function render(timeMs) {
     const cubeRotation = cubeRotationResult[1];
     drawBox(cubePosition, cubeRotation, [5, 5, 5]);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -355,6 +414,18 @@ async function init() {
     uniformProjection = gl.getUniformLocation(program, 'pjMatrix');
     uniformModelView = gl.getUniformLocation(program, 'mvMatrix');
     uniformTexture = gl.getUniformLocation(program, 'texture');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     createBoxGeometry();
     texture = await loadTexture('../../../../assets/textures/frog.jpg');

--- a/examples/webgl1/havok/shogi/index.js
+++ b/examples/webgl1/havok/shogi/index.js
@@ -1,7 +1,7 @@
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
-const SHOW_DEBUG_WIREFRAME = false;
+const SHOW_DEBUG_WIREFRAME = true;
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);

--- a/examples/webgl2/havok/balls/index.html
+++ b/examples/webgl2/havok/balls/index.html
@@ -43,6 +43,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/havok/balls/index.js
+++ b/examples/webgl2/havok/balls/index.js
@@ -31,6 +31,12 @@ let worldId;
 let balls = [];
 let basketWalls = [];
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 let viewProj = mat4.create();
 let projection = mat4.create();
 let view = mat4.create();
@@ -256,6 +262,88 @@ function checkResult(result, label) {
     throw new Error(label + ' failed with code: ' + String(result));
 }
 
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a0 = (i / SEG) * Math.PI * 2;
+        const a1 = ((i + 1) / SEG) * Math.PI * 2;
+        const c0 = Math.cos(a0), s0 = Math.sin(a0);
+        const c1 = Math.cos(a1), s1 = Math.sin(a1);
+        positions.push(c0, s0, 0,  c1, s1, 0);
+        positions.push(0, s0, c0,  0, s1, c1);
+        positions.push(c0, 0, s0,  c1, 0, s1);
+    }
+    const posFloat = new Float32Array(positions);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, posFloat, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: posFloat.length / 3 };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindVertexArray(debugBoxMesh.vao);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [20, 2, 20]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindVertexArray(null);
+
+    gl.bindVertexArray(debugSphereMesh.vao);
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (const item of balls) {
+        const posR = HK.HP_Body_GetPosition(item.bodyId);
+        const rotR = HK.HP_Body_GetOrientation(item.bodyId);
+        mat4.fromRotationTranslationScale(model, rotR[1], posR[1], [item.radius, item.radius, item.radius]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+    }
+    gl.bindVertexArray(null);
+}
+
 function createBody(shapeId, motionType, position, rotation, setMass) {
     const created = HK.HP_Body_Create();
     checkResult(created[0], 'HP_Body_Create');
@@ -389,6 +477,8 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -424,6 +514,22 @@ async function main() {
         alpha:    gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl2/havok/box/index.html
+++ b/examples/webgl2/havok/box/index.html
@@ -43,6 +43,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -45,6 +45,11 @@ let groundMesh;
 let groundTexture;
 let whiteTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
 const boxBodyIds = [];
 const boxTints = [];
 
@@ -305,6 +310,58 @@ function createMeshBuffers(positions, normals, uvs) {
     };
 }
 
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+    gl.bindVertexArray(debugBoxMesh.vao);
+
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+
+    gl.bindVertexArray(null);
+}
+
 function createBody(shapeId, motionType, position, rotation, setMass) {
     const created = HK.HP_Body_Create();
     checkResult(created[0], 'HP_Body_Create');
@@ -404,6 +461,8 @@ function render(timeMs) {
         drawMesh(cubeMesh, whiteTexture, boxTints[i], model);
     }
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -444,6 +503,20 @@ async function init() {
 
     gl.useProgram(program);
     gl.uniform1i(uniforms.texture, 0);
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     cubeMesh = createBoxGeometry();
     groundMesh = createGroundPlaneData(GROUND_UV_REPEAT);

--- a/examples/webgl2/havok/cone/index.html
+++ b/examples/webgl2/havok/cone/index.html
@@ -43,6 +43,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/havok/cone/index.js
+++ b/examples/webgl2/havok/cone/index.js
@@ -26,6 +26,12 @@ let ground;
 let basketWalls = [];
 const coneShapeCache = new Map();
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugConeMesh;
+
 let viewProj = mat4.create();
 let projection = mat4.create();
 let view = mat4.create();
@@ -211,6 +217,90 @@ function generateConeMesh(segments) {
         uvs: new Float32Array(uvs),
         vertexCount: positions.length / 3
     };
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function createDebugWireframeConeMesh() {
+    const SEG = 16;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a0 = (i / SEG) * Math.PI * 2;
+        const a1 = ((i + 1) / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a0), -0.5, Math.sin(a0));
+        positions.push(Math.cos(a1), -0.5, Math.sin(a1));
+    }
+    for (let i = 0; i < SEG; i += 2) {
+        const a = (i / SEG) * Math.PI * 2;
+        positions.push(Math.cos(a), -0.5, Math.sin(a));
+        positions.push(0, 0.5, 0);
+    }
+    const posFloat = new Float32Array(positions);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, posFloat, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: posFloat.length / 3 };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindVertexArray(debugBoxMesh.vao);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindVertexArray(null);
+
+    gl.bindVertexArray(debugConeMesh.vao);
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (const item of cones) {
+        const pResult = HK.HP_Body_GetPosition(item.body);
+        const qResult = HK.HP_Body_GetOrientation(item.body);
+        mat4.fromRotationTranslationScale(model, qResult[1], pResult[1], [item.radius, item.height, item.radius]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawArrays(gl.LINES, 0, debugConeMesh.count);
+    }
+    gl.bindVertexArray(null);
 }
 
 function enumToNumber(value) {
@@ -443,6 +533,8 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -478,6 +570,22 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugConeMesh = createDebugWireframeConeMesh();
 
     coneMesh = createMeshBuffers(generateConeMesh(48));
     cubeMesh = createMeshBuffers(generateCubeMesh());

--- a/examples/webgl2/havok/domino/index.html
+++ b/examples/webgl2/havok/domino/index.html
@@ -36,6 +36,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/havok/domino/index.js
+++ b/examples/webgl2/havok/domino/index.js
@@ -87,6 +87,67 @@ const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const modelMatrix = mat4.create();
 const modelViewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
+
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+    gl.bindVertexArray(debugBoxMesh.vao);
+
+    mat4.fromRotationTranslation(modelMatrix, IDENTITY_QUATERNION, [0, -0.1, 0]);
+    mat4.scale(modelMatrix, modelMatrix, [100, 0.2, 100]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (let i = 0; i < DOMINO_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(dominoBodyIds[i]);
+        const rotResult = HK.HP_Body_GetOrientation(dominoBodyIds[i]);
+        mat4.fromRotationTranslation(modelMatrix, rotResult[1], posResult[1]);
+        mat4.scale(modelMatrix, modelMatrix, [DOMINO_W, DOMINO_H, DOMINO_D]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+
+    gl.bindVertexArray(null);
+}
 
 function enumToNumber(value) {
     if (typeof value === 'number') {
@@ -349,6 +410,8 @@ function render(timeMs) {
 
     gl.bindVertexArray(null);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -377,6 +440,20 @@ async function init() {
     uniformProjection = gl.getUniformLocation(program, 'pjMatrix');
     uniformModelView = gl.getUniformLocation(program, 'mvMatrix');
     uniformColor = gl.getUniformLocation(program, 'uColor');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     createBoxGeometry();
     initPhysics();

--- a/examples/webgl2/havok/football/index.html
+++ b/examples/webgl2/havok/football/index.html
@@ -43,6 +43,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -55,10 +55,93 @@ let planeMesh;
 let footballTexture;
 let grassTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const viewProjMatrix = mat4.create();
 const modelMatrix = mat4.create();
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a0 = (i / SEG) * Math.PI * 2;
+        const a1 = ((i + 1) / SEG) * Math.PI * 2;
+        const c0 = Math.cos(a0), s0 = Math.sin(a0);
+        const c1 = Math.cos(a1), s1 = Math.sin(a1);
+        positions.push(c0, s0, 0,  c1, s1, 0);
+        positions.push(0, s0, c0,  0, s1, c1);
+        positions.push(c0, 0, s0,  c1, 0, s1);
+    }
+    const posFloat = new Float32Array(positions);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, posFloat, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: posFloat.length / 3 };
+}
+
+function drawPhysicsDebug() {
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+
+    gl.bindVertexArray(debugBoxMesh.vao);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2, 0], [30, 2, 30]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    gl.bindVertexArray(null);
+
+    gl.bindVertexArray(debugSphereMesh.vao);
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [0.5, 0.5, 0.5]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+    }
+    gl.bindVertexArray(null);
+}
 
 function enumToNumber(value) {
     if (typeof value === 'number') return value;
@@ -421,6 +504,8 @@ function render(timeMs) {
         );
     }
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -455,6 +540,21 @@ async function init() {
     uniformTint = gl.getUniformLocation(program, 'uTint');
     uniformLightDir = gl.getUniformLocation(program, 'uLightDir');
     uniformAlpha = gl.getUniformLocation(program, 'uAlpha');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);
     planeMesh = createPlaneGeometry(30, 6);

--- a/examples/webgl2/havok/marbles/index.html
+++ b/examples/webgl2/havok/marbles/index.html
@@ -244,6 +244,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/havok/marbles/index.js
+++ b/examples/webgl2/havok/marbles/index.js
@@ -32,6 +32,12 @@ let groundMesh;
 let groundTexture;
 let envCubeTexture = null;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+let debugSphereMesh;
+
 function rand(min, max) {
     return min + Math.random() * (max - min);
 }
@@ -661,6 +667,85 @@ async function loadMarbleTemplates() {
     });
 }
 
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5
+    ]);
+    const indices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function createDebugWireframeSphereMesh() {
+    const SEG = 32;
+    const positions = [];
+    for (let i = 0; i < SEG; i++) {
+        const a0 = (i / SEG) * Math.PI * 2;
+        const a1 = ((i + 1) / SEG) * Math.PI * 2;
+        const c0 = Math.cos(a0), s0 = Math.sin(a0);
+        const c1 = Math.cos(a1), s1 = Math.sin(a1);
+        positions.push(c0, s0, 0,  c1, s1, 0);
+        positions.push(0, s0, c0,  0, s1, c1);
+        positions.push(c0, 0, s0,  c1, 0, s1);
+    }
+    const posFloat = new Float32Array(positions);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, posFloat, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: posFloat.length / 3 };
+}
+
+function drawPhysicsDebug() {
+    const model = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
+
+    gl.bindVertexArray(debugBoxMesh.vao);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -5, 0], [80, 4, 80]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, model);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    gl.bindVertexArray(null);
+
+    gl.bindVertexArray(debugSphereMesh.vao);
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (const marble of marbles) {
+        const pResult = HK.HP_Body_GetPosition(marble.body);
+        const qResult = HK.HP_Body_GetOrientation(marble.body);
+        const r = marble.radius;
+        mat4.fromRotationTranslationScale(model, qResult[1], pResult[1], [r, r, r]);
+        gl.uniformMatrix4fv(lineUniforms.model, false, model);
+        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+    }
+    gl.bindVertexArray(null);
+}
+
 function resetBodyVelocity(body) {
     checkResult(HK.HP_Body_SetLinearVelocity(body, [0, 0, 0]), 'HP_Body_SetLinearVelocity');
     checkResult(HK.HP_Body_SetAngularVelocity(body, [0, 0, 0]), 'HP_Body_SetAngularVelocity');
@@ -780,7 +865,7 @@ function initPhysics(templates) {
             true
         );
 
-        marbles.push({ body, primitives: template.primitives, scale: template.scale });
+        marbles.push({ body, primitives: template.primitives, scale: template.scale, radius: template.radius });
     }
 }
 
@@ -996,6 +1081,7 @@ function render(timeMs) {
 
     drawGround();
     drawMarbles();
+    drawPhysicsDebug();
 
     requestAnimationFrame(render);
 }
@@ -1043,6 +1129,21 @@ async function main() {
         metallic: gl.getUniformLocation(program, 'uMetallic'),
         roughness: gl.getUniformLocation(program, 'uRoughness')
     };
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = {
+        position: gl.getAttribLocation(lineProgram, 'aPosition')
+    };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
+    debugSphereMesh = createDebugWireframeSphereMesh();
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgl2/havok/minimum/index.html
+++ b/examples/webgl2/havok/minimum/index.html
@@ -32,6 +32,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/havok/minimum/index.js
+++ b/examples/webgl2/havok/minimum/index.js
@@ -19,6 +19,11 @@ let uniformProjection;
 let uniformModelView;
 let uniformTexture;
 
+let lineProgram;
+let lineAttribs;
+let lineUniforms;
+let debugBoxMesh;
+
 let vao;
 let boxVertexBuffer;
 let boxUvBuffer;
@@ -31,6 +36,7 @@ const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const modelMatrix = mat4.create();
 const modelViewMatrix = mat4.create();
+const viewProjMatrix = mat4.create();
 
 function enumToNumber(value) {
     if (typeof value === 'number') {
@@ -119,6 +125,60 @@ function createProgram(vsSource, fsSource) {
         throw new Error(gl.getProgramInfoLog(shaderProgram));
     }
     return shaderProgram;
+}
+
+function createDebugWireframeBoxMesh() {
+    const positions = new Float32Array([
+        -0.5, -0.5, -0.5,
+         0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,
+        -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,
+         0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,
+        -0.5,  0.5,  0.5,
+    ]);
+    const indices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7
+    ]);
+    const meshVao = gl.createVertexArray();
+    gl.bindVertexArray(meshVao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(lineAttribs.position);
+    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+    const ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    return { vao: meshVao, count: indices.length };
+}
+
+function drawPhysicsDebug() {
+    mat4.multiply(viewProjMatrix, projectionMatrix, viewMatrix);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProjMatrix);
+    gl.bindVertexArray(debugBoxMesh.vao);
+
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2.5, 0], [20, 1, 20]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    const posResult = HK.HP_Body_GetPosition(cubeBodyId);
+    checkResult(posResult[0], 'HP_Body_GetPosition debug');
+    const rotResult = HK.HP_Body_GetOrientation(cubeBodyId);
+    checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
+    mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [5, 5, 5]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
+    gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.bindVertexArray(null);
 }
 
 function createBoxGeometry() {
@@ -328,6 +388,8 @@ function render(timeMs) {
 
     gl.bindVertexArray(null);
 
+    drawPhysicsDebug();
+
     requestAnimationFrame(render);
 }
 
@@ -356,6 +418,18 @@ async function init() {
     uniformProjection = gl.getUniformLocation(program, 'pjMatrix');
     uniformModelView = gl.getUniformLocation(program, 'mvMatrix');
     uniformTexture = gl.getUniformLocation(program, 'textureSampler');
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    lineAttribs = { position: gl.getAttribLocation(lineProgram, 'aPosition') };
+    lineUniforms = {
+        viewProj: gl.getUniformLocation(lineProgram, 'uViewProj'),
+        model: gl.getUniformLocation(lineProgram, 'uModel'),
+        color: gl.getUniformLocation(lineProgram, 'uColor')
+    };
+    debugBoxMesh = createDebugWireframeBoxMesh();
 
     createBoxGeometry();
     texture = await loadTexture('../../../../assets/textures/frog.jpg');

--- a/examples/webgl2/havok/shogi/index.html
+++ b/examples/webgl2/havok/shogi/index.html
@@ -88,6 +88,24 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/havok/shogi/index.js
+++ b/examples/webgl2/havok/shogi/index.js
@@ -297,6 +297,50 @@ gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, groundBoxIdx, gl.STATIC_DRAW);
 let groundIdxCount = groundBoxIdx.length;
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
 
+// Line debug program
+let p3 = gl.createProgram();
+for (let i = 0; i < 2; i++) {
+    let lineShader = gl.createShader([gl.VERTEX_SHADER, gl.FRAGMENT_SHADER][i]);
+    gl.shaderSource(lineShader, [
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    ][i]);
+    gl.compileShader(lineShader);
+    gl.attachShader(p3, lineShader);
+    gl.deleteShader(lineShader);
+}
+gl.linkProgram(p3);
+let lineAttribs = { position: gl.getAttribLocation(p3, 'aPosition') };
+let lineUniforms = {
+    viewProj: gl.getUniformLocation(p3, 'uViewProj'),
+    model: gl.getUniformLocation(p3, 'uModel'),
+    color: gl.getUniformLocation(p3, 'uColor')
+};
+const lineBoxPositions = new Float32Array([
+    -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,
+     0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+    -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,
+     0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+]);
+const lineBoxIndices = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+const lineVao = gl.createVertexArray();
+gl.bindVertexArray(lineVao);
+const lineVbo = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, lineVbo);
+gl.bufferData(gl.ARRAY_BUFFER, lineBoxPositions, gl.STATIC_DRAW);
+gl.enableVertexAttribArray(lineAttribs.position);
+gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+const lineIbo = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, lineIbo);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, lineBoxIndices, gl.STATIC_DRAW);
+gl.bindVertexArray(null);
+const debugBoxMesh = { vao: lineVao, count: lineBoxIndices.length };
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
+
 // physics
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 let HK;
@@ -465,6 +509,34 @@ function startPhysicsLoop() {
     }, 1000 / 200);
 }
 
+function drawPhysicsDebug() {
+    const vpMatrix = mat4.create();
+    mat4.multiply(vpMatrix, perspMatrix, vMatrix);
+    const mMatrix = mat4.create();
+    gl.useProgram(p3);
+    gl.uniformMatrix4fv(lineUniforms.viewProj, false, vpMatrix);
+    gl.bindVertexArray(debugBoxMesh.vao);
+
+    mat4.fromRotationTranslation(mMatrix, IDENTITY_QUATERNION, [0, -10, 0]);
+    mat4.scale(mMatrix, mMatrix, [13, 0.1, 13]);
+    gl.uniformMatrix4fv(lineUniforms.model, false, mMatrix);
+    gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
+    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+
+    gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
+    for (let i = 0; i < max; i++) {
+        const pResult = HK.HP_Body_GetPosition(bodys[i]);
+        const qResult = HK.HP_Body_GetOrientation(bodys[i]);
+        mat4.fromRotationTranslation(mMatrix, qResult[1], pResult[1]);
+        mat4.scale(mMatrix, mMatrix, SHOGI_PHYSICS_SIZE);
+        gl.uniformMatrix4fv(lineUniforms.model, false, mMatrix);
+        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    }
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
+}
+
 function render() {
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
@@ -490,6 +562,8 @@ function render() {
     gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
     gl.drawElementsInstanced(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, max);
+
+    drawPhysicsDebug();
 
     requestAnimationFrame(render);
 }

--- a/examples/webgpu/havok/balls/index.html
+++ b/examples/webgpu/havok/balls/index.html
@@ -60,6 +60,34 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/havok/balls/index.js
+++ b/examples/webgpu/havok/balls/index.js
@@ -7,6 +7,11 @@ const BALL_COUNT = 160;
 const BASKET_HALF = 2.5;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
+const NUM_WALLS = 4;
+
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = 1 + NUM_WALLS + BALL_COUNT;
 const TEXTURE_FILES = [
     '../../../../assets/textures/Basketball.jpg',
     '../../../../assets/textures/BeachBall.jpg',
@@ -28,6 +33,17 @@ let depthTexture;
 
 let sphereMesh;
 let cubeMesh;
+
+let linePipeline;
+let debugSphereVertexBuffer;
+let debugSphereIndexBuffer;
+let debugSphereIndexCount = 0;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 let HK;
 let worldId;
@@ -313,6 +329,16 @@ function initRenderItems() {
     ballRenderItems = balls.map((ball) => createRenderItem(textureViews[ball.textureIndex]));
 }
 
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
+
 function writeUniforms(uniformBuffer, tint) {
     device.queue.writeBuffer(uniformBuffer, 0, viewProj);
     device.queue.writeBuffer(uniformBuffer, 64, model);
@@ -349,6 +375,22 @@ function render(timeMs) {
     mat4.lookAt(view, eye, [0, 4, 0], [0, 1, 0]);
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
+
+    mat4.fromRotationTranslationScale(model, rotationIdentity, [0, -2, 0], [20, 2, 20]);
+    setLineSlot(0, viewProj, model, 0, 1, 0, 1);
+    for (let i = 0; i < basketWalls.length; i++) {
+        const wall = basketWalls[i];
+        mat4.fromRotationTranslationScale(model, rotationIdentity, wall.pos, wall.size);
+        setLineSlot(i + 1, viewProj, model, 0, 1, 0, 1);
+    }
+    for (let i = 0; i < balls.length; i++) {
+        const item = balls[i];
+        const posR = HK.HP_Body_GetPosition(item.bodyId);
+        const rotR = HK.HP_Body_GetOrientation(item.bodyId);
+        mat4.fromRotationTranslationScale(model, rotR[1], posR[1], [item.radius, item.radius, item.radius]);
+        setLineSlot(NUM_WALLS + 1 + i, viewProj, model, 1, 1, 0, 1);
+    }
+    device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
 
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
@@ -392,6 +434,20 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotationIdentity, wallPos, wall.size);
         writeUniforms(renderItem.uniformBuffer, [0.25, 0.28, 0.3, 0.28]);
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    for (let i = 0; i <= NUM_WALLS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugBoxIndexCount);
+    }
+    pass.setVertexBuffer(0, debugSphereVertexBuffer);
+    pass.setIndexBuffer(debugSphereIndexBuffer, 'uint16');
+    for (let i = 0; i < balls.length; i++) {
+        pass.setBindGroup(0, lineBindGroup, [(NUM_WALLS + 1 + i) * LINE_ALIGN]);
+        pass.drawIndexed(debugSphereIndexCount);
     }
 
     pass.end();
@@ -487,6 +543,71 @@ async function main() {
     });
     initPhysics();
     initRenderItems();
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    const SPHERE_SEGS = 32;
+    const sphereLineVerts = [];
+    const sphereLineIndices = [];
+    const rings = [[1,0,2],[0,1,2],[1,2,0]];
+    for (let r = 0; r < 3; r++) {
+        const base = r * SPHERE_SEGS;
+        for (let i = 0; i < SPHERE_SEGS; i++) {
+            const a = (i / SPHERE_SEGS) * Math.PI * 2;
+            const v = [0, 0, 0];
+            v[rings[r][0]] = Math.cos(a);
+            v[rings[r][1]] = Math.sin(a);
+            v[rings[r][2]] = 0;
+            sphereLineVerts.push(...v);
+            sphereLineIndices.push(base + i, base + (i + 1) % SPHERE_SEGS);
+        }
+    }
+    const sphereLineVertsF32 = new Float32Array(sphereLineVerts);
+    const sphereLineIndicesU16 = new Uint16Array(sphereLineIndices);
+    debugSphereIndexCount = sphereLineIndicesU16.length;
+    debugSphereVertexBuffer = device.createBuffer({ size: sphereLineVertsF32.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereVertexBuffer, 0, sphereLineVertsF32);
+    debugSphereIndexBuffer = device.createBuffer({ size: sphereLineIndicesU16.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereIndexBuffer, 0, sphereLineIndicesU16);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgpu/havok/box/index.html
+++ b/examples/webgpu/havok/box/index.html
@@ -60,6 +60,34 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -24,6 +24,10 @@ const BOX_SIZE = 1;
 const BOX_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = BOX_COUNT + 1;
+
 const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
 const GROUND_UV_REPEAT = 6;
 
@@ -43,6 +47,14 @@ let groundTextureView;
 
 let cubeMesh;
 let groundMesh;
+
+let linePipeline;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 const boxBodyIds = [];
 const boxTints = [];
@@ -274,6 +286,16 @@ function createRenderItem(textureView) {
     return { uniformBuffer, bindGroup };
 }
 
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
+
 function writeUniforms(uniformBuffer, tint) {
     device.queue.writeBuffer(uniformBuffer, 0, viewProj);
     device.queue.writeBuffer(uniformBuffer, 64, model);
@@ -380,6 +402,16 @@ function render(timeMs) {
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
 
+    mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
+    setLineSlot(0, viewProj, model, 0, 1, 0, 1);
+    for (let i = 0; i < BOX_COUNT; i++) {
+        const posR = HK.HP_Body_GetPosition(boxBodyIds[i]);
+        const rotR = HK.HP_Body_GetOrientation(boxBodyIds[i]);
+        mat4.fromRotationTranslationScale(model, rotR[1], posR[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        setLineSlot(i + 1, viewProj, model, 1, 1, 0, 1);
+    }
+    device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
+
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
         colorAttachments: [{
@@ -411,6 +443,14 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
         writeUniforms(boxRenderItems[i].uniformBuffer, [boxTints[i][0], boxTints[i][1], boxTints[i][2], 1]);
         drawMesh(pass, cubeMesh, boxRenderItems[i].bindGroup);
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    for (let i = 0; i < NUM_LINE_OBJECTS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugBoxIndexCount);
     }
 
     pass.end();
@@ -492,6 +532,53 @@ async function init() {
 
     initPhysics();
     initRenderItems();
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    debugBoxIndexCount = boxLineIndices.length;
+
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgpu/havok/cone/index.html
+++ b/examples/webgpu/havok/cone/index.html
@@ -60,6 +60,34 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/havok/cone/index.js
+++ b/examples/webgpu/havok/cone/index.js
@@ -6,6 +6,11 @@ const BASKET_HALF = 3.0;
 const WALL_RENDER_Y_OFFSET = 0.03;
 const CONE_TEXTURE = '../../../../assets/textures/carrot.jpg';
 const CONE_HULL_SEGMENTS = 16;
+const NUM_WALLS = 4;
+
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = 1 + NUM_WALLS + CONE_COUNT;
 
 let canvas;
 let device;
@@ -21,6 +26,17 @@ let depthTexture;
 
 let coneMesh;
 let cubeMesh;
+
+let linePipeline;
+let debugConeVertexBuffer;
+let debugConeIndexBuffer;
+let debugConeIndexCount = 0;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 
@@ -372,6 +388,16 @@ function initRenderItems() {
     coneRenderItems = cones.map(() => createRenderItem(coneTextureView));
 }
 
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
+
 function writeUniforms(uniformBuffer, tint) {
     device.queue.writeBuffer(uniformBuffer, 0, viewProj);
     device.queue.writeBuffer(uniformBuffer, 64, model);
@@ -406,6 +432,23 @@ function render(timeMs) {
     mat4.lookAt(view, eye, [0, 3, 0], [0, 1, 0]);
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
     mat4.multiply(viewProj, projection, view);
+
+    mat4.fromRotationTranslationScale(model, rotationIdentity, ground.pos, ground.size);
+    setLineSlot(0, viewProj, model, 0, 1, 0, 1);
+    for (let i = 0; i < basketWalls.length; i++) {
+        const wall = basketWalls[i];
+        mat4.fromRotationTranslationScale(model, rotationIdentity, wall.pos, wall.size);
+        setLineSlot(i + 1, viewProj, model, 0, 1, 0, 1);
+    }
+    for (let i = 0; i < cones.length; i++) {
+        const item = cones[i];
+        const pResult = HK.HP_Body_GetPosition(item.body);
+        const qResult = HK.HP_Body_GetOrientation(item.body);
+        const rotation = quat.fromValues(qResult[1][0], qResult[1][1], qResult[1][2], qResult[1][3]);
+        mat4.fromRotationTranslationScale(model, rotation, pResult[1], [item.radius, item.height, item.radius]);
+        setLineSlot(NUM_WALLS + 1 + i, viewProj, model, 1, 1, 0, 1);
+    }
+    device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
 
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
@@ -453,6 +496,20 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotationIdentity, wallPos, wall.size);
         writeUniforms(renderItem.uniformBuffer, [0.25, 0.28, 0.3, 0.28]);
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    for (let i = 0; i <= NUM_WALLS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugBoxIndexCount);
+    }
+    pass.setVertexBuffer(0, debugConeVertexBuffer);
+    pass.setIndexBuffer(debugConeIndexBuffer, 'uint16');
+    for (let i = 0; i < cones.length; i++) {
+        pass.setBindGroup(0, lineBindGroup, [(NUM_WALLS + 1 + i) * LINE_ALIGN]);
+        pass.drawIndexed(debugConeIndexCount);
     }
 
     pass.end();
@@ -525,6 +582,65 @@ async function main() {
     const coneTexture = await loadTexture(CONE_TEXTURE);
     coneTextureView = coneTexture.createView();
     whiteTextureView = createSolidTextureView(255, 255, 255, 255);
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    const CONE_SEGS = 16;
+    const coneLineVerts = [];
+    for (let i = 0; i < CONE_SEGS; i++) {
+        const a = (i / CONE_SEGS) * Math.PI * 2;
+        coneLineVerts.push(Math.cos(a), -0.5, Math.sin(a));
+    }
+    coneLineVerts.push(0, 0.5, 0);
+    const coneLineIndices = [];
+    for (let i = 0; i < CONE_SEGS; i++) coneLineIndices.push(i, (i + 1) % CONE_SEGS);
+    for (let i = 0; i < 8; i++) coneLineIndices.push(i * 2, CONE_SEGS);
+    const coneLineVertsF32 = new Float32Array(coneLineVerts);
+    const coneLineIndicesU16 = new Uint16Array(coneLineIndices);
+    debugConeIndexCount = coneLineIndicesU16.length;
+    debugConeVertexBuffer = device.createBuffer({ size: coneLineVertsF32.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugConeVertexBuffer, 0, coneLineVertsF32);
+    debugConeIndexBuffer = device.createBuffer({ size: coneLineIndicesU16.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugConeIndexBuffer, 0, coneLineIndicesU16);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgpu/havok/domino/index.html
+++ b/examples/webgpu/havok/domino/index.html
@@ -55,6 +55,34 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/havok/domino/index.js
+++ b/examples/webgpu/havok/domino/index.js
@@ -63,6 +63,10 @@ const DOMINO_W = 2;
 const DOMINO_H = 4;
 const DOMINO_D = 0.6;
 
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = DOMINO_COUNT + 1;
+
 // Uniform buffer layout: viewProjection(64) + model(64) + color(12) + pad(4) = 144 bytes
 const UNIFORM_BUFFER_SIZE = 144;
 
@@ -86,6 +90,14 @@ let groundUniformBuffer;
 let groundBindGroup;
 const dominoUniformBuffers = [];
 const dominoBindGroups = [];
+
+let linePipeline;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
@@ -254,6 +266,16 @@ function createBindGroupForBuffer(uniformBuffer) {
     });
 }
 
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
+
 function writeUniformData(uniformBuffer, position, rotation, scale, color) {
     mat4.fromRotationTranslationScale(modelMatrix, rotation, position, scale);
 
@@ -348,6 +370,16 @@ function render(timeMs) {
         writeUniformData(dominoUniformBuffers[i], posResult[1], rotResult[1], [DOMINO_W, DOMINO_H, DOMINO_D], dominoColors[i]);
     }
 
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -0.1, 0], [100, 0.2, 100]);
+    setLineSlot(0, viewProjectionMatrix, modelMatrix, 0, 1, 0, 1);
+    for (let i = 0; i < DOMINO_COUNT; i++) {
+        const posResult = HK.HP_Body_GetPosition(dominoBodyIds[i]);
+        const rotResult = HK.HP_Body_GetOrientation(dominoBodyIds[i]);
+        mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [DOMINO_W, DOMINO_H, DOMINO_D]);
+        setLineSlot(i + 1, viewProjectionMatrix, modelMatrix, 1, 1, 0, 1);
+    }
+    device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
+
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
         colorAttachments: [{
@@ -377,6 +409,14 @@ function render(timeMs) {
     for (let i = 0; i < DOMINO_COUNT; i++) {
         pass.setBindGroup(0, dominoBindGroups[i]);
         pass.drawIndexed(indexCount, 1, 0, 0, 0);
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    for (let i = 0; i < NUM_LINE_OBJECTS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugBoxIndexCount);
     }
 
     pass.end();
@@ -449,6 +489,52 @@ async function init() {
         dominoUniformBuffers.push(buf);
         dominoBindGroups.push(createBindGroupForBuffer(buf));
     }
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,
+        4,5, 5,6, 6,7, 7,4,
+        0,4, 1,5, 2,6, 3,7
+    ]);
+    debugBoxIndexCount = boxLineIndices.length;
+
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgpu/havok/football/index.html
+++ b/examples/webgpu/havok/football/index.html
@@ -63,6 +63,34 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -23,6 +23,10 @@ const DOT_ROWS = [
 const BALL_COUNT = DOT_ROWS.length * DOT_ROWS[0].length;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = BALL_COUNT + 1;
+
 const FOOTBALL_TEXTURE = '../../../../assets/textures/Football.jpg';
 const GROUND_TEXTURE = '../../../../assets/textures/grass.jpg';
 
@@ -54,6 +58,17 @@ let groundUniformBuffer;
 let groundBindGroup;
 let ballUniformBuffers = [];
 let ballBindGroups = [];
+
+let linePipeline;
+let debugSphereVertexBuffer;
+let debugSphereIndexBuffer;
+let debugSphereIndexCount = 0;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
@@ -247,6 +262,16 @@ function createBindGroup(uniformBuffer, textureView) {
     });
 }
 
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
+
 function updateUniform(uniformBuffer, position, rotation, scale, tint, alpha) {
     mat4.fromRotationTranslationScale(modelMatrix, rotation, position, scale);
 
@@ -371,6 +396,16 @@ function render(timeMs) {
         updateUniform(ballUniformBuffers[i], posResult[1], rotResult[1], [1, 1, 1], ballTints[i], 1);
     }
 
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2, 0], [30, 2, 30]);
+    setLineSlot(0, viewProjMatrix, modelMatrix, 0, 1, 0, 1);
+    for (let i = 0; i < BALL_COUNT; i++) {
+        const posR = HK.HP_Body_GetPosition(ballBodyIds[i]);
+        const rotR = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        mat4.fromRotationTranslationScale(modelMatrix, rotR[1], posR[1], [0.5, 0.5, 0.5]);
+        setLineSlot(i + 1, viewProjMatrix, modelMatrix, 1, 1, 0, 1);
+    }
+    device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
+
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
         colorAttachments: [{
@@ -406,6 +441,19 @@ function render(timeMs) {
     for (let i = 0; i < BALL_COUNT; i++) {
         pass.setBindGroup(0, ballBindGroups[i]);
         pass.drawIndexed(sphereMesh.indexCount, 1, 0, 0, 0);
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    pass.setBindGroup(0, lineBindGroup, [0]);
+    pass.drawIndexed(debugBoxIndexCount);
+
+    pass.setVertexBuffer(0, debugSphereVertexBuffer);
+    pass.setIndexBuffer(debugSphereIndexBuffer, 'uint16');
+    for (let i = 1; i < NUM_LINE_OBJECTS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugSphereIndexCount);
     }
 
     pass.end();
@@ -488,6 +536,71 @@ async function init() {
         ballUniformBuffers.push(ub);
         ballBindGroups.push(createBindGroup(ub, footballTextureView));
     }
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    const SPHERE_SEGS = 32;
+    const sphereLineVerts = [];
+    const sphereLineIndices = [];
+    const rings = [[1,0,2],[0,1,2],[1,2,0]];
+    for (let r = 0; r < 3; r++) {
+        const base = r * SPHERE_SEGS;
+        for (let i = 0; i < SPHERE_SEGS; i++) {
+            const a = (i / SPHERE_SEGS) * Math.PI * 2;
+            const v = [0, 0, 0];
+            v[rings[r][0]] = Math.cos(a);
+            v[rings[r][1]] = Math.sin(a);
+            v[rings[r][2]] = 0;
+            sphereLineVerts.push(...v);
+            sphereLineIndices.push(base + i, base + (i + 1) % SPHERE_SEGS);
+        }
+    }
+    const sphereLineVertsF32 = new Float32Array(sphereLineVerts);
+    const sphereLineIndicesU16 = new Uint16Array(sphereLineIndices);
+    debugSphereIndexCount = sphereLineIndicesU16.length;
+    debugSphereVertexBuffer = device.createBuffer({ size: sphereLineVertsF32.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereVertexBuffer, 0, sphereLineVertsF32);
+    debugSphereIndexBuffer = device.createBuffer({ size: sphereLineIndicesU16.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereIndexBuffer, 0, sphereLineIndicesU16);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
 
     resize();
     window.addEventListener('resize', resize);

--- a/examples/webgpu/havok/marbles/index.html
+++ b/examples/webgpu/havok/marbles/index.html
@@ -278,6 +278,34 @@ fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/havok/marbles/index.js
+++ b/examples/webgpu/havok/marbles/index.js
@@ -8,6 +8,10 @@ const MARBLE_SCALE = 1.0;
 const MAX_MARBLES = 120;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const NUM_LINE_OBJECTS = MAX_MARBLES + 1;
+
 let canvas;
 let device;
 let context;
@@ -31,6 +35,17 @@ const marbles = [];
 let groundMesh;
 let groundRenderItem;
 let groundTextureView;
+
+let linePipeline;
+let debugSphereVertexBuffer;
+let debugSphereIndexBuffer;
+let debugSphereIndexCount = 0;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
 
 const projection = mat4.create();
 const view = mat4.create();
@@ -784,7 +799,7 @@ function initPhysics(templates) {
             true
         );
 
-        marbles.push({ body, primitives: template.primitives, scale: template.scale });
+        marbles.push({ body, primitives: template.primitives, scale: template.scale, radius: template.radius });
     }
 }
 
@@ -813,6 +828,16 @@ function drawMesh(pass, mesh, bindGroup) {
     pass.setVertexBuffer(2, mesh.uvBuffer);
     pass.setBindGroup(0, bindGroup);
     pass.draw(mesh.vertexCount, 1, 0, 0);
+}
+
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
 }
 
 function drawSkybox(encoder) {
@@ -859,6 +884,21 @@ function render(timeMs) {
     mat4.lookAt(view, eye, [0, 2, 0], [0, 1, 0]);
     mat4.perspective(projection, Math.PI / 4, canvas.width / canvas.height, 0.1, 200);
     mat4.multiply(viewProj, projection, view);
+
+    {
+        const lineModel = mat4.create();
+        mat4.fromRotationTranslationScale(lineModel, IDENTITY_QUATERNION, [0, -5, 0], [80, 4, 80]);
+        setLineSlot(0, viewProj, lineModel, 0, 1, 0, 1);
+        for (let i = 0; i < marbles.length; i++) {
+            const marble = marbles[i];
+            const pResult = HK.HP_Body_GetPosition(marble.body);
+            const qResult = HK.HP_Body_GetOrientation(marble.body);
+            const rotation = quat.fromValues(qResult[1][0], qResult[1][1], qResult[1][2], qResult[1][3]);
+            mat4.fromRotationTranslationScale(lineModel, rotation, pResult[1], [marble.radius, marble.radius, marble.radius]);
+            setLineSlot(i + 1, viewProj, lineModel, 1, 1, 0, 1);
+        }
+        device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
+    }
 
     const encoder = device.createCommandEncoder();
     drawSkybox(encoder);
@@ -940,6 +980,18 @@ function render(timeMs) {
             checkResult(HK.HP_Body_SetOrientation(marble.body, IDENTITY_QUATERNION), 'HP_Body_SetOrientation reset');
             resetBodyVelocity(marble.body);
         }
+    }
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    pass.setBindGroup(0, lineBindGroup, [0]);
+    pass.drawIndexed(debugBoxIndexCount);
+    pass.setVertexBuffer(0, debugSphereVertexBuffer);
+    pass.setIndexBuffer(debugSphereIndexBuffer, 'uint16');
+    for (let i = 1; i < NUM_LINE_OBJECTS; i++) {
+        pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+        pass.drawIndexed(debugSphereIndexCount);
     }
 
     pass.end();
@@ -1091,6 +1143,71 @@ async function main() {
 
     const templates = await loadMarblesFromGLTF();
     initPhysics(templates);
+
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    const SPHERE_SEGS = 32;
+    const sphereLineVerts = [];
+    const sphereLineIndices = [];
+    const rings = [[1,0,2],[0,1,2],[1,2,0]];
+    for (let r = 0; r < 3; r++) {
+        const base = r * SPHERE_SEGS;
+        for (let i = 0; i < SPHERE_SEGS; i++) {
+            const a = (i / SPHERE_SEGS) * Math.PI * 2;
+            const v = [0, 0, 0];
+            v[rings[r][0]] = Math.cos(a);
+            v[rings[r][1]] = Math.sin(a);
+            v[rings[r][2]] = 0;
+            sphereLineVerts.push(...v);
+            sphereLineIndices.push(base + i, base + (i + 1) % SPHERE_SEGS);
+        }
+    }
+    const sphereLineVertsF32 = new Float32Array(sphereLineVerts);
+    const sphereLineIndicesU16 = new Uint16Array(sphereLineIndices);
+    debugSphereIndexCount = sphereLineIndicesU16.length;
+    debugSphereVertexBuffer = device.createBuffer({ size: sphereLineVertsF32.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereVertexBuffer, 0, sphereLineVertsF32);
+    debugSphereIndexBuffer = device.createBuffer({ size: sphereLineIndicesU16.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugSphereIndexBuffer, 0, sphereLineIndicesU16);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
 
     requestAnimationFrame(render);
 

--- a/examples/webgpu/havok/minimum/index.html
+++ b/examples/webgpu/havok/minimum/index.html
@@ -43,6 +43,34 @@ fn main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/havok/minimum/index.js
+++ b/examples/webgpu/havok/minimum/index.js
@@ -28,6 +28,15 @@ let cubeUniformBuffer;
 let groundBindGroup;
 let cubeBindGroup;
 
+let linePipeline;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+
 const projectionMatrix = mat4.create();
 const viewMatrix = mat4.create();
 const modelMatrix = mat4.create();
@@ -211,6 +220,14 @@ async function createTextureFromImage(src) {
     return texture;
 }
 
+function writeLineUniform(slotIndex, vpMatrix, modelMat, color) {
+    const data = new Float32Array(LINE_ALIGN / 4);
+    data.set(vpMatrix, 0);
+    data.set(modelMat, 16);
+    data[32] = color[0]; data[33] = color[1]; data[34] = color[2]; data[35] = color[3];
+    device.queue.writeBuffer(lineUniformBuffer, slotIndex * LINE_ALIGN, data);
+}
+
 function createBody(shapeId, motionType, position, rotation, setMass) {
     const created = HK.HP_Body_Create();
     checkResult(created[0], 'HP_Body_Create');
@@ -305,6 +322,11 @@ function render(timeMs) {
     const cubeData = createModelUniformData(cubePositionResult[1], cubeRotationResult[1], [5, 5, 5]);
     device.queue.writeBuffer(cubeUniformBuffer, 0, cubeData);
 
+    mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2.5, 0], [20, 1, 20]);
+    writeLineUniform(0, viewProjectionMatrix, modelMatrix, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(modelMatrix, cubeRotationResult[1], cubePositionResult[1], [5, 5, 5]);
+    writeLineUniform(1, viewProjectionMatrix, modelMatrix, [1, 1, 0, 1]);
+
     const encoder = device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
         colorAttachments: [{
@@ -331,6 +353,14 @@ function render(timeMs) {
 
     pass.setBindGroup(0, cubeBindGroup);
     pass.drawIndexed(indexCount, 1, 0, 0, 0);
+
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, debugBoxVertexBuffer);
+    pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+    pass.setBindGroup(0, lineBindGroup, [0 * LINE_ALIGN]);
+    pass.drawIndexed(debugBoxIndexCount);
+    pass.setBindGroup(0, lineBindGroup, [1 * LINE_ALIGN]);
+    pass.drawIndexed(debugBoxIndexCount);
 
     pass.end();
     device.queue.submit([encoder.finish()]);
@@ -388,6 +418,44 @@ async function init() {
             depthWriteEnabled: true,
             depthCompare: 'less'
         }
+    });
+
+    const lineVsModule = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const lineFsModule = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+    const lineBindGroupLayout = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBindGroupLayout] }),
+        vertex: {
+            module: lineVsModule,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: lineFsModule, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list', cullMode: 'none' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+
+    const boxPositions = new Float32Array([
+        -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+        -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+    ]);
+    const boxIndices = new Uint16Array([0,1,1,2,2,3,3,0, 4,5,5,6,6,7,7,4, 0,4,1,5,2,6,3,7]);
+    debugBoxVertexBuffer = device.createBuffer({ size: boxPositions.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxPositions);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxIndices);
+    debugBoxIndexCount = boxIndices.length;
+
+    lineUniformBuffer = device.createBuffer({ size: 2 * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineBindGroup = device.createBindGroup({
+        layout: lineBindGroupLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
     });
 
     createBoxGeometry();

--- a/examples/webgpu/havok/shogi/index.html
+++ b/examples/webgpu/havok/shogi/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>WebGPU + Havok Falling Shogi Example</title>
   <link rel="stylesheet" type="text/css" href="style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/2.8.1/gl-matrix-min.js"></script>
     <script src="https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics_umd.js"></script>
 </head>
 <body>
@@ -90,6 +91,34 @@ fn main(@location(0) position: vec3<f32>) -> @builtin(position) vec4<f32> {
 @fragment
 fn main() -> @location(0) vec4<f32> {
     return vec4<f32>(0.6, 0.6, 0.6, 1.0);
+}
+</script>
+
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return uniforms.color;
 }
 </script>
 

--- a/examples/webgpu/havok/shogi/index.js
+++ b/examples/webgpu/havok/shogi/index.js
@@ -14,12 +14,37 @@ const IDENTITY_QUATERNION = [0, 0, 0, 1];
 let HK, worldId, bodies;
 let posArray, rotArray;
 
+const LINE_ALIGN = 256;
+const LINE_STRUCT_SIZE = 144;
+const SHOGI_VMAT = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,-40,1]);
+let currentPMatrix = null;
+
+let linePipeline;
+let debugBoxVertexBuffer;
+let debugBoxIndexBuffer;
+let debugBoxIndexCount = 0;
+let lineUniformBuffer;
+let lineBindGroup;
+let lineUniformData;
+let shogiLineModel = null;
+
 const MAX = 300;
+const NUM_LINE_OBJECTS = MAX + 1;
 const DOT_SIZE = 2;
 const pw = DOT_SIZE * 0.8 * 1.0;
 const ph = DOT_SIZE * 0.8 * 1.0;
 const pd = DOT_SIZE * 0.8 * 0.2;
 const SHOGI_PHYSICS_SIZE = [pw, ph * 1.2, pd * 1.4];
+
+function setLineSlot(slotIndex, vpMatrix, modelMat, r, g, b, a) {
+    const base = slotIndex * (LINE_ALIGN / 4);
+    lineUniformData.set(vpMatrix, base);
+    lineUniformData.set(modelMat, base + 16);
+    lineUniformData[base + 32] = r;
+    lineUniformData[base + 33] = g;
+    lineUniformData[base + 34] = b;
+    lineUniformData[base + 35] = a;
+}
 
 function enumToNumber(value) {
     if (typeof value === 'number') {
@@ -114,8 +139,8 @@ async function init() {
         canvas.height = window.innerHeight;
         depthTexture.destroy();
         depthTexture = createDepthTexture();
-        const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
-        device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+        currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
+        device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
     });
 
     const gpu = navigator['gpu'];
@@ -290,8 +315,8 @@ async function init() {
         size: 64,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
     });
-    const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
-    device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+    currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
+    device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
 
     // Texture
     const shogiTexture = await createTextureFromImage('../../../../assets/textures/shogi_001/shogi.png');
@@ -423,6 +448,46 @@ async function init() {
         bodies[i] = createBody(shogiShapeId, HK.MotionType.DYNAMIC, [p.x, p.y, p.z], IDENTITY_QUATERNION, true);
     }
 
+    const vsLine = device.createShaderModule({ code: document.getElementById('vs-line').textContent });
+    const fsLine = device.createShaderModule({ code: document.getElementById('fs-line').textContent });
+    const lineBGL = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE }
+        }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGL] }),
+        vertex: {
+            module: vsLine,
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: fsLine, entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus-stencil8', depthWriteEnabled: false, depthCompare: 'less-equal' }
+    });
+
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5
+    ]);
+    const boxLineIndices = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = device.createBuffer({ size: boxLineVerts.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxVertexBuffer, 0, boxLineVerts);
+    debugBoxIndexBuffer = device.createBuffer({ size: boxLineIndices.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(debugBoxIndexBuffer, 0, boxLineIndices);
+
+    lineUniformBuffer = device.createBuffer({ size: NUM_LINE_OBJECTS * LINE_ALIGN, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    lineUniformData = new Float32Array(NUM_LINE_OBJECTS * LINE_ALIGN / 4);
+    lineBindGroup = device.createBindGroup({
+        layout: lineBGL,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuffer, size: LINE_STRUCT_SIZE } }]
+    });
+    shogiLineModel = mat4.create();
+
     updateInstanceArrays();
 
     setInterval(function () {
@@ -547,6 +612,21 @@ function render() {
     device.queue.writeBuffer(offsetBuffer, 0, posArray);
     device.queue.writeBuffer(rotBuffer,    0, rotArray);
 
+    if (currentPMatrix && shogiLineModel) {
+        const lineViewProj = mat4mul(currentPMatrix, SHOGI_VMAT);
+        mat4.fromRotationTranslation(shogiLineModel, IDENTITY_QUATERNION, [0, -10, 0]);
+        mat4.scale(shogiLineModel, shogiLineModel, [13, 0.1, 13]);
+        setLineSlot(0, lineViewProj, shogiLineModel, 0, 1, 0, 1);
+        for (let i = 0; i < MAX; i++) {
+            const pos = [posArray[i*3], posArray[i*3+1], posArray[i*3+2]];
+            const rot = [rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]];
+            mat4.fromRotationTranslation(shogiLineModel, rot, pos);
+            mat4.scale(shogiLineModel, shogiLineModel, SHOGI_PHYSICS_SIZE);
+            setLineSlot(i + 1, lineViewProj, shogiLineModel, 1, 1, 0, 1);
+        }
+        device.queue.writeBuffer(lineUniformBuffer, 0, lineUniformData);
+    }
+
     const textureView = ctx.getCurrentTexture().createView();
     const commandEncoder = device.createCommandEncoder();
     const passEncoder = commandEncoder.beginRenderPass({
@@ -584,6 +664,16 @@ function render() {
     passEncoder.setIndexBuffer(indexBuffer, 'uint16');
     passEncoder.setBindGroup(0, bindGroup);
     passEncoder.drawIndexed(indexNum, MAX, 0, 0, 0);
+
+    if (linePipeline) {
+        passEncoder.setPipeline(linePipeline);
+        passEncoder.setVertexBuffer(0, debugBoxVertexBuffer);
+        passEncoder.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+        for (let i = 0; i < NUM_LINE_OBJECTS; i++) {
+            passEncoder.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
+            passEncoder.drawIndexed(debugBoxIndexCount);
+        }
+    }
 
     passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);


### PR DESCRIPTION
## Summary

- Add physics shape wireframe overlay to all Havok examples across WebGL 1.0, WebGL 2.0, and WebGPU renderers (8 examples x 3 renderers = 24 examples total)
- Green wireframes indicate static/ground bodies; yellow wireframes indicate dynamic bodies
- Shape types covered: box (minimum, box, domino, shogi), sphere (balls, football, marbles), cone (cone)

## Implementation Details

- **WebGL 1.0 / WebGL 2.0**: GLSL line-loop/line-segment shader with per-object MVP uniform; dynamically generates box, sphere (3 great-circle rings), and cone wireframe geometry
- **WebGPU**: WGSL line-list pipeline with dynamic-offset uniform buffer (LINE_ALIGN=256 bytes/slot); separate bind group offsets per object via setBindGroup(0, lineBindGroup, [i * LINE_ALIGN])
- WebGPU shogi example required adding gl-matrix 2.8.1 (no math library was present) and matching the existing depth24plus-stencil8 depth format

## Test plan

- [ ] WebGL1 examples render green ground wireframe and yellow dynamic body wireframes
- [ ] WebGL2 examples render green ground wireframe and yellow dynamic body wireframes
- [ ] WebGPU examples render green ground wireframe and yellow dynamic body wireframes
- [ ] Wireframes overlay correctly without z-fighting (depthWriteEnabled: false / less-equal)
- [ ] No regressions in existing physics simulation behavior

Generated with [Claude Code](https://claude.com/claude-code)