### PR TITLE
feat: standardize WebGPU wireframe W-key behavior

### DIFF
--- a/examples/webgpu/wgsl_compute/coins/index.html
+++ b/examples/webgpu/wgsl_compute/coins/index.html
@@ -481,7 +481,7 @@ fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
-<div id="wireHint">W: collider wireframe OFF</div>
+<div id="hint">W: wireframe OFF</div>
 <canvas id="c"></canvas>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -708,7 +708,7 @@ async function init() {
     window.addEventListener('keydown', event => {
         if (event.key.toLowerCase() !== 'w' || event.repeat) return;
         showWireframe = !showWireframe;
-        document.getElementById('wireHint').textContent = 'W: collider wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
     requestAnimationFrame(frame);
 }

--- a/examples/webgpu/wgsl_compute/coins/style.css
+++ b/examples/webgpu/wgsl_compute/coins/style.css
@@ -12,7 +12,7 @@ body {
   font: 30px sans-serif;
 }
 
-#wireHint {
+#hint {
   position: fixed;
   top: 8px;
   left: 8px;

--- a/examples/webgpu/wgsl_compute/cone/index.html
+++ b/examples/webgpu/wgsl_compute/cone/index.html
@@ -398,7 +398,7 @@ fn main(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 <div id="hint">
-    W: debug collider ON
+    W: wireframe OFF
 </div>
 
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/cone/index.js
+++ b/examples/webgpu/wgsl_compute/cone/index.js
@@ -30,7 +30,7 @@ let computeBindGroups = [];
 let wireBindGroups = [];
 let currentState = 0;
 let lastTime = -1;
-let showWireframe = true;
+let showWireframe = false;
 
 const projectionMatrix = new Float32Array(16);
 const viewMatrix = new Float32Array(16);
@@ -464,10 +464,9 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key === 'w' || event.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent = 'W: debug collider ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     requestAnimationFrame(frame);

--- a/examples/webgpu/wgsl_compute/gltf/index.html
+++ b/examples/webgpu/wgsl_compute/gltf/index.html
@@ -279,7 +279,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 <div id="hint">
-    W: debug collider ON
+    W: wireframe OFF
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf/index.js
+++ b/examples/webgpu/wgsl_compute/gltf/index.js
@@ -26,7 +26,7 @@ let duckModel, groundMesh, wireMesh;
 let stateBuffer, simParamsBuffer, groundUniformBuffer, groundBindGroup, wireUniformBuffer, wireBindGroup;
 let computeBindGroup;
 let renderBindGroups = new Map();
-let showWireframe = true;
+let showWireframe = false;
 let lastTime = -1;
 let duckHalfExtents = [1, 1, 1];
 let duckCenter = [0, 0, 0];
@@ -561,10 +561,9 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key === 'w' || event.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent = 'W: debug collider ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     requestAnimationFrame(frame);

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
@@ -336,7 +336,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 
 <canvas id="c"></canvas>
 <div id="hint">
-  W: debug colliders ON
+    W: wireframe OFF
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
@@ -34,7 +34,7 @@ let wireBindGroups = [];
 let meshWireItems = [];
 let bodyRecords = [];
 let staticTriangleCount = 0;
-let showWireframe = true;
+let showWireframe = false;
 let lastTime = -1;
 
 const projectionMatrix = new Float32Array(16);
@@ -812,10 +812,9 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key === 'w' || event.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent = 'W: debug colliders ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
     requestAnimationFrame(frame);
 }

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
@@ -330,7 +330,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: debug OBB OFF
+    W: wireframe OFF
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
@@ -769,11 +769,10 @@ async function init() {
 
     // ── W key toggle ──────────────────────────────────────────────────────
     window.addEventListener('keydown', e => {
-        if (e.key === 'w' || e.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent =
-                'W: debug OBB ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent =
+            'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     requestAnimationFrame(frame);

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
@@ -238,7 +238,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: debug OBB OFF
+    W: wireframe OFF
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
@@ -735,11 +735,10 @@ async function init() {
 
     // ── W key toggle ──────────────────────────────────────────────────────
     window.addEventListener('keydown', e => {
-        if (e.key === 'w' || e.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent =
-                'W: debug OBB ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent =
+            'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     requestAnimationFrame(frame);

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
@@ -390,7 +390,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 
 <canvas id="c"></canvas>
 <div id="hint">
-  W: debug colliders ON
+    W: wireframe OFF
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
@@ -36,7 +36,7 @@ let meshWireItems = [];
 let bodyRecords = [];
 let staticTriangleCount = 0;
 let staticCeilingY = 100000;
-let showWireframe = true;
+let showWireframe = false;
 let lastTime = -1;
 
 const projectionMatrix = new Float32Array(16);
@@ -837,10 +837,9 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key === 'w' || event.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('hint').textContent = 'W: debug colliders ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
     requestAnimationFrame(frame);
 }

--- a/examples/webgpu/wgsl_compute/shogi/index.html
+++ b/examples/webgpu/wgsl_compute/shogi/index.html
@@ -403,7 +403,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
-<div id="wireHint" style="position:fixed;top:8px;left:8px;color:#0f0;font:13px monospace;pointer-events:none">W: wireframe ON</div>
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -260,7 +260,7 @@ let uniformBuffer, renderBindGroupA, renderBindGroupB, pipeline;
 let groundPipeline, groundVBuffer, groundIBuffer, groundMVPBuffer, groundBindGroup, groundICount;
 let wirePipeline, wireVBuffer, wireIBuffer, wireICount;
 let wireBindGroupA, wireBindGroupB;
-let showWireframe = true;
+let showWireframe = false;
 let srcBuffer, dstBuffer;
 let computePipeline, computeBindGroupA, computeBindGroupB;
 let simParamsBuffer;
@@ -565,11 +565,9 @@ async function init() {
 
     // Toggle wireframe with W key
     window.addEventListener('keydown', e => {
-        if (e.key === 'w' || e.key === 'W') {
-            showWireframe = !showWireframe;
-            document.getElementById('wireHint').textContent =
-                'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
-        }
+        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        showWireframe = !showWireframe;
+        document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     requestAnimationFrame(render);

--- a/examples/webgpu/wgsl_compute/shogi/style.css
+++ b/examples/webgpu/wgsl_compute/shogi/style.css
@@ -11,3 +11,17 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Standardize wireframe toggle behavior across WebGPU WGSL samples that already have wireframe rendering
- Use consistent W-key handling (case-insensitive, ignore key repeat)
- Normalize hint text to W: wireframe ON/OFF
- Align initial wireframe state to OFF for consistency
- Unify hint element usage in coins/shogi and move shogi hint styling into CSS

## Updated Samples
- wgsl_compute/coins
- wgsl_compute/cone
- wgsl_compute/gltf
- wgsl_compute/gltf_physics_Basic_Shapes
- wgsl_compute/gltf_physics_Motion_Properties
- wgsl_compute/gltf_physics_Materials_Friction
- wgsl_compute/gltf_physics_Materials_Restitution
- wgsl_compute/shogi

## Testing
- Confirmed no VS Code diagnostics errors in updated WebGPU sample paths
- Verified modified files compile/load without syntax errors