### PR TITLE
fix(oimo/marbles): correct sphere wireframe scale in WebGL1/2

### DIFF
--- a/examples/webgl1/oimo/marbles/index.js
+++ b/examples/webgl1/oimo/marbles/index.js
@@ -983,7 +983,7 @@ function render(timeMs) {
     for (const marble of marbles) {
         const p = marble.body.getPosition();
         const q = marble.body.getQuaternion();
-        const r = marble.radius * 2;
+        const r = marble.radius;
         mat4.fromRotationTranslationScale(lineModel,
             quat.fromValues(q.x, q.y, q.z, q.w),
             [p.x, p.y, p.z],

--- a/examples/webgl2/oimo/marbles/index.js
+++ b/examples/webgl2/oimo/marbles/index.js
@@ -968,7 +968,7 @@ function render(timeMs) {
     for (const marble of marbles) {
         const p = marble.body.getPosition();
         const q = marble.body.getQuaternion();
-        const r = marble.radius * 2;
+        const r = marble.radius;
         mat4.fromRotationTranslationScale(lineModel, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [r, r, r]);
         gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
         gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);


### PR DESCRIPTION
## Summary

- Oimo.js sphere uses `size[0]` as **diameter**, whereas Havok uses radius
- The wireframe in WebGL1/WebGL2 was scaled by `marble.radius * 2` (diameter), causing it to appear twice the size of the actual marble
- Fix: change wireframe scale from `marble.radius * 2` to `marble.radius`
- WebGPU was already using the correct `marble.radius` scale

## Test plan

- [ ] Verify WebGL1 Oimo marbles wireframe matches marble visual size
- [ ] Verify WebGL2 Oimo marbles wireframe matches marble visual size
- [ ] Confirm WebGPU Oimo marbles wireframe is unchanged and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)