### PR TITLE
fix(webgl1/havok/football): apply body orientation to sphere wireframe in debug view

### DIFF
--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -252,7 +252,8 @@ function drawPhysicsDebug() {
     for (let i = 0; i < BALL_COUNT; i++) {
         const posResult = HK.HP_Body_GetPosition(ballBodyIds[i]);
         checkResult(posResult[0], 'HP_Body_GetPosition debug');
-        mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, posResult[1], [0.5, 0.5, 0.5]);
+        const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
+        mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [0.5, 0.5, 0.5]);
         gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
         gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
     }


### PR DESCRIPTION
## Summary

- `drawPhysicsDebug()` was using `IDENTITY_QUATERNION` (a fixed value) for sphere wireframe rendering, causing the wireframe to remain stationary even when the ball rotated
- Fixed by retrieving the actual body orientation via `HP_Body_GetOrientation()`
- WebGL2 and WebGPU variants were already implemented correctly; this fix applies to WebGL1 only

## Test plan

- [ ] Verify that the debug wireframe sphere rotates in sync with the ball rolling in WebGL1 + Havok Falling Football

🤖 Generated with [Claude Code](https://claude.com/claude-code)