### PR TITLE
feat(oimo): add physics debug wireframe rendering to all samples

### DIFF
--- a/examples/webgl1/oimo/balls/index.html
+++ b/examples/webgl1/oimo/balls/index.html
@@ -42,6 +42,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/oimo/balls/index.js
+++ b/examples/webgl1/oimo/balls/index.js
@@ -34,6 +34,35 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [], idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            const c = Math.cos(a), s = Math.sin(a);
+            if (ring === 0) verts.push(c, s, 0);
+            else if (ring === 1) verts.push(c, 0, s);
+            else verts.push(0, c, s);
+        }
+        for (let i = 0; i < SEG; i++) idx.push(base + i, base + (i + 1) % SEG);
+    }
+    return { verts: new Float32Array(verts), indices: new Uint16Array(idx) };
+}
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -365,6 +394,36 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, model);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(model, quat.create(), wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of balls) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(model,
+            quat.fromValues(q.x, q.y, q.z, q.w),
+            [p.x, p.y, p.z],
+            [item.radius, item.radius, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -420,6 +479,31 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    const sphData = buildSphereWire();
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, sphData.verts, gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphData.indices, gl.STATIC_DRAW);
+    sphWireCount = sphData.indices.length;
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl1/oimo/box/index.html
+++ b/examples/webgl1/oimo/box/index.html
@@ -42,6 +42,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -43,6 +43,18 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -367,6 +379,28 @@ function render(timeMs) {
         drawMesh(cubeMesh, whiteTexture, item.tint, model);
     }
 
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, model);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of boxes) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(model,
+            quat.fromValues(q.x, q.y, q.z, q.w),
+            [p.x, p.y, p.z],
+            [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -419,6 +453,23 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl1/oimo/cone/index.html
+++ b/examples/webgl1/oimo/cone/index.html
@@ -42,6 +42,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/oimo/cone/index.js
+++ b/examples/webgl1/oimo/cone/index.js
@@ -25,6 +25,38 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB, cylWireVB, cylWireIB, cylWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
+function buildCylWire() {
+    const SEG = 16;
+    const verts = [], idx = [];
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        verts.push(Math.cos(a), -0.5, Math.sin(a));
+    }
+    for (let i = 0; i < SEG; i++) idx.push(i, (i + 1) % SEG);
+    for (let i = 0; i < SEG; i++) {
+        const a = (i / SEG) * Math.PI * 2;
+        verts.push(Math.cos(a), 0.5, Math.sin(a));
+    }
+    for (let i = 0; i < SEG; i++) idx.push(SEG + i, SEG + (i + 1) % SEG);
+    for (let i = 0; i < 4; i++) {
+        const j = Math.floor(i * SEG / 4);
+        idx.push(j, SEG + j);
+    }
+    return { verts: new Float32Array(verts), indices: new Uint16Array(idx) };
+}
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -334,6 +366,36 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, model);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(model, quat.create(), wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, cylWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of cones) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(model,
+            quat.fromValues(q.x, q.y, q.z, q.w),
+            [p.x, p.y, p.z],
+            [item.radius, item.height, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -377,6 +439,31 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    const cylData = buildCylWire();
+    cylWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, cylData.verts, gl.STATIC_DRAW);
+    cylWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, cylWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, cylData.indices, gl.STATIC_DRAW);
+    cylWireCount = cylData.indices.length;
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl1/oimo/domino/index.html
+++ b/examples/webgl1/oimo/domino/index.html
@@ -59,6 +59,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/oimo/domino/index.js
+++ b/examples/webgl1/oimo/domino/index.js
@@ -56,6 +56,19 @@ let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
 gl.clearColor(0.05, 0.05, 0.1, 1.0);
 gl.enable(gl.DEPTH_TEST);
+let dominoIBO, dominoPosVBO;
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let lineVP = mat4.create();
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
 gl.depthFunc(gl.LEQUAL);
 let ext = gl.getExtension("ANGLE_instanced_arrays");
 
@@ -121,13 +134,16 @@ let indeces = new Int16Array([
     12, 15, 14, 12, 14, 13,
     16, 17, 18, 16, 18, 19,
     20, 23, 22, 20, 22, 21 ]);
-gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, gl.createBuffer());
+dominoIBO = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, dominoIBO);
 gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indeces, gl.STATIC_DRAW);
 let indexCount = indeces.length;
 
 let idx = 0;
 for (let i = 0; i < 2; i++) {
-    gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+    let buf = gl.createBuffer();
+    if (i === 0) dominoPosVBO = buf;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.bufferData(gl.ARRAY_BUFFER, [position, normal][i], gl.STATIC_DRAW);
     gl.enableVertexAttribArray(idx);
     gl.vertexAttribPointer(idx, [3, 3][i], gl.FLOAT, false, 0, 0);
@@ -207,6 +223,38 @@ for ( let i = 0; i < number; i++ ) {
 gl.bindBuffer(gl.ARRAY_BUFFER, colBuffer);
 gl.bufferData(gl.ARRAY_BUFFER, colArray, gl.STATIC_DRAW);
 
+(function() {
+    let viewMat = mat4.create();
+    mat4.lookAt(viewMat, [60.0, 50.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
+    mat4.multiply(lineVP, perspective(45, c.width / c.height, 0.1, 200), viewMat);
+})();
+lineProgram = gl.createProgram();
+(function() {
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(p1);
+gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);
+gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, dominoIBO);
+
 let data2buf = function () {
     let pIdx = 0;
     let qIdx = 0;
@@ -258,7 +306,32 @@ let fps0 = 0;
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     gl.useProgram(p1);
     ext.drawElementsInstancedANGLE(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, number);
-    
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, lineVP);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    let wm = mat4.create();
+    let gp = ground.getPosition();
+    mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [100, 0.2, 100]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (let i = 0; i < number; i++) {
+        let q = quat.fromValues(quatArray[i*4], quatArray[i*4+1], quatArray[i*4+2], quatArray[i*4+3]);
+        mat4.fromRotationTranslationScale(wm, q,
+            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [2, 4, 0.6]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.useProgram(p1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, dominoIBO);
+
     requestAnimationFrame(arguments.callee);
 })();
  

--- a/examples/webgl1/oimo/eraser/index.html
+++ b/examples/webgl1/oimo/eraser/index.html
@@ -78,6 +78,22 @@ void main()
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -4,6 +4,19 @@ let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
 gl.clearColor(0.7, 0.7, 0.7, 1.0);
 gl.enable(gl.DEPTH_TEST);
+let eraserIBO, eraserPosVBO;
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let lineVP = mat4.create();
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
 gl.depthFunc(gl.LEQUAL);
 let ext = gl.getExtension("ANGLE_instanced_arrays");
 
@@ -139,14 +152,17 @@ let indeces = new Int16Array([
     12, 15, 14, 12, 14, 13,
     16, 17, 18, 16, 18, 19,
     20, 23, 22, 20, 22, 21 ]);
-gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, gl.createBuffer());
+eraserIBO = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, eraserIBO);
 gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indeces, gl.STATIC_DRAW);
 let indexCount = indeces.length;
 
 let strides = [3, 3, 2];
 let vertices = [position, normal, textureCoords];
 for (let i = 0; i < strides.length; i++) {
-    gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+    let buf = gl.createBuffer();
+    if (i === 0) eraserPosVBO = buf;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.bufferData(gl.ARRAY_BUFFER, vertices[i], gl.STATIC_DRAW);
     gl.vertexAttribPointer(i, strides[i], gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(i);
@@ -187,6 +203,38 @@ img.onload = function(){
 img.src = "../../../../assets/textures/eraser_001/eraser.png";
 
 // physics
+(function() {
+    let viewMat = mat4.create();
+    mat4.lookAt(viewMat, [0.0, 0.0, 40.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
+    mat4.multiply(lineVP, perspective(45, c.width / c.height, 0.1, 1000.0), viewMat);
+})();
+lineProgram = gl.createProgram();
+(function() {
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(p1);
+gl.bindBuffer(gl.ARRAY_BUFFER, eraserPosVBO);
+gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, eraserIBO);
+
 let world = new OIMO.World();
 world.gravity = new OIMO.Vec3(0, -0.98, 0);
 
@@ -264,8 +312,32 @@ animate();
 (function () {
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     gl.useProgram(p1);
-    //gl.drawElementsInstanced(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, max);
     ext.drawElementsInstancedANGLE(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, max);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, lineVP);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    let wm = mat4.create();
+    let gp = ground.getPosition();
+    mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [13, 0.1, 13]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (let i = 0; i < max; i++) {
+        let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
+        mat4.fromRotationTranslationScale(wm, q,
+            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [2, 0.4, 1]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.useProgram(p1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, eraserPosVBO);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, eraserIBO);
 
     requestAnimationFrame(arguments.callee);
 })();

--- a/examples/webgl1/oimo/football/index.html
+++ b/examples/webgl1/oimo/football/index.html
@@ -42,6 +42,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -47,6 +47,35 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [], idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            const c = Math.cos(a), s = Math.sin(a);
+            if (ring === 0) verts.push(c, s, 0);
+            else if (ring === 1) verts.push(c, 0, s);
+            else verts.push(0, c, s);
+        }
+        for (let i = 0; i < SEG; i++) idx.push(base + i, base + (i + 1) % SEG);
+    }
+    return { verts: new Float32Array(verts), indices: new Uint16Array(idx) };
+}
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -385,6 +414,31 @@ function render(timeMs) {
         drawMesh(sphereMesh, textures[item.textureIndex], item.tint, model);
     }
 
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, model);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of balls) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(model,
+            quat.fromValues(q.x, q.y, q.z, q.w),
+            [p.x, p.y, p.z],
+            [item.radius, item.radius, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, model);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -442,6 +496,31 @@ async function main() {
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    const sphData = buildSphereWire();
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, sphData.verts, gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphData.indices, gl.STATIC_DRAW);
+    sphWireCount = sphData.indices.length;
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl1/oimo/marbles/index.html
+++ b/examples/webgl1/oimo/marbles/index.html
@@ -239,6 +239,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl1/oimo/marbles/index.js
+++ b/examples/webgl1/oimo/marbles/index.js
@@ -31,6 +31,35 @@ let groundMesh;
 let groundTexture;
 let envCubeTexture = null;
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [], idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            const c = Math.cos(a), s = Math.sin(a);
+            if (ring === 0) verts.push(c, s, 0);
+            else if (ring === 1) verts.push(c, 0, s);
+            else verts.push(0, c, s);
+        }
+        for (let i = 0; i < SEG; i++) idx.push(base + i, base + (i + 1) % SEG);
+    }
+    return { verts: new Float32Array(verts), indices: new Uint16Array(idx) };
+}
+
 function rand(min, max) {
     return min + Math.random() * (max - min);
 }
