### PR TITLE
feat: increase WebGPU WGSL coin count

### DIFF
--- a/examples/webgpu/wgsl_compute/coins/index.html
+++ b/examples/webgpu/wgsl_compute/coins/index.html
@@ -31,8 +31,8 @@ struct SimParams {
     spawnRange  : f32,
 }
 
-const COIN_CAPACITY : u32 = 300u;
-const GROUND_HALF : f32 = 6.5;
+const COIN_CAPACITY : u32 = 2048u;
+const GROUND_HALF : f32 = 13.0;
 const PHYSICS_THICKNESS_SCALE : f32 = 1.0;
 
 @group(0) @binding(0) var<storage, read> srcStates : array<CoinState>;
@@ -290,7 +290,7 @@ struct VSOut {
     @location(6) worldPosition : vec3<f32>,
 }
 
-const COIN_CAPACITY : u32 = 300u;
+const COIN_CAPACITY : u32 = 2048u;
 
 @group(0) @binding(0) var<uniform> camera : Camera;
 @group(0) @binding(1) var<storage, read> states : array<CoinState>;
@@ -481,7 +481,7 @@ fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
-<div id="wireHint" style="position:fixed;top:8px;left:8px;color:#9f9;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">W: collider wireframe OFF</div>
+<div id="wireHint">W: collider wireframe OFF</div>
 <canvas id="c"></canvas>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -9,7 +9,7 @@ const wireFragmentShaderWGSL = document.getElementById('wfs').textContent;
 const canvas = document.getElementById('c');
 
 const ENV_HDR_URL = 'https://cx20.github.io/gltf-test/textures/hdr/papermill.hdr';
-const MAX_COINS = 300;
+const MAX_COINS = 2048;
 const STATIC_COUNT = 1;
 const STATE_FLOATS = 16;
 const INFO_FLOATS = 12;
@@ -430,7 +430,7 @@ async function createInitialData() {
 function createStaticItems() {
     const items = new Float32Array(STATIC_COUNT * STATIC_FLOATS);
     const data = [
-        { pos: [0, -10.5, 0], scale: [13, 1, 13], color: [0.46, 0.47, 0.49, 1] },
+        { pos: [0, -10.5, 0], scale: [26, 1, 26], color: [0.46, 0.47, 0.49, 1] },
     ];
     for (let i = 0; i < data.length; i++) {
         const base = i * STATIC_FLOATS;
@@ -442,9 +442,17 @@ function createStaticItems() {
 }
 
 function writeCamera(timeMs) {
-    const eye = [0, 0, 40];
+    const alpha = -Math.PI / 6;
+    const beta = 76 * Math.PI / 180;
+    const radius = 24;
+    const target = [0, -8, 0];
+    const eye = [
+        target[0] + Math.cos(alpha) * Math.sin(beta) * radius,
+        target[1] + Math.cos(beta) * radius,
+        target[2] + Math.sin(alpha) * Math.sin(beta) * radius,
+    ];
     mat4Perspective(projectionMatrix, Math.PI / 4, canvas.width / canvas.height, 0.1, 150);
-    mat4LookAt(viewMatrix, eye, [0, 0, 0], [0, 1, 0]);
+    mat4LookAt(viewMatrix, eye, target, [0, 1, 0]);
     mat4Multiply(viewProjectionMatrix, projectionMatrix, viewMatrix);
     const cameraData = new Float32Array(20);
     cameraData.set(viewProjectionMatrix, 0);

--- a/examples/webgpu/wgsl_compute/coins/style.css
+++ b/examples/webgpu/wgsl_compute/coins/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#wireHint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/cone/index.html
+++ b/examples/webgpu/wgsl_compute/cone/index.html
@@ -397,7 +397,7 @@ fn main(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
     W: debug collider ON
 </div>
 

--- a/examples/webgpu/wgsl_compute/cone/style.css
+++ b/examples/webgpu/wgsl_compute/cone/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/gltf/index.html
+++ b/examples/webgpu/wgsl_compute/gltf/index.html
@@ -278,7 +278,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
     W: debug collider ON
 </div>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/gltf/style.css
+++ b/examples/webgpu/wgsl_compute/gltf/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
@@ -335,7 +335,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
   W: debug colliders ON
 </div>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/style.css
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
@@ -329,7 +329,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
     W: debug OBB OFF
 </div>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/style.css
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/style.css
@@ -11,3 +11,17 @@ body {
   background: #f7f7fa;
   font: 13px monospace;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
@@ -237,7 +237,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
     W: debug OBB OFF
 </div>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/style.css
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/style.css
@@ -11,3 +11,17 @@ body {
   background: #f7f7fa;
   font: 13px monospace;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
@@ -389,7 +389,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
-<div id="hint" style="position:fixed;top:8px;left:8px;color:#ddd;background:rgba(0,0,0,0.45);padding:4px 8px;border-radius:4px;font:13px monospace;pointer-events:none">
+<div id="hint">
   W: debug colliders ON
 </div>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/style.css
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #ddd;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Increase the WebGPU WGSL Falling Coins sample to 2048 coins
- Enlarge the floor and set the initial camera to a Babylon.js-like oblique view
- Fix WebGPU sample hint overlays so they no longer inherit full-screen width/height and darken the scene

## Testing
- Verified VS Code diagnostics for updated WebGPU sample files
- Ran the coins sample locally and confirmed coinCount = 2048 with no console/page errors
- Ran the WebGPU WGSL glTF sample locally and confirmed the hint label is no longer full-screen