### PR TITLE
fix: correct DOT_ROWS row 9 from 17 to 16 characters in box and football

### DIFF
--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -12,7 +12,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -12,7 +12,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -12,7 +12,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -12,7 +12,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgpu/oimo/box/index.js
+++ b/examples/webgpu/oimo/box/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',

--- a/examples/webgpu/oimo/football/index.js
+++ b/examples/webgpu/oimo/football/index.js
@@ -11,7 +11,7 @@ const DOT_ROWS = [
     '....nnppppnnnnr.',
     '......pppppppr..',
     '..rrrrrbrrrbr...',
-    '.rrrrrrrrbrrrb..n',
+    '.rrrrrrrbrrrb..n',
     'pprrrrrrbbbbb..n',
     'ppp.bbrbbybbybnn',
     '.p.nbbbbbbbbbbnn',


### PR DESCRIPTION
## Summary

- Row 9 of `DOT_ROWS` in all box/football samples had 17 characters instead of the intended 16 (the original 16×16 dot art)
- `.rrrrrrrrbrrrb..n` (8 r's) → `.rrrrrrrbrrrb..n` (7 r's)
- This caused a `RangeError: offset is out of bounds` at `Float32Array.set` in WebGPU samples (the pre-allocated line uniform buffer had exactly 257 slots for 1 ground + 256 objects, but 257 objects were created)

## Affected files

12 files across all renderers and physics engines:
- `webgl1/havok/box`, `webgl1/havok/football`
- `webgl1/oimo/box`, `webgl1/oimo/football`
- `webgl2/havok/box`, `webgl2/havok/football`
- `webgl2/oimo/box`, `webgl2/oimo/football`
- `webgpu/havok/box`, `webgpu/havok/football`
- `webgpu/oimo/box`, `webgpu/oimo/football`

## Test plan

- [ ] Verify webgpu/oimo/box no longer throws `RangeError: offset is out of bounds`
- [ ] Verify dot art renders as expected 16×16 pattern in box and football samples
- [ ] Check all 6 renderer/physics combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)