@@ -934,6 +963,35 @@ function render(timeMs) {
     drawGround();
     drawMarbles();
 
+    const groundPos = [0, -5, 0];
+    const groundSize = [80, 4, 80];
+    const lineModel = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(lineModel, [0,0,0,1], groundPos, groundSize);
+    gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const marble of marbles) {
+        const p = marble.body.getPosition();
+        const q = marble.body.getQuaternion();
+        const r = marble.radius * 2;
+        mat4.fromRotationTranslationScale(lineModel,
+            quat.fromValues(q.x, q.y, q.z, q.w),
+            [p.x, p.y, p.z],
+            [r, r, r]);
+        gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -1002,6 +1060,29 @@ async function main() {
 
     const templates = await loadMarbleTemplates();
     initPhysics(templates);
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    const sphData = buildSphereWire();
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, sphData.verts, gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, sphData.indices, gl.STATIC_DRAW);
+    sphWireCount = sphData.indices.length;
 
     requestAnimationFrame(render);
 

--- a/examples/webgl1/oimo/minimum/index.html
+++ b/examples/webgl1/oimo/minimum/index.html
@@ -33,6 +33,22 @@ void main()
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/oimo/minimum/index.js
+++ b/examples/webgl1/oimo/minimum/index.js
@@ -2,6 +2,18 @@
 let c, gl;
 let aLoc = [];
 let uLoc = [];
+let mainProgram;
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
 
 let mvMatrix;
 let pMatrix;
@@ -75,7 +87,7 @@ function initWorld() {
 }
 
 function initShaders() {
-    let p = gl.createProgram();
+    mainProgram = gl.createProgram();
     let vs = gl.createShader(gl.VERTEX_SHADER);
     let fs = gl.createShader(gl.FRAGMENT_SHADER);
     let v = document.getElementById("vs").textContent;
@@ -84,15 +96,15 @@ function initShaders() {
     gl.shaderSource(fs, f);
     gl.compileShader(vs);
     gl.compileShader(fs);
-    gl.attachShader(p, vs);
-    gl.attachShader(p, fs);
-    gl.linkProgram(p);
-    gl.useProgram(p);
-    aLoc[0] = gl.getAttribLocation(p, "position");
-    aLoc[1] = gl.getAttribLocation(p, "textureCoord");
-    uLoc[0] = gl.getUniformLocation(p, "pjMatrix");
-    uLoc[1] = gl.getUniformLocation(p, "mvMatrix");
-    uLoc[2]  = gl.getUniformLocation(p, "texture");
+    gl.attachShader(mainProgram, vs);
+    gl.attachShader(mainProgram, fs);
+    gl.linkProgram(mainProgram);
+    gl.useProgram(mainProgram);
+    aLoc[0] = gl.getAttribLocation(mainProgram, "position");
+    aLoc[1] = gl.getAttribLocation(mainProgram, "textureCoord");
+    uLoc[0] = gl.getUniformLocation(mainProgram, "pjMatrix");
+    uLoc[1] = gl.getUniformLocation(mainProgram, "mvMatrix");
+    uLoc[2]  = gl.getUniformLocation(mainProgram, "texture");
     gl.enableVertexAttribArray(aLoc[0]);
     gl.enableVertexAttribArray(aLoc[1]);
 }
@@ -295,6 +307,32 @@ function draw() {
 
     gl.drawElements(gl.TRIANGLES, 36, gl.UNSIGNED_SHORT, 0);
 
+    let wm = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, pMatrix);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    let gp = oimoGround.getPosition();
+    let gr = oimoGround.getQuaternion();
+    mat4.fromRotationTranslationScale(wm, quat.fromValues(gr.x, gr.y, gr.z, gr.w), [gp.x, gp.y, gp.z], [4, 0.1, 4]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    let bp = oimoBox.getPosition();
+    let br = oimoBox.getQuaternion();
+    mat4.fromRotationTranslationScale(wm, quat.fromValues(br.x, br.y, br.z, br.w), [bp.x, bp.y, bp.z], [1, 1, 1]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.useProgram(mainProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
+    gl.vertexAttribPointer(aLoc[0], 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, coordBuffer);
+    gl.vertexAttribPointer(aLoc[1], 2, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexIndexBuffer);
+
     gl.flush();
 }
 
@@ -309,4 +347,34 @@ initShaders();
 initBuffers();
 addGround();
 addBox();
+
+lineProgram = gl.createProgram();
+(function() {
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(mainProgram);
+gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
+gl.vertexAttribPointer(aLoc[0], 3, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ARRAY_BUFFER, coordBuffer);
+gl.vertexAttribPointer(aLoc[1], 2, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexIndexBuffer);
+
 animate();

--- a/examples/webgl1/oimo/shogi/index.html
+++ b/examples/webgl1/oimo/shogi/index.html
@@ -93,6 +93,22 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uColor;
+void main() {
+    gl_FragColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl1/oimo/shogi/index.js
+++ b/examples/webgl1/oimo/shogi/index.js
@@ -2,6 +2,18 @@ let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let lineVP = mat4.create();
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
 gl.depthFunc(gl.LEQUAL);
 let ext = gl.getExtension("ANGLE_instanced_arrays");
 
@@ -353,6 +365,34 @@ let data2buf = function () {
 };
 data2buf();
 
+mat4.multiply(lineVP, perspMatrix, vMatrix);
+lineProgram = gl.createProgram();
+(function() {
+    let vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    let fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(p1);
+gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);
+gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
+
 setInterval(function () {
     world.step();
     for (let i = 0; i < max; i++) {
@@ -388,6 +428,31 @@ setInterval(function () {
     gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
     ext.drawElementsInstancedANGLE(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, max);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, lineVP);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    let wm = mat4.create();
+    let gp = ground.getPosition();
+    mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [13, 0.1, 13]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (let i = 0; i < max; i++) {
+        let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
+        mat4.fromRotationTranslationScale(wm, q,
+            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.useProgram(p1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);
+    gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
 
     requestAnimationFrame(render);
 })();

--- a/examples/webgl2/oimo/balls/index.html
+++ b/examples/webgl2/oimo/balls/index.html
@@ -43,6 +43,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/oimo/balls/index.js
+++ b/examples/webgl2/oimo/balls/index.js
@@ -34,6 +34,19 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -216,6 +229,29 @@ function createSolidTexture(r, g, b, a) {
     return texture;
 }
 
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [];
+    const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(idx), gl.STATIC_DRAW);
+    sphWireCount = idx.length;
+}
+
 function initPhysics() {
     world = new OIMO.World({
         timestep: 1 / 60,
@@ -349,6 +385,35 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    gl.bindVertexArray(null);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(wm, quat.create(), wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of balls) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.radius, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -404,6 +469,24 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    buildSphereWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl2/oimo/box/index.html
+++ b/examples/webgl2/oimo/box/index.html
@@ -43,6 +43,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -43,6 +43,18 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -351,6 +363,27 @@ function render(timeMs) {
         drawMesh(cubeMesh, whiteTexture, item.tint, model);
     }
 
+    gl.bindVertexArray(null);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of boxes) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -403,6 +436,23 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl2/oimo/cone/index.html
+++ b/examples/webgl2/oimo/cone/index.html
@@ -43,6 +43,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/oimo/cone/index.js
+++ b/examples/webgl2/oimo/cone/index.js
@@ -25,6 +25,19 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let cylWireVB, cylWireIB, cylWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -207,6 +220,29 @@ function generateConeMesh(segments) {
     };
 }
 
+function buildCylWire() {
+    const SEG = 16;
+    const verts = [];
+    const idx = [];
+    for (let cap = 0; cap < 2; cap++) {
+        const y = cap === 0 ? -0.5 : 0.5;
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            verts.push(Math.cos(a), y, Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    idx.push(0, SEG, SEG / 4, SEG + SEG / 4, SEG / 2, SEG + SEG / 2, 3 * SEG / 4, SEG + 3 * SEG / 4);
+    cylWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    cylWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, cylWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(idx), gl.STATIC_DRAW);
+    cylWireCount = idx.length;
+}
+
 function initPhysics() {
     world = new OIMO.World({
         timestep: 1 / 60,
@@ -318,6 +354,35 @@ function render(timeMs) {
     gl.depthMask(true);
     gl.disable(gl.BLEND);
 
+    gl.bindVertexArray(null);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    for (const wall of basketWalls) {
+        mat4.fromRotationTranslationScale(wm, quat.create(), wall.pos, wall.size);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, cylWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of cones) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.height, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -361,6 +426,24 @@ async function main() {
     whiteTexture = createSolidTexture(255, 255, 255, 255);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    buildCylWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl2/oimo/domino/index.html
+++ b/examples/webgl2/oimo/domino/index.html
@@ -60,6 +60,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/oimo/domino/index.js
+++ b/examples/webgl2/oimo/domino/index.js
@@ -57,6 +57,20 @@ gl.clearColor(0.05, 0.05, 0.1, 1.0);
 gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let dominoPosVBO;
+let lineVP = mat4.create();
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 resizeCanvas();
 window.addEventListener("resize", resizeCanvas);
 
@@ -100,6 +114,11 @@ gl.uniformMatrix4fv(
     false,
     perspective(45, canvas.width / canvas.height, 0.1, 200)
 );
+(function() {
+    let viewMat = mat4.create();
+    mat4.lookAt(viewMat, [60, 50, 0], [0, 0, 0], [0, 1, 0]);
+    mat4.multiply(lineVP, perspective(45, canvas.width / canvas.height, 0.1, 200), viewMat);
+})();
 
 // --- Geometry (box) ---
 let bw = 1, bh = 2, bd = 0.3;
@@ -139,6 +158,7 @@ let aCol      = gl.getAttribLocation(program, 'col');
 // Per-vertex buffers
 for (let i = 0; i < 2; i++) {
     let buf = gl.createBuffer();
+    if (i === 0) dominoPosVBO = buf;
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.bufferData(gl.ARRAY_BUFFER, [position, normal][i], gl.STATIC_DRAW);
     let loc = [aPosition, aNormal][i];
@@ -220,6 +240,33 @@ gl.bufferData(gl.ARRAY_BUFFER, colArray, gl.STATIC_DRAW);
 // Re-bind element array after color setup
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 
+lineProgram = gl.createProgram();
+(function() {
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(program);
+gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);
+gl.vertexAttribPointer(aPosition, 3, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
 function uploadInstanceData() {
     let pIdx = 0, qIdx = 0;
     for (let i = 0; i < number; i++) {
@@ -261,5 +308,29 @@ setInterval(function () {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 
     gl.drawElementsInstanced(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, number);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, lineVP);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    mat4.fromRotationTranslationScale(wm, quat.create(), [0, -0.1, 0], [100, 0.2, 100]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (let i = 0; i < number; i++) {
+        const q = quat.fromValues(quatArray[i*4], quatArray[i*4+1], quatArray[i*4+2], quatArray[i*4+3]);
+        mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [bw*2, bh*2, bd*2]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.useProgram(program);
+    gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);
+    gl.vertexAttribPointer(aPosition, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
     requestAnimationFrame(render);
 })();

--- a/examples/webgl2/oimo/football/index.html
+++ b/examples/webgl2/oimo/football/index.html
@@ -43,6 +43,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -47,6 +47,19 @@ let projection = mat4.create();
 let view = mat4.create();
 let model = mat4.create();
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 function resize() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = Math.floor(window.innerWidth * dpr);
@@ -275,6 +288,29 @@ function getTintColor(code) {
     return colorHash[code] || [1.0, 1.0, 1.0];
 }
 
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [];
+    const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(idx), gl.STATIC_DRAW);
+    sphWireCount = idx.length;
+}
+
 function initPhysics() {
     world = new OIMO.World({
         timestep: 1 / 60,
@@ -369,6 +405,30 @@ function render(timeMs) {
         drawMesh(sphereMesh, textures[item.textureIndex], item.tint, model);
     }
 
+    gl.bindVertexArray(null);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const item of balls) {
+        const p = item.body.getPosition();
+        const q = item.body.getQuaternion();
+        mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.radius, item.radius]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -426,6 +486,24 @@ async function main() {
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE);
 
     initPhysics();
+
+    lineProgram = createProgram(
+        gl,
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    buildSphereWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgl2/oimo/marbles/index.html
+++ b/examples/webgl2/oimo/marbles/index.html
@@ -244,6 +244,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgl2/oimo/marbles/index.js
+++ b/examples/webgl2/oimo/marbles/index.js
@@ -20,6 +20,19 @@ let skyboxVbo;
 let world;
 const marbles = [];
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let sphWireVB, sphWireIB, sphWireCount;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 const projection = mat4.create();
 const view = mat4.create();
 const viewProj = mat4.create();
@@ -658,6 +671,29 @@ async function loadMarbleTemplates() {
     });
 }
 
+function buildSphereWire() {
+    const SEG = 32;
+    const verts = [];
+    const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    sphWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(verts), gl.STATIC_DRAW);
+    sphWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(idx), gl.STATIC_DRAW);
+    sphWireCount = idx.length;
+}
+
 function resetBodyVelocity(body) {
     if (body.linearVelocity && body.linearVelocity.set) {
         body.linearVelocity.set(0, 0, 0);
@@ -702,7 +738,7 @@ function initPhysics(templates) {
             restitution: 0.3
         });
 
-        marbles.push({ body, primitives: template.primitives, scale: template.scale });
+        marbles.push({ body, primitives: template.primitives, scale: template.scale, radius: template.radius });
     }
 }
 
@@ -913,6 +949,31 @@ function render(timeMs) {
     drawGround();
     drawMarbles();
 
+    gl.bindVertexArray(null);
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, viewProj);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const lineModel = mat4.create();
+    mat4.fromRotationTranslationScale(lineModel, quat.create(), [0, -5, 0], [80, 4, 80]);
+    gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (const marble of marbles) {
+        const p = marble.body.getPosition();
+        const q = marble.body.getQuaternion();
+        const r = marble.radius * 2;
+        mat4.fromRotationTranslationScale(lineModel, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [r, r, r]);
+        gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
+        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+    }
+
     requestAnimationFrame(render);
 }
 
@@ -979,6 +1040,22 @@ async function main() {
 
     const templates = await loadMarbleTemplates();
     initPhysics(templates);
+
+    lineProgram = createProgram(
+        document.getElementById('vs-line').textContent,
+        document.getElementById('fs-line').textContent
+    );
+    linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+    lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+    lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+    lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+    boxWireVB = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+    boxWireIB = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+    buildSphereWire();
 
     requestAnimationFrame(render);
 

--- a/examples/webgl2/oimo/minimum/index.html
+++ b/examples/webgl2/oimo/minimum/index.html
@@ -32,6 +32,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/oimo/minimum/index.js
+++ b/examples/webgl2/oimo/minimum/index.js
@@ -2,6 +2,18 @@ let canvas;
 let gl;
 let attributeLocations = [];
 let uniformLocations = [];
+let mainProgram;
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
 
 let modelViewMatrix;
 let projectionMatrix;
@@ -73,20 +85,20 @@ function createShader(type, source) {
 }
 
 function initShaders() {
-    const program = gl.createProgram();
+    mainProgram = gl.createProgram();
     const vertexShader = createShader(gl.VERTEX_SHADER, document.getElementById('vs').textContent);
     const fragmentShader = createShader(gl.FRAGMENT_SHADER, document.getElementById('fs').textContent);
 
-    gl.attachShader(program, vertexShader);
-    gl.attachShader(program, fragmentShader);
-    gl.linkProgram(program);
-    gl.useProgram(program);
+    gl.attachShader(mainProgram, vertexShader);
+    gl.attachShader(mainProgram, fragmentShader);
+    gl.linkProgram(mainProgram);
+    gl.useProgram(mainProgram);
 
-    attributeLocations[0] = gl.getAttribLocation(program, 'position');
-    attributeLocations[1] = gl.getAttribLocation(program, 'textureCoord');
-    uniformLocations[0] = gl.getUniformLocation(program, 'pjMatrix');
-    uniformLocations[1] = gl.getUniformLocation(program, 'mvMatrix');
-    uniformLocations[2] = gl.getUniformLocation(program, 'textureSampler');
+    attributeLocations[0] = gl.getAttribLocation(mainProgram, 'position');
+    attributeLocations[1] = gl.getAttribLocation(mainProgram, 'textureCoord');
+    uniformLocations[0] = gl.getUniformLocation(mainProgram, 'pjMatrix');
+    uniformLocations[1] = gl.getUniformLocation(mainProgram, 'mvMatrix');
+    uniformLocations[2] = gl.getUniformLocation(mainProgram, 'textureSampler');
 
     gl.enableVertexAttribArray(attributeLocations[0]);
     gl.enableVertexAttribArray(attributeLocations[1]);
@@ -241,6 +253,32 @@ function draw() {
     drawBody(groundBody, [4, 0.1, 4]);
     drawBody(boxBody, [1, 1, 1]);
 
+    const wm = mat4.create();
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, projectionMatrix);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const gp = groundBody.getPosition();
+    const gr = groundBody.getQuaternion();
+    mat4.fromRotationTranslationScale(wm, quat.fromValues(gr.x, gr.y, gr.z, gr.w), [gp.x, gp.y, gp.z], [4, 0.1, 4]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    const bp = boxBody.getPosition();
+    const br = boxBody.getQuaternion();
+    mat4.fromRotationTranslationScale(wm, quat.fromValues(br.x, br.y, br.z, br.w), [bp.x, bp.y, bp.z], [1, 1, 1]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.useProgram(mainProgram);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
+    gl.vertexAttribPointer(attributeLocations[0], 3, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, coordBuffer);
+    gl.vertexAttribPointer(attributeLocations[1], 2, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexIndexBuffer);
+
     gl.flush();
 }
 
@@ -255,4 +293,34 @@ initShaders();
 initBuffers();
 addGround();
 addBox();
+
+lineProgram = gl.createProgram();
+(function() {
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(mainProgram);
+gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
+gl.vertexAttribPointer(attributeLocations[0], 3, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ARRAY_BUFFER, coordBuffer);
+gl.vertexAttribPointer(attributeLocations[1], 2, gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexIndexBuffer);
+
 animate();

--- a/examples/webgl2/oimo/shogi/index.html
+++ b/examples/webgl2/oimo/shogi/index.html
@@ -88,6 +88,23 @@ void main() {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+uniform mat4 uViewProj;
+uniform mat4 uModel;
+void main() {
+    gl_Position = uViewProj * uModel * vec4(aPosition, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 uColor;
+out vec4 outColor;
+void main() {
+    outColor = uColor;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgl2/oimo/shogi/index.js
+++ b/examples/webgl2/oimo/shogi/index.js
@@ -15,6 +15,19 @@ function resizeCanvas() {
     gl.viewport(0, 0, c.width, c.height);
 }
 
+let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let boxWireVB, boxWireIB;
+let lineVP = mat4.create();
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([
+    0,1, 1,2, 2,3, 3,0,
+    4,5, 5,6, 6,7, 7,4,
+    0,4, 1,5, 2,6, 3,7
+]);
+
 let p1 = gl.createProgram();
 let type = [gl.VERTEX_SHADER, gl.FRAGMENT_SHADER];
 let src = [vs.text.trim(), fs.text.trim()];
@@ -348,6 +361,34 @@ let data2buf = function () {
 };
 data2buf();
 
+mat4.multiply(lineVP, perspMatrix, vMatrix);
+lineProgram = gl.createProgram();
+(function() {
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, document.getElementById('vs-line').textContent);
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, document.getElementById('fs-line').textContent);
+    gl.compileShader(fs);
+    gl.attachShader(lineProgram, vs);
+    gl.attachShader(lineProgram, fs);
+    gl.linkProgram(lineProgram);
+})();
+linePosLoc = gl.getAttribLocation(lineProgram, 'aPosition');
+lineVPLoc = gl.getUniformLocation(lineProgram, 'uViewProj');
+lineModelLoc = gl.getUniformLocation(lineProgram, 'uModel');
+lineColorLoc = gl.getUniformLocation(lineProgram, 'uColor');
+boxWireVB = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+gl.bufferData(gl.ARRAY_BUFFER, BOX_WIRE_VERTS, gl.STATIC_DRAW);
+boxWireIB = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, BOX_WIRE_INDICES, gl.STATIC_DRAW);
+gl.useProgram(p1);
+gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);
+gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
+
 setInterval(function () {
     world.step();
     for (let i = 0; i < max; i++) {
@@ -383,6 +424,30 @@ setInterval(function () {
     gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
     gl.drawElementsInstanced(gl.TRIANGLES, indexCount, gl.UNSIGNED_SHORT, 0, max);
+
+    gl.useProgram(lineProgram);
+    gl.uniformMatrix4fv(lineVPLoc, false, lineVP);
+    gl.bindBuffer(gl.ARRAY_BUFFER, boxWireVB);
+    gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(linePosLoc);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
+    const wm = mat4.create();
+    const gp = ground.getPosition();
+    mat4.fromRotationTranslationScale(wm, quat.create(), [gp.x, gp.y, gp.z], [13, 0.1, 13]);
+    gl.uniformMatrix4fv(lineModelLoc, false, wm);
+    gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
+    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
+    for (let i = 0; i < max; i++) {
+        const q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
+        mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
+        gl.uniformMatrix4fv(lineModelLoc, false, wm);
+        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    }
+    gl.useProgram(p1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);
+    gl.vertexAttribPointer(0, strides[0], gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, shogiIdxBuf);
 
     requestAnimationFrame(render);
 })();

--- a/examples/webgpu/oimo/balls/index.html
+++ b/examples/webgpu/oimo/balls/index.html
@@ -60,6 +60,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/oimo/balls/index.js
+++ b/examples/webgpu/oimo/balls/index.js
@@ -39,6 +39,37 @@ const view = mat4.create();
 const model = mat4.create();
 const rotationIdentity = quat.create();
 
+let linePipeline, lineVtxBuf, lineIdxBuf, sphWireVB, sphWireIB, sphWireCount, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 185; // 1 ground + 4 walls + 180 balls
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+
+function buildSphereWire() {
+    const SEG = 32; const verts = []; const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vd = new Float32Array(verts);
+    const id = new Uint16Array(idx);
+    sphWireVB = device.createBuffer({ size: vd.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireVB, 0, vd);
+    sphWireIB = device.createBuffer({ size: id.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireIB, 0, id);
+    sphWireCount = idx.length;
+}
+
 function sphericalUV(x, y, z) {
     const len = Math.hypot(x, y, z);
     if (len === 0) return [0.5, 0.5];
@@ -338,6 +369,8 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(model, rotationIdentity, ground.pos, ground.size);
     writeUniforms(staticRenderItems[0].uniformBuffer, [0.22, 0.22, 0.24, 1.0]);
     drawMesh(pass, cubeMesh, staticRenderItems[0].bindGroup);
+    lineUniformData.set(viewProj, 0); lineUniformData.set(model, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
 
     for (let i = 0; i < balls.length; i++) {
         const item = balls[i];
@@ -350,6 +383,9 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotation, tr, s);
         writeUniforms(renderItem.uniformBuffer, [1, 1, 1, 1.0]);
         drawMesh(pass, sphereMesh, renderItem.bindGroup);
+        const base = (5 + i) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
     }
 
     for (let i = 0; i < basketWalls.length; i++) {
@@ -359,6 +395,24 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotationIdentity, wallPos, wall.size);
         writeUniforms(renderItem.uniformBuffer, [0.25, 0.28, 0.3, 0.28]);
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
+        const base = (1 + i) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=0; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, lineVtxBuf);
+    pass.setIndexBuffer(lineIdxBuf, 'uint16');
+    for (let i = 0; i < 5; i++) {
+        pass.setBindGroup(0, lineBG, [i * LINE_ALIGN]);
+        pass.drawIndexed(24);
+    }
+    pass.setVertexBuffer(0, sphWireVB);
+    pass.setIndexBuffer(sphWireIB, 'uint16');
+    for (let i = 0; i < balls.length; i++) {
+        pass.setBindGroup(0, lineBG, [(5 + i) * LINE_ALIGN]);
+        pass.drawIndexed(sphWireCount);
     }
 
     pass.end();
@@ -449,6 +503,31 @@ async function main() {
 
     initPhysics();
     initRenderItems();
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+    buildSphereWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgpu/oimo/box/index.html
+++ b/examples/webgpu/oimo/box/index.html
@@ -60,6 +60,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/oimo/box/index.js
+++ b/examples/webgpu/oimo/box/index.js
@@ -48,6 +48,16 @@ const view = mat4.create();
 const model = mat4.create();
 const rotationIdentity = quat.create();
 
+let linePipeline, lineVtxBuf, lineIdxBuf, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 257;
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+
 function boxUV(x, y, z) {
     const ax = Math.abs(x);
     const ay = Math.abs(y);
@@ -351,6 +361,8 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(model, rotationIdentity, ground.pos, ground.size);
     writeUniforms(groundRenderItem.uniformBuffer, [1.0, 1.0, 1.0, 1.0]);
     drawMesh(pass, groundMesh, groundRenderItem.bindGroup);
+    lineUniformData.set(viewProj, 0); lineUniformData.set(model, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
 
     for (let i = 0; i < boxes.length; i++) {
         const item = boxes[i];
@@ -363,6 +375,20 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotation, tr, s);
         writeUniforms(renderItem.uniformBuffer, [item.tint[0], item.tint[1], item.tint[2], 1.0]);
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
+        const base = (i + 1) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, lineVtxBuf);
+    pass.setIndexBuffer(lineIdxBuf, 'uint16');
+    pass.setBindGroup(0, lineBG, [0]);
+    pass.drawIndexed(24);
+    for (let i = 0; i < boxes.length; i++) {
+        pass.setBindGroup(0, lineBG, [(i + 1) * LINE_ALIGN]);
+        pass.drawIndexed(24);
     }
 
     pass.end();
@@ -452,6 +478,30 @@ async function main() {
 
     initPhysics();
     initRenderItems();
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgpu/oimo/cone/index.html
+++ b/examples/webgpu/oimo/cone/index.html
@@ -60,6 +60,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/oimo/cone/index.js
+++ b/examples/webgpu/oimo/cone/index.js
@@ -31,6 +31,36 @@ const view = mat4.create();
 const model = mat4.create();
 const rotationIdentity = quat.create();
 
+let linePipeline, lineVtxBuf, lineIdxBuf, cylWireVB, cylWireIB, cylWireCount, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 165; // 1 ground + 4 walls + 160 cones
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+
+function buildCylWire() {
+    const SEG = 16; const verts = []; const idx = [];
+    for (let cap = 0; cap < 2; cap++) {
+        const y = cap === 0 ? -0.5 : 0.5; const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            verts.push(Math.cos(a), y, Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    idx.push(0, SEG, SEG/4, SEG+SEG/4, SEG/2, SEG+SEG/2, 3*SEG/4, SEG+3*SEG/4);
+    const vd = new Float32Array(verts);
+    const id = new Uint16Array(idx);
+    cylWireVB = device.createBuffer({ size: vd.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(cylWireVB, 0, vd);
+    cylWireIB = device.createBuffer({ size: id.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(cylWireIB, 0, id);
+    cylWireCount = idx.length;
+}
+
 function generateCubeMesh() {
     const p = [
         -0.5, -0.5, 0.5, 0.5, -0.5, 0.5, 0.5, 0.5, 0.5,
@@ -326,6 +356,8 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(model, rotationIdentity, ground.pos, ground.size);
     writeUniforms(staticRenderItems[0].uniformBuffer, [0.22, 0.22, 0.24, 1.0]);
     drawMesh(pass, cubeMesh, staticRenderItems[0].bindGroup);
+    lineUniformData.set(viewProj, 0); lineUniformData.set(model, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
 
     for (let i = 0; i < cones.length; i++) {
         const item = cones[i];
@@ -338,6 +370,9 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotation, tr, s);
         writeUniforms(renderItem.uniformBuffer, [1, 1, 1, 1.0]);
         drawMesh(pass, coneMesh, renderItem.bindGroup);
+        const base = (5 + i) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
     }
 
     for (let i = 0; i < basketWalls.length; i++) {
@@ -347,6 +382,24 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotationIdentity, wallPos, wall.size);
         writeUniforms(renderItem.uniformBuffer, [0.25, 0.28, 0.3, 0.28]);
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
+        const base = (1 + i) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=0; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, lineVtxBuf);
+    pass.setIndexBuffer(lineIdxBuf, 'uint16');
+    for (let i = 0; i < 5; i++) {
+        pass.setBindGroup(0, lineBG, [i * LINE_ALIGN]);
+        pass.drawIndexed(24);
+    }
+    pass.setVertexBuffer(0, cylWireVB);
+    pass.setIndexBuffer(cylWireIB, 'uint16');
+    for (let i = 0; i < cones.length; i++) {
+        pass.setBindGroup(0, lineBG, [(5 + i) * LINE_ALIGN]);
+        pass.drawIndexed(cylWireCount);
     }
 
     pass.end();
@@ -425,6 +478,31 @@ async function main() {
 
     initPhysics();
     initRenderItems();
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+    buildCylWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgpu/oimo/domino/index.html
+++ b/examples/webgpu/oimo/domino/index.html
@@ -72,6 +72,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/oimo/domino/index.js
+++ b/examples/webgpu/oimo/domino/index.js
@@ -61,6 +61,44 @@ let depthTexture;
 let world, bodys;
 let posArray, quatArray;
 
+let linePipeline, lineVtxBuf, lineIdxBuf, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 257;
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+const lineModelTmp = new Float32Array(16);
+// View matrix for lookAt(60,50,0 -> 0,0,0): column-major
+const DOMINO_VIEW = new Float32Array([
+    0, -0.6401844, 0.7682213, 0,
+    0,  0.7682213, 0.6401844, 0,
+   -1,  0,         0,         0,
+    0,  0,        -78.10247,  1
+]);
+let lineViewProj = new Float32Array(16);
+
+function computeLineViewProj(aspect) {
+    const p = makePerspective(45, aspect, 0.1, 200);
+    for (let c = 0; c < 4; c++)
+        for (let row = 0; row < 4; row++) {
+            let s = 0;
+            for (let k = 0; k < 4; k++) s += p[k*4+row] * DOMINO_VIEW[c*4+k];
+            lineViewProj[c*4+row] = s;
+        }
+}
+
+function makeModelMatrix(out, px, py, pz, qx, qy, qz, qw, sx, sy, sz) {
+    const x2=qx+qx, y2=qy+qy, z2=qz+qz;
+    const xx=qx*x2, xy=qx*y2, xz=qx*z2, yy=qy*y2, yz=qy*z2, zz=qz*z2, wx=qw*x2, wy=qw*y2, wz=qw*z2;
+    out[0]=(1-(yy+zz))*sx; out[1]=(xy+wz)*sx;    out[2]=(xz-wy)*sx;    out[3]=0;
+    out[4]=(xy-wz)*sy;     out[5]=(1-(xx+zz))*sy; out[6]=(yz+wx)*sy;   out[7]=0;
+    out[8]=(xz+wy)*sz;     out[9]=(yz-wx)*sz;    out[10]=(1-(xx+yy))*sz; out[11]=0;
+    out[12]=px; out[13]=py; out[14]=pz; out[15]=1;
+}
+
 async function init() {
     canvas = document.getElementById('c');
     canvas.width  = window.innerWidth;
@@ -73,6 +111,7 @@ async function init() {
         depthTexture = createDepthTexture();
         const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 200);
         device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+        computeLineViewProj(canvas.width / canvas.height);
     });
 
     const gpu = navigator['gpu'];
@@ -141,6 +180,7 @@ async function init() {
     });
     const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 200);
     device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+    computeLineViewProj(canvas.width / canvas.height);
 
     // --- Pipeline ---
     const vModule = device.createShaderModule({ code: document.getElementById('vs').textContent });
@@ -224,6 +264,29 @@ async function init() {
         world.step();
         uploadInstanceData();
     }, 1000 / 60);
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus-stencil8', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
 
     requestAnimationFrame(render);
 }
@@ -320,6 +383,26 @@ function render() {
     passEncoder.setIndexBuffer(indexBuf, 'uint16');
     passEncoder.setBindGroup(0, bindGroup);
     passEncoder.drawIndexed(indexCount, NUMBER, 0, 0, 0);
+
+    makeModelMatrix(lineModelTmp, 0, -0.1, 0, 0, 0, 0, 1, 100, 0.2, 100);
+    lineUniformData.set(lineViewProj, 0); lineUniformData.set(lineModelTmp, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
+    for (let i = 0; i < NUMBER; i++) {
+        const px=posArray[i*3], py=posArray[i*3+1], pz=posArray[i*3+2];
+        const qx=quatArray[i*4], qy=quatArray[i*4+1], qz=quatArray[i*4+2], qw=quatArray[i*4+3];
+        makeModelMatrix(lineModelTmp, px, py, pz, qx, qy, qz, qw, BW*2, BH*2, BD*2);
+        const base = (i + 1) * (LINE_ALIGN / 4);
+        lineUniformData.set(lineViewProj, base); lineUniformData.set(lineModelTmp, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    passEncoder.setPipeline(linePipeline);
+    passEncoder.setVertexBuffer(0, lineVtxBuf);
+    passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
+    for (let i = 0; i < LINE_MAX; i++) {
+        passEncoder.setBindGroup(0, lineBG, [i * LINE_ALIGN]);
+        passEncoder.drawIndexed(24);
+    }
 
     passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);

--- a/examples/webgpu/oimo/football/index.html
+++ b/examples/webgpu/oimo/football/index.html
@@ -60,6 +60,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/oimo/football/index.js
+++ b/examples/webgpu/oimo/football/index.js
@@ -53,6 +53,36 @@ const view = mat4.create();
 const model = mat4.create();
 const rotationIdentity = quat.create();
 
+let linePipeline, lineVtxBuf, lineIdxBuf, sphWireVB, sphWireIB, sphWireCount, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 257; // 1 ground + 256 balls
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+
+function buildSphereWire() {
+    const SEG = 32; const verts = []; const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vd = new Float32Array(verts); const id = new Uint16Array(idx);
+    sphWireVB = device.createBuffer({ size: vd.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireVB, 0, vd);
+    sphWireIB = device.createBuffer({ size: id.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireIB, 0, id);
+    sphWireCount = idx.length;
+}
+
 function sphericalUV(x, y, z) {
     const len = Math.hypot(x, y, z);
     if (len === 0) return [0.5, 0.5];
@@ -370,6 +400,8 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(model, rotationIdentity, ground.pos, ground.size);
     writeUniforms(staticRenderItems[0].uniformBuffer, [1.0, 1.0, 1.0, 1.0]);
     drawMesh(pass, groundMesh, staticRenderItems[0].bindGroup);
+    lineUniformData.set(viewProj, 0); lineUniformData.set(model, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
 
     for (let i = 0; i < balls.length; i++) {
         const item = balls[i];
@@ -382,6 +414,22 @@ function render(timeMs) {
         mat4.fromRotationTranslationScale(model, rotation, tr, s);
         writeUniforms(renderItem.uniformBuffer, [item.tint[0], item.tint[1], item.tint[2], 1.0]);
         drawMesh(pass, sphereMesh, renderItem.bindGroup);
+        const base = (1 + i) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(model, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, lineVtxBuf);
+    pass.setIndexBuffer(lineIdxBuf, 'uint16');
+    pass.setBindGroup(0, lineBG, [0]);
+    pass.drawIndexed(24);
+    pass.setVertexBuffer(0, sphWireVB);
+    pass.setIndexBuffer(sphWireIB, 'uint16');
+    for (let i = 0; i < balls.length; i++) {
+        pass.setBindGroup(0, lineBG, [(1 + i) * LINE_ALIGN]);
+        pass.drawIndexed(sphWireCount);
     }
 
     pass.end();
@@ -478,6 +526,31 @@ async function main() {
 
     initPhysics();
     initRenderItems();
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+    buildSphereWire();
+
     requestAnimationFrame(render);
 }
 

--- a/examples/webgpu/oimo/marbles/index.html
+++ b/examples/webgpu/oimo/marbles/index.html
@@ -278,6 +278,29 @@ fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c"></canvas>
 
 <script type="module" src="index.js"></script>

--- a/examples/webgpu/oimo/marbles/index.js
+++ b/examples/webgpu/oimo/marbles/index.js
@@ -34,6 +34,36 @@ const view = mat4.create();
 const viewProj = mat4.create();
 const viewNoTranslation = mat4.create();
 
+let linePipeline, lineVtxBuf, lineIdxBuf, sphWireVB, sphWireIB, sphWireCount, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 121; // 1 ground + 120 marbles
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+
+function buildSphereWire() {
+    const SEG = 32; const verts = []; const idx = [];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = verts.length / 3;
+        for (let i = 0; i < SEG; i++) {
+            const a = (i / SEG) * Math.PI * 2;
+            if (ring === 0) verts.push(Math.cos(a), Math.sin(a), 0);
+            else if (ring === 1) verts.push(Math.cos(a), 0, Math.sin(a));
+            else verts.push(0, Math.cos(a), Math.sin(a));
+            idx.push(base + i, base + (i + 1) % SEG);
+        }
+    }
+    const vd = new Float32Array(verts); const id = new Uint16Array(idx);
+    sphWireVB = device.createBuffer({ size: vd.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireVB, 0, vd);
+    sphWireIB = device.createBuffer({ size: id.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(sphWireIB, 0, id);
+    sphWireCount = idx.length;
+}
+
 function rand(min, max) {
     return min + Math.random() * (max - min);
 }
@@ -706,7 +736,7 @@ function initPhysics(templates) {
             restitution: 0.3
         });
 
-        marbles.push({ body, primitives: template.primitives, scale: template.scale });
+        marbles.push({ body, primitives: template.primitives, scale: template.scale, radius: template.radius });
     }
 }
 
@@ -819,11 +849,24 @@ function render(timeMs) {
         unlitTextureOnly: 1.0
     });
     drawMesh(pass, groundMesh, groundRenderItem.bindGroup);
+    const lineGroundModel = mat4.create();
+    const lineIdentity = quat.create();
+    mat4.fromRotationTranslationScale(lineGroundModel, lineIdentity, [0, -5, 0], [80, 4, 80]);
+    lineUniformData.set(viewProj, 0); lineUniformData.set(lineGroundModel, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
 
+    let marbleIdx = 0;
     for (const marble of marbles) {
         const p = marble.body.getPosition();
         const q = marble.body.getQuaternion();
         const rotation = quat.fromValues(q.x, q.y, q.z, q.w);
+
+        const lineWireModel = mat4.create();
+        mat4.fromRotationTranslationScale(lineWireModel, rotation, [p.x,p.y,p.z], [marble.radius,marble.radius,marble.radius]);
+        const base = (1 + marbleIdx) * (LINE_ALIGN / 4);
+        lineUniformData.set(viewProj, base); lineUniformData.set(lineWireModel, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+        marbleIdx++;
 
         const model = mat4.create();
         mat4.fromRotationTranslation(model, rotation, [p.x, p.y, p.z]);
@@ -857,6 +900,19 @@ function render(timeMs) {
             marble.body.resetPosition(rand(-5, 5), rand(12, 30), rand(-5, 5));
             resetBodyVelocity(marble.body);
         }
+    }
+
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    pass.setPipeline(linePipeline);
+    pass.setVertexBuffer(0, lineVtxBuf);
+    pass.setIndexBuffer(lineIdxBuf, 'uint16');
+    pass.setBindGroup(0, lineBG, [0]);
+    pass.drawIndexed(24);
+    pass.setVertexBuffer(0, sphWireVB);
+    pass.setIndexBuffer(sphWireIB, 'uint16');
+    for (let i = 0; i < marbles.length; i++) {
+        pass.setBindGroup(0, lineBG, [(1 + i) * LINE_ALIGN]);
+        pass.drawIndexed(sphWireCount);
     }
 
     pass.end();
@@ -1000,6 +1056,30 @@ async function main() {
 
     const templates = await loadMarblesFromGLTF();
     initPhysics(templates);
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+    buildSphereWire();
 
     requestAnimationFrame(render);
 

--- a/examples/webgpu/oimo/minimum/index.html
+++ b/examples/webgpu/oimo/minimum/index.html
@@ -43,6 +43,29 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/oimo/minimum/index.js
+++ b/examples/webgpu/oimo/minimum/index.js
@@ -19,6 +19,15 @@ let world;
 let groundBody;
 let boxBody;
 let angle = 0;
+let format;
+let linePipeline, lineVtxBuf, lineIdxBuf, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * 2);
 
 async function init() {
     canvas = document.getElementById('c');
@@ -39,7 +48,7 @@ async function init() {
 
     // Setup context
     ctx = canvas.getContext('webgpu');
-    const format = gpu.getPreferredCanvasFormat();
+    format = gpu.getPreferredCanvasFormat();
     ctx.configure({
         device: device,
         format: format,
@@ -248,6 +257,30 @@ async function init() {
     addGround();
     addBox();
 
+    // Line pipeline for wireframe debug
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * 2, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus-stencil8', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
+
     // Start render loop
     requestAnimationFrame(render);
 }
@@ -417,6 +450,28 @@ async function render() {
 
         passEncoder.setBindGroup(0, boxBindGroup);
         passEncoder.drawIndexed(indexNum, 1, 0, 0, 0);
+
+        const lineVP = mat4.create();
+        mat4.multiply(lineVP, projectionMatrix, viewMatrix);
+        const gp = groundBody.getPosition(); const gr = groundBody.getQuaternion();
+        const gm = mat4.create();
+        mat4.fromRotationTranslationScale(gm, quat.fromValues(gr.x,gr.y,gr.z,gr.w), [gp.x,gp.y,gp.z], [4,0.1,4]);
+        lineUniformData.set(lineVP, 0); lineUniformData.set(gm, 16);
+        lineUniformData[32] = 0; lineUniformData[33] = 1; lineUniformData[34] = 0; lineUniformData[35] = 1;
+        const bp = boxBody.getPosition(); const bq = boxBody.getQuaternion();
+        const bm = mat4.create();
+        mat4.fromRotationTranslationScale(bm, quat.fromValues(bq.x,bq.y,bq.z,bq.w), [bp.x,bp.y,bp.z], [1,1,1]);
+        const s1 = LINE_ALIGN / 4;
+        lineUniformData.set(lineVP, s1); lineUniformData.set(bm, s1 + 16);
+        lineUniformData[s1+32] = 1; lineUniformData[s1+33] = 1; lineUniformData[s1+34] = 0; lineUniformData[s1+35] = 1;
+        device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+        passEncoder.setPipeline(linePipeline);
+        passEncoder.setVertexBuffer(0, lineVtxBuf);
+        passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
+        passEncoder.setBindGroup(0, lineBG, [0]);
+        passEncoder.drawIndexed(24);
+        passEncoder.setBindGroup(0, lineBG, [LINE_ALIGN]);
+        passEncoder.drawIndexed(24);
 
         passEncoder.end();
         device.queue.submit([commandEncoder.finish()]);

--- a/examples/webgpu/oimo/shogi/index.html
+++ b/examples/webgpu/oimo/shogi/index.html
@@ -93,6 +93,29 @@ fn main() -> @location(0) vec4<f32> {
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@vertex
+fn main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return uniforms.viewProj * uniforms.model * vec4<f32>(pos, 1.0);
+}
+</script>
+<script id="fs-line" type="x-shader/x-fragment">
+struct LineUniforms {
+    viewProj : mat4x4<f32>,
+    model : mat4x4<f32>,
+    color : vec4<f32>
+};
+@group(0) @binding(0) var<uniform> uniforms : LineUniforms;
+@fragment
+fn main() -> @location(0) vec4<f32> { return uniforms.color; }
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
 <script src="index.js"></script>

--- a/examples/webgpu/oimo/shogi/index.js
+++ b/examples/webgpu/oimo/shogi/index.js
@@ -3,7 +3,7 @@ const fragmentShaderWGSL = document.getElementById('fs').textContent;
 const groundVertWGSL     = document.getElementById('gvs').textContent;
 const groundFragWGSL     = document.getElementById('gfs').textContent;
 
-let canvas, device, ctx, pipeline;
+let canvas, device, ctx, format, pipeline;
 let positionBuffer, normalBuffer, texCoordBuffer, indexBuffer, indexNum;
 let offsetBuffer, rotBuffer;
 let uniformBuffer, bindGroup;
@@ -11,6 +11,27 @@ let groundPipeline, groundVBuffer, groundIBuffer, groundMVPBuffer, groundBindGro
 let depthTexture;
 let world, bodies;
 let posArray, rotArray;
+
+let linePipeline, lineVtxBuf, lineIdxBuf, lineUniformBuf, lineBG;
+const LINE_STRUCT_SIZE = 144, LINE_ALIGN = 256;
+const BOX_WIRE_VERTS = new Float32Array([
+    -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
+    -0.5,-0.5, 0.5,  0.5,-0.5, 0.5,  0.5, 0.5, 0.5, -0.5, 0.5, 0.5
+]);
+const BOX_WIRE_INDICES = new Uint16Array([0,1, 1,2, 2,3, 3,0, 4,5, 5,6, 6,7, 7,4, 0,4, 1,5, 2,6, 3,7]);
+const LINE_MAX = 301;
+const lineUniformData = new Float32Array(LINE_ALIGN / 4 * LINE_MAX);
+const lineModelTmp = new Float32Array(16);
+let lineViewProj = new Float32Array(16);
+
+function makeModelMatrix(out, px, py, pz, qx, qy, qz, qw, sx, sy, sz) {
+    const x2=qx+qx, y2=qy+qy, z2=qz+qz;
+    const xx=qx*x2, xy=qx*y2, xz=qx*z2, yy=qy*y2, yz=qy*z2, zz=qz*z2, wx=qw*x2, wy=qw*y2, wz=qw*z2;
+    out[0]=(1-(yy+zz))*sx; out[1]=(xy+wz)*sx;    out[2]=(xz-wy)*sx;    out[3]=0;
+    out[4]=(xy-wz)*sy;     out[5]=(1-(xx+zz))*sy; out[6]=(yz+wx)*sy;   out[7]=0;
+    out[8]=(xz+wy)*sz;     out[9]=(yz-wx)*sz;    out[10]=(1-(xx+yy))*sz; out[11]=0;
+    out[12]=px; out[13]=py; out[14]=pz; out[15]=1;
+}
 
 const MAX = 300;
 const DOT_SIZE = 2;
@@ -30,6 +51,7 @@ async function init() {
         depthTexture = createDepthTexture();
         const pMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
         device.queue.writeBuffer(uniformBuffer, 0, pMatrix);
+        lineViewProj = mat4mul(pMatrix, new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,-40,1]));
     });
 
     const gpu = navigator['gpu'];
@@ -39,7 +61,7 @@ async function init() {
     device = await adapter.requestDevice();
 
     ctx = canvas.getContext('webgpu');
-    const format = gpu.getPreferredCanvasFormat();
+    format = gpu.getPreferredCanvasFormat();
     ctx.configure({ device, format, alphaMode: 'opaque' });
 
     // ---- geometry ----
@@ -304,6 +326,7 @@ async function init() {
     const mMat = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,-10,0,1]);
     const groundMVP = mat4mul(mat4mul(pMatrix, vMat), mMat);
     device.queue.writeBuffer(groundMVPBuffer, 0, groundMVP);
+    lineViewProj = mat4mul(pMatrix, vMat);
 
     depthTexture = createDepthTexture();
 
@@ -346,6 +369,29 @@ async function init() {
         }
         updateInstanceArrays();
     }, 1000 / 200);
+
+    lineVtxBuf = device.createBuffer({ size: BOX_WIRE_VERTS.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineVtxBuf, 0, BOX_WIRE_VERTS);
+    lineIdxBuf = device.createBuffer({ size: BOX_WIRE_INDICES.byteLength, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(lineIdxBuf, 0, BOX_WIRE_INDICES);
+    lineUniformBuf = device.createBuffer({ size: LINE_ALIGN * LINE_MAX, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const lineBGLayout = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'uniform', hasDynamicOffset: true, minBindingSize: LINE_STRUCT_SIZE } }]
+    });
+    linePipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [lineBGLayout] }),
+        vertex: { module: device.createShaderModule({ code: document.getElementById('vs-line').textContent }),
+            entryPoint: 'main', buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }] },
+        fragment: { module: device.createShaderModule({ code: document.getElementById('fs-line').textContent }),
+            entryPoint: 'main', targets: [{ format }] },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus-stencil8', depthWriteEnabled: true, depthCompare: 'less' }
+    });
+    lineBG = device.createBindGroup({
+        layout: lineBGLayout,
+        entries: [{ binding: 0, resource: { buffer: lineUniformBuf, size: LINE_STRUCT_SIZE } }]
+    });
 
     requestAnimationFrame(render);
 }
@@ -481,6 +527,26 @@ function render() {
     passEncoder.setIndexBuffer(indexBuffer, 'uint16');
     passEncoder.setBindGroup(0, bindGroup);
     passEncoder.drawIndexed(indexNum, MAX, 0, 0, 0);
+
+    makeModelMatrix(lineModelTmp, 0, -10, 0, 0, 0, 0, 1, 13, 0.1, 13);
+    lineUniformData.set(lineViewProj, 0); lineUniformData.set(lineModelTmp, 16);
+    lineUniformData[32]=0; lineUniformData[33]=1; lineUniformData[34]=0; lineUniformData[35]=1;
+    for (let i = 0; i < MAX; i++) {
+        const px=posArray[i*3], py=posArray[i*3+1], pz=posArray[i*3+2];
+        const qx=rotArray[i*4], qy=rotArray[i*4+1], qz=rotArray[i*4+2], qw=rotArray[i*4+3];
+        makeModelMatrix(lineModelTmp, px, py, pz, qx, qy, qz, qw, pw*2, ph*2, pd*2);
+        const base = (i + 1) * (LINE_ALIGN / 4);
+        lineUniformData.set(lineViewProj, base); lineUniformData.set(lineModelTmp, base + 16);
+        lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
+    }
+    device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    passEncoder.setPipeline(linePipeline);
+    passEncoder.setVertexBuffer(0, lineVtxBuf);
+    passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
+    for (let i = 0; i < LINE_MAX; i++) {
+        passEncoder.setBindGroup(0, lineBG, [i * LINE_ALIGN]);
+        passEncoder.drawIndexed(24);
+    }
 
     passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);


### PR DESCRIPTION
## Summary

- Add green/yellow physics shape wireframe debug rendering to all 24 Oimo.js samples
- Covers all three renderers: WebGL 1.0 (9 samples), WebGL 2.0 (8 samples), WebGPU (8 samples)
- Green wireframes for static/ground bodies, yellow for dynamic bodies
- Shapes supported: box, sphere, cylinder/cone wireframes

## Implementation details

- WebGL1/WebGL2: line shader with `drawArrays(LINES, ...)` using pre-built edge index arrays
- WebGPU: `topology: 'line-list'` pipeline with dynamic-offset uniform buffers (`LINE_ALIGN=256`)
- Old-style WebGPU files (domino, shogi, minimum): manual CPU-side matrix math for viewProj computation
- ES module WebGPU files (box, balls, cone, football, marbles): use gl-matrix for matrix ops

## Test plan

- [ ] Verify WebGL1 samples show wireframes (minimum, box, balls, cone, football, domino, shogi, marbles, stack)
- [ ] Verify WebGL2 samples show wireframes (same 8 samples)
- [ ] Verify WebGPU samples show wireframes (minimum, box, balls, cone, football, domino, shogi, marbles)
- [ ] Confirm green for ground/static, yellow for dynamic bodies
- [ ] Confirm no regressions in existing physics behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)