### PR TITLE
Add WebGPU WGSL Compute Shader shogi example and fix Havok shogi errors

### DIFF
--- a/examples/webgpu/havok/shogi/index.js
+++ b/examples/webgpu/havok/shogi/index.js
@@ -137,7 +137,7 @@ async function init() {
     window.addEventListener('resize', () => {
         canvas.width  = window.innerWidth;
         canvas.height = window.innerHeight;
-        depthTexture.destroy();
+        if (depthTexture) depthTexture.destroy();
         depthTexture = createDepthTexture();
         currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
         device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
@@ -413,7 +413,7 @@ async function init() {
     const vMat = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,-40,1]);
     // Model matrix = translate(0, -10, 0) in column-major
     const mMat = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,-10,0,1]);
-    const groundMVP = mat4mul(mat4mul(pMatrix, vMat), mMat);
+    const groundMVP = mat4mul(mat4mul(currentPMatrix, vMat), mMat);
     device.queue.writeBuffer(groundMVPBuffer, 0, groundMVP);
 
     depthTexture = createDepthTexture();

--- a/examples/webgpu/wgsl_compute/shogi/index.html
+++ b/examples/webgpu/wgsl_compute/shogi/index.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>WebGPU + WGSL Compute Shader Falling Shogi Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+
+<!-- ================================================================
+  Compute Shader
+  State per piece (16 floats = 4 × vec4<f32>):
+    position  : xyz=pos,    w=seed(uint bits)
+    velocity  : xyz=vel,    w=pad
+    rotation  : xyzw quaternion
+    angularVel: xyz=angVel, w=pad
+================================================================ -->
+<script id="cs" type="x-shader/x-compute">
+struct PieceState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+
+struct SimParams {
+    dt          : f32,
+    gravity     : f32,
+    groundY     : f32,
+    damping     : f32,
+    angDamping  : f32,
+    restitution : f32,
+    friction    : f32,
+    spawnRange  : f32,
+}
+
+const COUNT : u32 = 300u;
+// Half-extents matching SHOGI_PHYSICS_SIZE = [pw, ph*1.2, pd*1.4]
+// pw=1.6, ph=1.6, pd=0.32  →  halves: [0.8, 0.96, 0.224]
+const HW : f32 = 0.80;
+const HH : f32 = 0.96;
+const HD : f32 = 0.224;
+
+@group(0) @binding(0) var<storage, read>       srcStates : array<PieceState>;
+@group(0) @binding(1) var<storage, read_write> dstStates : array<PieceState>;
+@group(0) @binding(2) var<uniform>             params    : SimParams;
+
+fn hash(n : u32) -> u32 {
+    var x = n ^ (n >> 17u);
+    x = x * 0xbf324c81u;
+    x ^= x >> 11u;
+    x = x * 0x68b665e5u;
+    x ^= x >> 16u;
+    return x;
+}
+
+fn hashF(n : u32) -> f32 {
+    return f32(hash(n) & 0xffffffu) * (1.0 / f32(0xffffffu));
+}
+
+fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(
+        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
+        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
+        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z,
+    );
+}
+
+fn rotateQ(q : vec4<f32>, v : vec3<f32>) -> vec3<f32> {
+    let t = 2.0 * cross(q.xyz, v);
+    return v + q.w * t + cross(q.xyz, t);
+}
+
+fn normalizeQ(q : vec4<f32>) -> vec4<f32> {
+    let l = length(q);
+    return select(vec4<f32>(0, 0, 0, 1), q / l, l > 0.0001);
+}
+
+// Build rotation matrix (column-major: axes[0]=local-X, axes[1]=local-Y, axes[2]=local-Z)
+fn quatToAxes(q : vec4<f32>) -> mat3x3<f32> {
+    let x = q.x; let y = q.y; let z = q.z; let w = q.w;
+    return mat3x3<f32>(
+        vec3<f32>(1.0-2.0*(y*y+z*z),   2.0*(x*y+w*z),   2.0*(x*z-w*y)),
+        vec3<f32>(  2.0*(x*y-w*z), 1.0-2.0*(x*x+z*z),   2.0*(y*z+w*x)),
+        vec3<f32>(  2.0*(x*z+w*y),   2.0*(y*z-w*x), 1.0-2.0*(x*x+y*y))
+    );
+}
+
+// Project OBB half-extents onto a unit axis
+fn obbHalfProj(axes : mat3x3<f32>, L : vec3<f32>) -> f32 {
+    return abs(dot(axes[0], L)) * HW
+         + abs(dot(axes[1], L)) * HH
+         + abs(dot(axes[2], L)) * HD;
+}
+
+// SAT penetration along L: positive = overlapping, <=0 = separated
+fn satPen(T : vec3<f32>, axA : mat3x3<f32>, axB : mat3x3<f32>, L : vec3<f32>) -> f32 {
+    let lenSq = dot(L, L);
+    if (lenSq < 1e-8) { return 1e9; }
+    let Ln = L * inverseSqrt(lenSq);
+    return obbHalfProj(axA, Ln) + obbHalfProj(axB, Ln) - abs(dot(T, Ln));
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let i = id.x;
+    if (i >= COUNT) { return; }
+
+    var pos    = srcStates[i].position.xyz;
+    let seedW  = bitcast<u32>(srcStates[i].position.w);
+    var vel    = srcStates[i].velocity.xyz;
+    var rot    = srcStates[i].rotation;
+    var angVel = srcStates[i].angularVel.xyz;
+
+    // Respawn when piece falls out of the play area
+    if (pos.y < -15.0 || abs(pos.x) > 30.0 || abs(pos.z) > 30.0) {
+        let s  = hash(seedW + 1u);
+        pos.x  = (hashF(s)      - 0.5) * params.spawnRange;
+        pos.y  = (hashF(s + 1u) + 1.0) * 15.0;
+        pos.z  = (hashF(s + 2u) - 0.5) * params.spawnRange;
+        // Random tumble on respawn
+        let av = vec3<f32>(
+            (hashF(s + 3u) - 0.5) * 6.0,
+            (hashF(s + 4u) - 0.5) * 2.0,
+            (hashF(s + 5u) - 0.5) * 6.0,
+        );
+        dstStates[i].position   = vec4<f32>(pos, bitcast<f32>(s));
+        dstStates[i].velocity   = vec4<f32>(0.0);
+        dstStates[i].rotation   = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        dstStates[i].angularVel = vec4<f32>(av, 0.0);
+        return;
+    }
+
+    // Gravity
+    vel.y -= params.gravity * params.dt;
+
+    // Integrate position
+    pos += vel * params.dt;
+
+    // Integrate rotation
+    let hw = angVel * 0.5 * params.dt;
+    let dq = quatMul(vec4<f32>(hw, 0.0), rot);
+    rot = normalizeQ(rot + dq);
+
+    // Ground collision: find lowest OBB corner and compute contact torque
+    var minY  = 1e9;
+    var cLocal = vec3<f32>(0.0, -HH, 0.0);  // contact local pos
+    for (var ix = 0; ix < 2; ix++) {
+        for (var iy = 0; iy < 2; iy++) {
+            for (var iz = 0; iz < 2; iz++) {
+                let lx = select(-HW, HW, ix == 1);
+                let ly = select(-HH, HH, iy == 1);
+                let lz = select(-HD, HD, iz == 1);
+                let local = vec3<f32>(lx, ly, lz);
+                let wy = pos.y + rotateQ(rot, local).y;
+                if (wy < minY) {
+                    minY   = wy;
+                    cLocal = local;
+                }
+            }
+        }
+    }
+    if (minY < params.groundY && abs(pos.x) < 6.5 && abs(pos.z) < 6.5) {
+        pos.y += params.groundY - minY;
+        if (vel.y < 0.0) {
+            let r  = rotateQ(rot, cLocal);
+            let jY = -vel.y * (1.0 + params.restitution);
+            // Torque from normal (vertical) impulse
+            angVel += cross(r, vec3<f32>(0.0, jY, 0.0)) * 0.20;
+            // Torque from friction (horizontal velocity removed by ground contact)
+            let dVelF = vec3<f32>(vel.x * (params.friction - 1.0), 0.0, vel.z * (params.friction - 1.0));
+            angVel += cross(r, dVelF) * 0.25;
+
+            vel.y  = -vel.y * params.restitution;
+            vel.x *= params.friction;
+            vel.z *= params.friction;
+        }
+        angVel *= 0.80;
+    }
+
+    // Piece-to-piece OBB collision (SAT)
+    let axA    = quatToAxes(rot);
+    let BSR2   = 6.76; // quick-reject: bounding sphere diameter^2 = (2*1.3)^2
+    for (var j = 0u; j < COUNT; j++) {
+        if (j == i) { continue; }
+        let jPos = srcStates[j].position.xyz;
+        let T    = jPos - pos;
+        if (dot(T, T) > BSR2) { continue; }  // bounding-sphere early exit
+        let axB = quatToAxes(srcStates[j].rotation);
+
+        var minPen  = 1e9;
+        var minAxis = vec3<f32>(1.0, 0.0, 0.0);
+        var sep     = false;
+
+        // A face normals (3)
+        for (var k = 0; k < 3; k++) {
+            if (sep) { break; }
+            let pen = satPen(T, axA, axB, axA[k]);
+            if (pen <= 0.0) { sep = true; break; }
+            if (pen < minPen) { minPen = pen; minAxis = axA[k]; }
+        }
+        // B face normals (3)
+        for (var k = 0; k < 3; k++) {
+            if (sep) { break; }
+            let pen = satPen(T, axA, axB, axB[k]);
+            if (pen <= 0.0) { sep = true; break; }
+            if (pen < minPen) { minPen = pen; minAxis = axB[k]; }
+        }
+        // Edge cross products (9)
+        for (var a = 0; a < 3; a++) {
+            if (sep) { break; }
+            for (var b = 0; b < 3; b++) {
+                if (sep) { break; }
+                let L   = cross(axA[a], axB[b]);
+                let pen = satPen(T, axA, axB, L);
+                if (pen <= 0.0) { sep = true; break; }
+                if (pen < minPen) { minPen = pen; minAxis = L; }
+            }
+        }
+        if (sep) { continue; }
+
+        // Orient push-out normal from j toward i
+        var n = minAxis;
+        if (dot(n, pos - jPos) < 0.0) { n = -n; }
+
+        // Push-out (take half)
+        pos += n * (minPen * 0.5);
+
+        // Contact point on piece i: project direction-toward-j onto i's local axes, clamp to half-extents
+        let cLx = clamp(dot(T, axA[0]), -HW, HW);
+        let cLy = clamp(dot(T, axA[1]), -HH, HH);
+        let cLz = clamp(dot(T, axA[2]), -HD, HD);
+        let r_i = axA[0]*cLx + axA[1]*cLy + axA[2]*cLz;
+
+        let jVel  = srcStates[j].velocity.xyz;
+        let relV  = vel - jVel;
+        let relVn = dot(relV, n);
+        if (relVn < 0.0) {
+            let Jn = -(relVn * (1.0 + 0.2) * 0.5);
+            // Normal impulse: linear + angular
+            vel    += n * Jn;
+            angVel += cross(r_i, n * Jn) * 0.5;
+            // Tangential friction impulse: generates spin when pieces scrape
+            let relVt    = relV - relVn * n;
+            let relVtLen = length(relVt);
+            if (relVtLen > 0.001) {
+                let Jt   = min(0.4 * Jn, relVtLen * 0.5);
+                let tDir = relVt / relVtLen;
+                vel    -= tDir * Jt;
+                angVel += cross(r_i, -tDir * Jt) * 1.5;
+            }
+        }
+    }
+
+    vel    *= params.damping;
+    angVel *= params.angDamping;
+
+    dstStates[i].position   = vec4<f32>(pos, bitcast<f32>(seedW));
+    dstStates[i].velocity   = vec4<f32>(vel, 0.0);
+    dstStates[i].rotation   = rot;
+    dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+}
+</script>
+
+<!-- Vertex shader: instanced shogi pieces with texture (matches Havok layout) -->
+<script id="vs" type="x-shader/x-vertex">
+struct Uniforms {
+    pMatrix : mat4x4<f32>,
+}
+
+struct PieceState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position : vec4<f32>,
+    @location(0) vTextureCoord  : vec2<f32>,
+    @location(1) vColor         : vec3<f32>,
+}
+
+@binding(0) @group(0) var<uniform>       uniforms : Uniforms;
+@binding(3) @group(0) var<storage, read> states   : array<PieceState>;
+
+fn qtransform(q : vec4<f32>, p : vec3<f32>) -> vec3<f32> {
+    return p + 2.0 * cross(cross(p, q.xyz) - q.w * p, q.xyz);
+}
+
+@vertex
+fn main(
+    @location(0) position     : vec3<f32>,
+    @location(1) normal       : vec3<f32>,
+    @location(2) textureCoord : vec2<f32>,
+    @builtin(instance_index) instance : u32,
+) -> VertexOutput {
+    var output : VertexOutput;
+
+    let eye    = vec3<f32>(0.0, 0.0, 40.0);
+    let center = vec3<f32>(0.0, 0.0, 0.0);
+    let up     = vec3<f32>(0.0, 1.0, 0.0);
+
+    let ww = normalize(eye - center);
+    let uu = normalize(cross(up, ww));
+    let vv = normalize(cross(ww, uu));
+    let vMatrix = mat4x4<f32>(
+        uu.x, vv.x, ww.x, 0.0,
+        uu.y, vv.y, ww.y, 0.0,
+        uu.z, vv.z, ww.z, 0.0,
+        -dot(uu, eye), -dot(uu, eye), -dot(ww, eye), 1.0
+    );
+
+    let state  = states[instance];
+    let rot    = state.rotation;
+    let offset = state.position.xyz;
+
+    let nor      = qtransform(rot, normal);
+    let light    = normalize(vec3<f32>(1.0, 1.0, 1.0));
+    let lighting = max(dot(light, (vMatrix * vec4<f32>(nor, 0.0)).xyz), 0.4);
+    output.vColor        = vec3<f32>(lighting);
+    output.vTextureCoord = textureCoord;
+
+    let pos = qtransform(rot, position) + offset;
+    output.position = uniforms.pMatrix * vMatrix * vec4<f32>(pos, 1.0);
+    return output;
+}
+</script>
+
+<script id="fs" type="x-shader/x-fragment">
+@binding(1) @group(0) var mySampler : sampler;
+@binding(2) @group(0) var myTexture : texture_2d<f32>;
+
+@fragment
+fn main(
+    @location(0) vTextureCoord : vec2<f32>,
+    @location(1) vColor        : vec3<f32>,
+) -> @location(0) vec4<f32> {
+    let col = pow(vColor, vec3<f32>(0.6));
+    return textureSample(myTexture, mySampler, vTextureCoord) * vec4<f32>(col, 1.0);
+}
+</script>
+
+<!-- Ground shaders -->
+<script id="gvs" type="x-shader/x-vertex">
+struct GroundUniforms {
+    mvpMatrix : mat4x4<f32>,
+};
+@binding(0) @group(0) var<uniform> groundUniforms : GroundUniforms;
+@vertex
+fn main(@location(0) position : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return groundUniforms.mvpMatrix * vec4<f32>(position, 1.0);
+}
+</script>
+<script id="gfs" type="x-shader/x-fragment">
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.6, 0.6, 0.6, 1.0);
+}
+</script>
+
+<!-- Wireframe debug: OBB box per piece (line-list, 'W' to toggle) -->
+<script id="wvs" type="x-shader/x-vertex">
+struct Uniforms { pMatrix : mat4x4<f32>, }
+struct PieceState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+@binding(0) @group(0) var<uniform>       uniforms : Uniforms;
+@binding(1) @group(0) var<storage, read> states   : array<PieceState>;
+fn qtransform(q : vec4<f32>, p : vec3<f32>) -> vec3<f32> {
+    return p + 2.0 * cross(cross(p, q.xyz) - q.w * p, q.xyz);
+}
+@vertex
+fn main(
+    @location(0) position : vec3<f32>,
+    @builtin(instance_index) instance : u32,
+) -> @builtin(position) vec4<f32> {
+    let eye    = vec3<f32>(0.0, 0.0, 40.0);
+    let center = vec3<f32>(0.0, 0.0,  0.0);
+    let up     = vec3<f32>(0.0, 1.0,  0.0);
+    let ww = normalize(eye - center);
+    let uu = normalize(cross(up, ww));
+    let vv = cross(ww, uu);
+    let vMat = mat4x4<f32>(
+        vec4<f32>(uu.x, vv.x, ww.x, 0.0),
+        vec4<f32>(uu.y, vv.y, ww.y, 0.0),
+        vec4<f32>(uu.z, vv.z, ww.z, 0.0),
+        vec4<f32>(-dot(uu,eye), -dot(vv,eye), -dot(ww,eye), 1.0)
+    );
+    let state    = states[instance];
+    let worldPos = state.position.xyz + qtransform(state.rotation, position);
+    return uniforms.pMatrix * vMat * vec4<f32>(worldPos, 1.0);
+}
+</script>
+<script id="wfs" type="x-shader/x-fragment">
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+
+<canvas id="c" width="465" height="465"></canvas>
+<div id="wireHint" style="position:fixed;top:8px;left:8px;color:#0f0;font:13px monospace;pointer-events:none">W: wireframe ON</div>
+<script src="index.js"></script>
+</body>
+</html>

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -1,0 +1,578 @@
+'use strict';
+
+const computeShaderWGSL  = document.getElementById('cs').textContent;
+const vertexShaderWGSL   = document.getElementById('vs').textContent;
+const fragmentShaderWGSL = document.getElementById('fs').textContent;
+const groundVertWGSL     = document.getElementById('gvs').textContent;
+const groundFragWGSL     = document.getElementById('gfs').textContent;
+const wireVertWGSL       = document.getElementById('wvs').textContent;
+const wireFragWGSL       = document.getElementById('wfs').textContent;
+
+// ------------------------------------------------------------------ constants
+const COUNT       = 300;
+const STATE_FLOATS = 16;   // 4 × vec4<f32>
+const SUBSTEPS    = 4;
+
+// Piece geometry dimensions (identical to Havok version)
+const DOT_SIZE = 2;
+const pw = DOT_SIZE * 0.8 * 1.0;   // 1.6
+const ph = DOT_SIZE * 0.8 * 1.0;   // 1.6
+const pd = DOT_SIZE * 0.8 * 0.2;   // 0.32
+
+// ------------------------------------------------------------------ geometry (identical to Havok version)
+const positions = new Float32Array([
+    // Front face
+    -0.5*pw, -0.5*ph,  0.7*pd,
+     0.5*pw, -0.5*ph,  0.7*pd,
+     0.35*pw, 0.5*ph,  0.4*pd,
+    -0.35*pw, 0.5*ph,  0.4*pd,
+    // Back face
+    -0.5*pw, -0.5*ph, -0.7*pd,
+     0.5*pw, -0.5*ph, -0.7*pd,
+     0.35*pw, 0.5*ph, -0.4*pd,
+    -0.35*pw, 0.5*ph, -0.4*pd,
+    // Top face
+     0.35*pw, 0.5*ph,  0.4*pd,
+    -0.35*pw, 0.5*ph,  0.4*pd,
+    -0.35*pw, 0.5*ph, -0.4*pd,
+     0.35*pw, 0.5*ph, -0.4*pd,
+    // Bottom face
+    -0.5*pw, -0.5*ph,  0.7*pd,
+     0.5*pw, -0.5*ph,  0.7*pd,
+     0.5*pw, -0.5*ph, -0.7*pd,
+    -0.5*pw, -0.5*ph, -0.7*pd,
+    // Right face
+     0.5*pw, -0.5*ph,  0.7*pd,
+     0.35*pw, 0.5*ph,  0.4*pd,
+     0.35*pw, 0.5*ph, -0.4*pd,
+     0.5*pw, -0.5*ph, -0.7*pd,
+    // Left face
+    -0.5*pw, -0.5*ph,  0.7*pd,
+    -0.35*pw, 0.5*ph,  0.4*pd,
+    -0.35*pw, 0.5*ph, -0.4*pd,
+    -0.5*pw, -0.5*ph, -0.7*pd,
+    // Front2 face
+    -0.35*pw, 0.5*ph,  0.4*pd,
+     0.35*pw, 0.5*ph,  0.4*pd,
+     0.0*pw,  0.6*ph,  0.35*pd,
+    // Back2 face
+    -0.35*pw, 0.5*ph, -0.4*pd,
+     0.35*pw, 0.5*ph, -0.4*pd,
+     0.0*pw,  0.6*ph, -0.35*pd,
+    // Right2 face
+     0.35*pw, 0.5*ph,  0.4*pd,
+     0.35*pw, 0.5*ph, -0.4*pd,
+     0.0*pw,  0.6*ph, -0.35*pd,
+     0.0*pw,  0.6*ph,  0.35*pd,
+    // Left2 face
+    -0.35*pw, 0.5*ph,  0.4*pd,
+    -0.35*pw, 0.5*ph, -0.4*pd,
+     0.0*pw,  0.6*ph, -0.35*pd,
+     0.0*pw,  0.6*ph,  0.35*pd
+]);
+
+const normals = new Float32Array([
+    // Front face
+     0,  0.0599,  0.9982,   0,  0.0599,  0.9982,   0,  0.0599,  0.9982,   0,  0.0599,  0.9982,
+    // Back face
+     0, -0.0599, -0.9982,   0, -0.0599, -0.9982,   0, -0.0599, -0.9982,   0, -0.0599, -0.9982,
+    // Top face
+     0,  1,  0,   0,  1,  0,   0,  1,  0,   0,  1,  0,
+    // Bottom face
+     0, -1,  0,   0, -1,  0,   0, -1,  0,   0, -1,  0,
+    // Right face
+     0.9889,  0.1483,  0,   0.9889,  0.1483,  0,   0.9889,  0.1483,  0,   0.9889,  0.1483,  0,
+    // Left face
+    -0.9889,  0.1483,  0,  -0.9889,  0.1483,  0,  -0.9889,  0.1483,  0,  -0.9889,  0.1483,  0,
+    // Front2 face
+     0,  0.0995,  0.995,   0,  0.0995,  0.995,   0,  0.0995,  0.995,
+    // Back2 face
+     0, -0.0995, -0.995,   0, -0.0995, -0.995,   0, -0.0995, -0.995,
+    // Right2 face
+     0.2747,  0.9615,  0,   0.2747,  0.9615,  0,   0.2747,  0.9615,  0,   0.2747,  0.9615,  0,
+    // Left2 face
+    -0.2747,  0.9615,  0,  -0.2747,  0.9615,  0,  -0.2747,  0.9615,  0,  -0.2747,  0.9615,  0
+]);
+
+const texCoords = new Float32Array([
+    // Front face
+    0.5,         0.5,
+    0.75,        0.5,
+    0.75-0.25/8, 1.0,
+    0.5+0.25/8,  1.0,
+    // Back face
+    0.5,         0.5,
+    0.25,        0.5,
+    0.25+0.25/8, 1.0,
+    0.5-0.25/8,  1.0,
+    // Top face
+    0.75, 0.5,
+    0.5,  0.5,
+    0.5,  0.0,
+    0.75, 0.0,
+    // Bottom face
+    0.0,  0.5,
+    0.25, 0.5,
+    0.25, 1.0,
+    0.0,  1.0,
+    // Right face
+    0.0,  0.5,
+    0.0,  0.0,
+    0.25, 0.0,
+    0.25, 0.5,
+    // Left face
+    0.5,  0.5,
+    0.5,  0.0,
+    0.25, 0.0,
+    0.25, 0.5,
+    // Front2 face
+    0.75, 0.0,
+    1.0,  0.0,
+    1.0,  0.5,
+    // Back2 face
+    0.75, 0.0,
+    1.0,  0.0,
+    1.0,  0.5,
+    // Right2 face
+    0.75, 0.0,
+    1.0,  0.0,
+    1.0,  0.5,
+    0.75, 0.5,
+    // Left2 face
+    0.75, 0.0,
+    1.0,  0.0,
+    1.0,  0.5,
+    0.75, 0.5
+]);
+
+const indices = new Uint16Array([
+     0,  1,  2,   0,  2,  3,
+     4,  5,  6,   4,  6,  7,
+     8,  9, 10,   8, 10, 11,
+    12, 13, 14,  12, 14, 15,
+    16, 17, 18,  16, 18, 19,
+    20, 21, 22,  20, 22, 23,
+    24, 25, 26,
+    27, 28, 29,
+    30, 33, 31,  33, 32, 31,
+    34, 35, 36,  34, 36, 37
+]);
+
+// ------------------------------------------------------------------ state init
+function hash32(n) {
+    let x = ((n >>> 0) ^ (n >>> 17)) >>> 0;
+    x = Math.imul(x, 0xbf324c81) >>> 0;
+    x = (x ^ (x >>> 11)) >>> 0;
+    x = Math.imul(x, 0x68b665e5) >>> 0;
+    x = (x ^ (x >>> 16)) >>> 0;
+    return x;
+}
+function hashF(n) { return (hash32(n) & 0xffffff) / 0xffffff; }
+
+function createInitialStates() {
+    const states = new Float32Array(COUNT * STATE_FLOATS);
+    const statesU = new Uint32Array(states.buffer);
+    for (let i = 0; i < COUNT; i++) {
+        const base = i * STATE_FLOATS;
+        const seed = hash32(i + 1);
+        states[base + 0] = (hashF(seed)     - 0.5) * 15;  // x
+        states[base + 1] = (hashF(seed + 1) + 1.0) * 15;  // y (15..30)
+        states[base + 2] = (hashF(seed + 2) - 0.5) * 15;  // z
+        statesU[base + 3] = seed;                          // seed as uint32 bits
+        // rotation: identity (qw=1)
+        states[base + 11] = 1.0;
+        // Initial angular velocity: random tumble so pieces tip on landing
+        states[base + 12] = (hashF(seed + 3) - 0.5) * 6;
+        states[base + 13] = (hashF(seed + 4) - 0.5) * 2;
+        states[base + 14] = (hashF(seed + 5) - 0.5) * 6;
+    }
+    return states;
+}
+
+// ------------------------------------------------------------------ mat4 helpers (matching Havok version)
+function makePerspective(fovy, aspect, near, far) {
+    const top   = near * Math.tan(fovy * Math.PI / 360.0);
+    const right = top * aspect;
+    const u = right * 2, v = top * 2, ww = far - near;
+    return new Float32Array([
+        near*2/u, 0,         0,                  0,
+        0,        near*2/v,  0,                  0,
+        0,        0,        -(far+near)/ww,      -1,
+        0,        0,        -(far*near*2)/ww,     0
+    ]);
+}
+
+function mat4mul(a, b) {
+    const r = new Float32Array(16);
+    for (let c = 0; c < 4; c++)
+        for (let row = 0; row < 4; row++) {
+            let s = 0;
+            for (let k = 0; k < 4; k++) s += a[k*4+row] * b[c*4+k];
+            r[c*4+row] = s;
+        }
+    return r;
+}
+
+// ------------------------------------------------------------------ WebGPU helpers
+let device;
+
+function makeVertexBuffer(data) {
+    const buf = device.createBuffer({ size: data.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+}
+
+function makeIndexBuffer(data) {
+    const buf = device.createBuffer({ size: data.byteLength, usage: GPUBufferUsage.INDEX, mappedAtCreation: true });
+    new Uint16Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+}
+
+async function createTextureFromImage(src) {
+    const img = document.createElement('img');
+    img.src = src;
+    await img.decode();
+    const bitmap = await createImageBitmap(img);
+    const tex = device.createTexture({
+        size: [bitmap.width, bitmap.height, 1],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT
+    });
+    device.queue.copyExternalImageToTexture({ source: bitmap }, { texture: tex }, [bitmap.width, bitmap.height, 1]);
+    return tex;
+}
+
+function createDepthTexture() {
+    return device.createTexture({
+        size: { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+        format: 'depth24plus',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT
+    });
+}
+
+// ------------------------------------------------------------------ globals
+const canvas = document.getElementById('c');
+let ctx, format, depthTexture;
+let positionBuffer, normalBuffer, texCoordBuffer, indexBuffer, indexNum;
+let uniformBuffer, renderBindGroupA, renderBindGroupB, pipeline;
+let groundPipeline, groundVBuffer, groundIBuffer, groundMVPBuffer, groundBindGroup, groundICount;
+let wirePipeline, wireVBuffer, wireIBuffer, wireICount;
+let wireBindGroupA, wireBindGroupB;
+let showWireframe = true;
+let srcBuffer, dstBuffer;
+let computePipeline, computeBindGroupA, computeBindGroupB;
+let simParamsBuffer;
+let currentPMatrix = null;
+let ping = 0;
+
+// ------------------------------------------------------------------ resize
+function resize() {
+    canvas.width  = window.innerWidth;
+    canvas.height = window.innerHeight;
+    if (depthTexture) depthTexture.destroy();
+    depthTexture = createDepthTexture();
+    if (device && uniformBuffer) {
+        currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
+        device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
+    }
+}
+
+// ------------------------------------------------------------------ render loop
+function render() {
+    const encoder = device.createCommandEncoder();
+
+    // --- Compute substeps (ping-pong) ---
+    for (let s = 0; s < SUBSTEPS; s++) {
+        const cp = encoder.beginComputePass();
+        cp.setPipeline(computePipeline);
+        cp.setBindGroup(0, ping === 0 ? computeBindGroupA : computeBindGroupB);
+        cp.dispatchWorkgroups(Math.ceil(COUNT / 64));
+        cp.end();
+        ping ^= 1;
+    }
+
+    // After SUBSTEPS (even number) ping is back to 0: latest state is in srcBuffer
+    // renderBindGroupA reads srcBuffer, renderBindGroupB reads dstBuffer
+    const renderBG = (ping === 0) ? renderBindGroupA : renderBindGroupB;
+
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view:       ctx.getCurrentTexture().createView(),
+            loadOp:     'clear',
+            clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+            storeOp:    'store',
+        }],
+        depthStencilAttachment: {
+            view:            depthTexture.createView(),
+            depthClearValue: 1.0,
+            depthLoadOp:     'clear',
+            depthStoreOp:    'store',
+        }
+    });
+
+    // Draw ground
+    pass.setPipeline(groundPipeline);
+    pass.setVertexBuffer(0, groundVBuffer);
+    pass.setIndexBuffer(groundIBuffer, 'uint16');
+    pass.setBindGroup(0, groundBindGroup);
+    pass.drawIndexed(groundICount, 1, 0, 0, 0);
+
+    // Draw shogi pieces
+    pass.setPipeline(pipeline);
+    pass.setVertexBuffer(0, positionBuffer);
+    pass.setVertexBuffer(1, normalBuffer);
+    pass.setVertexBuffer(2, texCoordBuffer);
+    pass.setBindGroup(0, renderBG);
+    pass.setIndexBuffer(indexBuffer, 'uint16');
+    pass.drawIndexed(indexNum, COUNT, 0, 0, 0);
+
+    // Wireframe OBB debug
+    if (showWireframe) {
+        const wireBG = (ping === 0) ? wireBindGroupA : wireBindGroupB;
+        pass.setPipeline(wirePipeline);
+        pass.setVertexBuffer(0, wireVBuffer);
+        pass.setIndexBuffer(wireIBuffer, 'uint16');
+        pass.setBindGroup(0, wireBG);
+        pass.drawIndexed(wireICount, COUNT, 0, 0, 0);
+    }
+
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+    requestAnimationFrame(render);
+}
+
+// ------------------------------------------------------------------ init
+async function init() {
+    const gpu = navigator.gpu;
+    if (!gpu) { alert('WebGPU is not supported.'); return; }
+    const adapter = await gpu.requestAdapter();
+    if (!adapter) { alert('Failed to get GPU adapter.'); return; }
+    device = await adapter.requestDevice();
+
+    ctx    = canvas.getContext('webgpu');
+    format = gpu.getPreferredCanvasFormat();
+    ctx.configure({ device, format, alphaMode: 'opaque' });
+
+    canvas.width  = window.innerWidth;
+    canvas.height = window.innerHeight;
+    window.addEventListener('resize', resize);
+
+    // --- Geometry ---
+    positionBuffer = makeVertexBuffer(positions);
+    normalBuffer   = makeVertexBuffer(normals);
+    texCoordBuffer = makeVertexBuffer(texCoords);
+    indexBuffer    = makeIndexBuffer(indices);
+    indexNum       = indices.length;
+
+    // --- Uniform: perspective matrix ---
+    uniformBuffer  = device.createBuffer({ size: 64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
+    device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
+
+    // --- Texture ---
+    const shogiTexture = await createTextureFromImage('../../../../assets/textures/shogi_001/shogi.png');
+    const sampler = device.createSampler({ magFilter: 'linear', minFilter: 'linear' });
+
+    // --- Render pipeline ---
+    pipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: vertexShaderWGSL }),
+            entryPoint: 'main',
+            buffers: [
+                { arrayStride: 3*4, stepMode: 'vertex',   attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 3*4, stepMode: 'vertex',   attributes: [{ shaderLocation: 1, offset: 0, format: 'float32x3' }] },
+                { arrayStride: 2*4, stepMode: 'vertex',   attributes: [{ shaderLocation: 2, offset: 0, format: 'float32x2' }] },
+            ]
+        },
+        fragment: {
+            module: device.createShaderModule({ code: fragmentShaderWGSL }),
+            entryPoint: 'main',
+            targets: [{ format }]
+        },
+        primitive:    { topology: 'triangle-list' },
+        depthStencil: { depthWriteEnabled: true, depthCompare: 'less', format: 'depth24plus' }
+    });
+
+    // State buffers (ping-pong)
+    simParamsBuffer = device.createBuffer({ size: 32, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+
+    const stateBufSize = COUNT * STATE_FLOATS * 4;
+    srcBuffer = device.createBuffer({
+        size: stateBufSize,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        mappedAtCreation: true,
+    });
+    new Float32Array(srcBuffer.getMappedRange()).set(createInitialStates());
+    srcBuffer.unmap();
+
+    dstBuffer = device.createBuffer({
+        size: stateBufSize,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+
+    // Render bind groups: A reads srcBuffer, B reads dstBuffer
+    const textureView = shogiTexture.createView();
+    function makeRenderBG(stateBuf) {
+        return device.createBindGroup({
+            layout: pipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: uniformBuffer } },
+                { binding: 1, resource: sampler },
+                { binding: 2, resource: textureView },
+                { binding: 3, resource: { buffer: stateBuf } },
+            ]
+        });
+    }
+    renderBindGroupA = makeRenderBG(srcBuffer);
+    renderBindGroupB = makeRenderBG(dstBuffer);
+
+    computePipeline = device.createComputePipeline({
+        layout: 'auto',
+        compute: { module: device.createShaderModule({ code: computeShaderWGSL }), entryPoint: 'main' }
+    });
+
+    // Sim params: dt, gravity, groundY (top of floor = -10+0.1), damping, angDamping, restitution, friction, spawnRange
+    device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([
+        1 / (60 * SUBSTEPS),  // dt per substep (placeholder, fixed at 60fps)
+        9.8,                  // gravity
+        -9.9,                 // groundY  (floor top surface)
+        0.9992,               // linear damping
+        0.992,                // angular damping
+        0.35,                 // restitution
+        0.82,                 // friction
+        15.0,                 // spawnRange (x/z)
+    ]));
+
+    computeBindGroupA = device.createBindGroup({
+        layout: computePipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: srcBuffer } },
+            { binding: 1, resource: { buffer: dstBuffer } },
+            { binding: 2, resource: { buffer: simParamsBuffer } },
+        ],
+    });
+    computeBindGroupB = device.createBindGroup({
+        layout: computePipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: dstBuffer } },
+            { binding: 1, resource: { buffer: srcBuffer } },
+            { binding: 2, resource: { buffer: simParamsBuffer } },
+        ],
+    });
+
+    // --- Ground geometry (same as Havok) ---
+    const groundPositions = new Float32Array([
+        -6.5,  0.05, -6.5,  6.5,  0.05, -6.5,  6.5,  0.05,  6.5, -6.5,  0.05,  6.5,
+        -6.5, -0.05, -6.5,  6.5, -0.05, -6.5,  6.5, -0.05,  6.5, -6.5, -0.05,  6.5,
+        -6.5, -0.05,  6.5,  6.5, -0.05,  6.5,  6.5,  0.05,  6.5, -6.5,  0.05,  6.5,
+        -6.5, -0.05, -6.5,  6.5, -0.05, -6.5,  6.5,  0.05, -6.5, -6.5,  0.05, -6.5,
+         6.5, -0.05, -6.5,  6.5, -0.05,  6.5,  6.5,  0.05,  6.5,  6.5,  0.05, -6.5,
+        -6.5, -0.05, -6.5, -6.5, -0.05,  6.5, -6.5,  0.05,  6.5, -6.5,  0.05, -6.5
+    ]);
+    const groundIdx = new Uint16Array([
+         0, 1, 2,  0, 2, 3,
+         4, 7, 6,  4, 6, 5,
+         8, 9,10,  8,10,11,
+        12,15,14, 12,14,13,
+        16,17,18, 16,18,19,
+        20,23,22, 20,22,21
+    ]);
+    groundICount  = groundIdx.length;
+    groundVBuffer = makeVertexBuffer(groundPositions);
+    groundIBuffer = makeIndexBuffer(groundIdx);
+
+    groundMVPBuffer = device.createBuffer({ size: 64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    const gvPipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: groundVertWGSL }),
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 3*4, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: { module: device.createShaderModule({ code: groundFragWGSL }), entryPoint: 'main', targets: [{ format }] },
+        primitive:    { topology: 'triangle-list' },
+        depthStencil: { depthWriteEnabled: true, depthCompare: 'less', format: 'depth24plus' }
+    });
+    groundPipeline = gvPipeline;
+    groundBindGroup = device.createBindGroup({
+        layout: groundPipeline.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer: groundMVPBuffer } }]
+    });
+
+    // Ground MVP (static: camera at [0,0,40], ground at y=-10)
+    const vMat = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,-40,1]);
+    const mMat = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,-10,0,1]);
+    const groundMVP = mat4mul(mat4mul(currentPMatrix, vMat), mMat);
+    device.queue.writeBuffer(groundMVPBuffer, 0, groundMVP);
+
+    depthTexture = createDepthTexture();
+
+    // --- Wireframe OBB geometry ---
+    // HW=0.80, HH=0.96, HD=0.224 (matches compute shader constants)
+    const WH = 0.80, WV = 0.96, WD = 0.224;
+    const wirePos = new Float32Array([
+        -WH, -WV, -WD,   // 0
+         WH, -WV, -WD,   // 1
+         WH,  WV, -WD,   // 2
+        -WH,  WV, -WD,   // 3
+        -WH, -WV,  WD,   // 4
+         WH, -WV,  WD,   // 5
+         WH,  WV,  WD,   // 6
+        -WH,  WV,  WD,   // 7
+    ]);
+    const wireIdx = new Uint16Array([
+        0,1, 1,2, 2,3, 3,0,  // back face
+        4,5, 5,6, 6,7, 7,4,  // front face
+        0,4, 1,5, 2,6, 3,7   // connecting edges
+    ]);
+    wireICount  = wireIdx.length;
+    wireVBuffer = makeVertexBuffer(wirePos);
+    wireIBuffer = makeIndexBuffer(wireIdx);
+
+    wirePipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module:      device.createShaderModule({ code: wireVertWGSL }),
+            entryPoint:  'main',
+            buffers: [{ arrayStride: 3*4, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }]
+        },
+        fragment: {
+            module:     device.createShaderModule({ code: wireFragWGSL }),
+            entryPoint: 'main',
+            targets:    [{ format }]
+        },
+        primitive:    { topology: 'line-list' },
+        depthStencil: { depthWriteEnabled: false, depthCompare: 'less-equal', format: 'depth24plus' }
+    });
+    const wireBGL = wirePipeline.getBindGroupLayout(0);
+    wireBindGroupA = device.createBindGroup({
+        layout: wireBGL,
+        entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: { buffer: srcBuffer } }
+        ]
+    });
+    wireBindGroupB = device.createBindGroup({
+        layout: wireBGL,
+        entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: { buffer: dstBuffer } }
+        ]
+    });
+
+    // Toggle wireframe with W key
+    window.addEventListener('keydown', e => {
+        if (e.key === 'w' || e.key === 'W') {
+            showWireframe = !showWireframe;
+            document.getElementById('wireHint').textContent =
+                'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        }
+    });
+
+    requestAnimationFrame(render);
+}
+
+init().catch(err => { console.error(err); alert(err.message); });

--- a/examples/webgpu/wgsl_compute/shogi/style.css
+++ b/examples/webgpu/wgsl_compute/shogi/style.css
@@ -1,0 +1,13 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  background: #000;
+  font: 30px sans-serif;
+}


### PR DESCRIPTION
## Changes

### New: `examples/webgpu/wgsl_compute/shogi/`
WebGPU + WGSL Compute Shader falling shogi piece simulation without a physics library.

**Physics (compute shader):**
- Ping-pong storage buffers for parallel state update
- OBB ground collision with contact-point torque and friction spin
- OBB SAT piece-to-piece collision (15-axis separating axis test) with angular impulse and tangential friction
- Respawn when piece falls below y=-15 or drifts outside ±30 on x/z

**Rendering:**
- Instanced draw of textured pentagonal shogi piece geometry (identical to Havok version)
- Wireframe OBB debug overlay toggle with `W` key (default: ON)

### Fix: `examples/webgpu/havok/shogi/index.js`
- Fix `ReferenceError`: `pMatrix` → `currentPMatrix` in ground MVP calculation
- Fix `TypeError`: add null guard before `depthTexture.destroy()` in resize handler