### PR TITLE
feat: standardize WebGL1/2 wireframe W-key behavior

### DIFF
--- a/examples/webgl1/havok/balls/index.html
+++ b/examples/webgl1/havok/balls/index.html
@@ -61,6 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/balls/index.js
+++ b/examples/webgl1/havok/balls/index.js
@@ -27,6 +27,7 @@ let textures = [];
 let whiteTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -143,13 +144,13 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [20, 2, 20]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
@@ -163,7 +164,7 @@ function drawPhysicsDebug() {
         const r = item.radius;
         mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, posResult[1], [r, r, r]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -526,6 +527,14 @@ async function main() {
         alpha:    gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     lineProgram = createProgram(
         gl,

--- a/examples/webgl1/havok/balls/style.css
+++ b/examples/webgl1/havok/balls/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/box/index.html
+++ b/examples/webgl1/havok/box/index.html
@@ -61,6 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -46,6 +46,7 @@ let groundTexture;
 let whiteTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -236,7 +237,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
     for (let i = 0; i < BOX_COUNT; i++) {
@@ -246,7 +247,7 @@ function drawPhysicsDebug() {
         checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
         mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -516,6 +517,14 @@ async function init() {
     };
 
     gl.useProgram(program);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     gl.uniform1i(uniforms.texture, 0);
 
     lineProgram = createProgram(

--- a/examples/webgl1/havok/box/style.css
+++ b/examples/webgl1/havok/box/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/cone/index.html
+++ b/examples/webgl1/havok/cone/index.html
@@ -63,6 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/cone/index.js
+++ b/examples/webgl1/havok/cone/index.js
@@ -12,6 +12,7 @@ let canvas;
 let gl;
 let program;
 let lineProgram;
+let showWireframe = false;
 let attribs;
 let uniforms;
 let lineAttribs;
@@ -489,7 +490,7 @@ function drawDebugBox(position, rotation, size, color) {
     gl.enableVertexAttribArray(lineAttribs.position);
     gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 }
 
 function drawDebugCone(position, rotation, radius, height, color) {
@@ -505,7 +506,7 @@ function drawDebugCone(position, rotation, radius, height, color) {
     gl.enableVertexAttribArray(lineAttribs.position);
     gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugConeMesh.indexBuffer);
-    gl.drawElements(gl.LINES, debugConeMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugConeMesh.count, gl.UNSIGNED_SHORT, 0);
 }
 
 function drawPhysicsDebug() {
@@ -650,6 +651,14 @@ async function main() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     coneMesh = createMeshBuffers(generateConeMesh(40));
     cubeMesh = createMeshBuffers(generateCubeMesh());

--- a/examples/webgl1/havok/cone/style.css
+++ b/examples/webgl1/havok/cone/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/domino/index.html
+++ b/examples/webgl1/havok/domino/index.html
@@ -54,6 +54,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -81,6 +81,7 @@ let uniformModelView;
 let uniformColor;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -225,7 +226,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, GROUND_Y, 0], [100, GROUND_HALF_HEIGHT, 100]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
     for (let i = 0; i < DOMINO_COUNT; i++) {
@@ -235,7 +236,7 @@ function drawPhysicsDebug() {
         checkResult(rotResult[0], 'HP_Body_GetOrientation debug');
         mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [DOMINO_W, DOMINO_H, DOMINO_D]);
         gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -451,6 +452,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     createBoxGeometry();
     initPhysics();

--- a/examples/webgl1/havok/domino/style.css
+++ b/examples/webgl1/havok/domino/style.css
@@ -9,3 +9,17 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/football/index.html
+++ b/examples/webgl1/havok/football/index.html
@@ -61,6 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -52,6 +52,7 @@ let uniformLightDir;
 let uniformAlpha;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -242,7 +243,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2, 0], [30, 2, 30]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
     gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
@@ -255,7 +256,7 @@ function drawPhysicsDebug() {
         const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
         mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [0.5, 0.5, 0.5]);
         gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
-        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -577,6 +578,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     debugSphereMesh = createDebugWireframeSphereMesh();
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);

--- a/examples/webgl1/havok/football/style.css
+++ b/examples/webgl1/havok/football/style.css
@@ -9,3 +9,17 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf/index.html
+++ b/examples/webgl1/havok/gltf/index.html
@@ -74,6 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf/index.js
+++ b/examples/webgl1/havok/gltf/index.js
@@ -15,6 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -829,7 +830,7 @@ function drawPhysicsDebugBox() {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
 
     gl.disable(gl.CULL_FACE);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.enable(gl.CULL_FACE);
 }
 
@@ -919,6 +920,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     groundMesh = createGroundMesh();
     groundTexture = createSolidTexture(255, 255, 255, 255);

--- a/examples/webgl1/havok/gltf/style.css
+++ b/examples/webgl1/havok/gltf/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.html
@@ -74,6 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1447,7 +1448,7 @@ function drawPhysicsDebug() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, node.debugGLMesh.indexBuffer);
             gl.uniformMatrix4fv(lineUniforms.model, false, node.debugTransformMatrix);
             gl.uniform4fv(lineUniforms.color, color);
-            gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
+            if (showWireframe) gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
         } else {
             // Fallback: bounding-box wireframe
             const model = mat4.clone(node.worldMatrix);
@@ -1458,7 +1459,7 @@ function drawPhysicsDebug() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
             gl.uniformMatrix4fv(lineUniforms.model, false, model);
             gl.uniform4fv(lineUniforms.color, color);
-            gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+            if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
         }
     }
 
@@ -1554,6 +1555,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/style.css
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Filtering/index.html
+++ b/examples/webgl1/havok/gltf_physics_Filtering/index.html
@@ -133,6 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl1/havok/gltf_physics_Filtering/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1327,7 +1328,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1425,6 +1426,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Filtering/style.css
+++ b/examples/webgl1/havok/gltf_physics_Filtering/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.html
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.html
@@ -133,6 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1518,7 +1519,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1616,6 +1617,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_JointTypes/style.css
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
@@ -74,6 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
@@ -15,6 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -905,7 +906,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -998,6 +999,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/style.css
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
@@ -74,6 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
@@ -15,6 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -926,7 +927,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1019,6 +1020,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/style.css
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
@@ -133,6 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1293,7 +1294,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1391,6 +1392,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/style.css
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/gltf_physics_Triggers/index.html
+++ b/examples/webgl1/havok/gltf_physics_Triggers/index.html
@@ -133,6 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl1/havok/gltf_physics_Triggers/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1334,7 +1335,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1432,6 +1433,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl1/havok/gltf_physics_Triggers/style.css
+++ b/examples/webgl1/havok/gltf_physics_Triggers/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/marbles/index.html
+++ b/examples/webgl1/havok/marbles/index.html
@@ -258,6 +258,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/marbles/index.js
+++ b/examples/webgl1/havok/marbles/index.js
@@ -21,6 +21,7 @@ let skyboxUniforms;
 let skyboxVbo;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -108,7 +109,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -5, 0], [80, 4, 80]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, debugSphereMesh.vbo);
     gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
@@ -121,7 +122,7 @@ function drawPhysicsDebug() {
         const r = marble.radius;
         mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, posResult[1], [r, r, r]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugSphereMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 }
 
@@ -1182,6 +1183,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     initSkybox();
 
     groundMesh = createGroundMesh();

--- a/examples/webgl1/havok/marbles/style.css
+++ b/examples/webgl1/havok/marbles/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/minimum/index.html
+++ b/examples/webgl1/havok/minimum/index.html
@@ -50,6 +50,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/minimum/index.js
+++ b/examples/webgl1/havok/minimum/index.js
@@ -20,6 +20,7 @@ let uniformModelView;
 let uniformTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -167,7 +168,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2.5, 0], [20, 1, 20]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     const posResult = HK.HP_Body_GetPosition(cubeBodyId);
     checkResult(posResult[0], 'HP_Body_GetPosition debug');
@@ -176,7 +177,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [5, 5, 5]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 }
 
 function createBoxGeometry() {
@@ -426,6 +427,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     createBoxGeometry();
     texture = await loadTexture('../../../../assets/textures/frog.jpg');

--- a/examples/webgl1/havok/minimum/style.css
+++ b/examples/webgl1/havok/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/havok/shogi/index.html
+++ b/examples/webgl1/havok/shogi/index.html
@@ -95,6 +95,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/shogi/index.js
+++ b/examples/webgl1/havok/shogi/index.js
@@ -1,7 +1,7 @@
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
-const SHOW_DEBUG_WIREFRAME = true;
+let showWireframe = false;
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);
@@ -11,6 +11,14 @@ resizeCanvas();
 window.addEventListener("resize", function(){
     resizeCanvas();
 });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
 function resizeCanvas() {
     c.width = window.innerWidth;
@@ -336,7 +344,7 @@ function createDebugWireframeBoxMesh() {
 }
 
 function drawPhysicsWireframes() {
-    if (!SHOW_DEBUG_WIREFRAME || !debugBoxVBO || !debugBoxIBO) {
+    if (!showWireframe || !debugBoxVBO || !debugBoxIBO) {
         return;
     }
 
@@ -360,7 +368,7 @@ function drawPhysicsWireframes() {
         mat4.multiply(mvpMat, vMatrix, modelMat);
         mat4.multiply(mvpMat, perspMatrix, mvpMat);
         gl.uniformMatrix4fv(mvpLoc, false, mvpMat);
-        gl.drawElements(gl.LINES, debugBoxIndexCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxIndexCount, gl.UNSIGNED_SHORT, 0);
     }
 }
 

--- a/examples/webgl1/havok/shogi/style.css
+++ b/examples/webgl1/havok/shogi/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/balls/index.html
+++ b/examples/webgl1/oimo/balls/index.html
@@ -60,6 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/balls/index.js
+++ b/examples/webgl1/oimo/balls/index.js
@@ -35,6 +35,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -403,11 +404,11 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, model);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(model, quat.create(), wall.pos, wall.size);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
@@ -421,7 +422,7 @@ function render(timeMs) {
             [p.x, p.y, p.z],
             [item.radius, item.radius, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -459,6 +460,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl1/oimo/balls/style.css
+++ b/examples/webgl1/oimo/balls/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/box/index.html
+++ b/examples/webgl1/oimo/box/index.html
@@ -60,6 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -44,6 +44,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -388,7 +389,7 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, model);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (const item of boxes) {
         const p = item.body.getPosition();
@@ -398,7 +399,7 @@ function render(timeMs) {
             [p.x, p.y, p.z],
             [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -436,6 +437,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl1/oimo/box/style.css
+++ b/examples/webgl1/oimo/box/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/cone/index.html
+++ b/examples/webgl1/oimo/cone/index.html
@@ -60,6 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/cone/index.js
+++ b/examples/webgl1/oimo/cone/index.js
@@ -26,6 +26,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB, cylWireVB, cylWireIB, cylWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -375,11 +376,11 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, model);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(model, quat.create(), wall.pos, wall.size);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
@@ -393,7 +394,7 @@ function render(timeMs) {
             [p.x, p.y, p.z],
             [item.radius, item.height, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -431,6 +432,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     coneMesh = createMeshBuffers(generateConeMesh(40));
     cubeMesh = createMeshBuffers(generateCubeMesh());

--- a/examples/webgl1/oimo/cone/style.css
+++ b/examples/webgl1/oimo/cone/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/domino/index.html
+++ b/examples/webgl1/oimo/domino/index.html
@@ -77,6 +77,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/domino/index.js
+++ b/examples/webgl1/oimo/domino/index.js
@@ -58,6 +58,7 @@ gl.clearColor(0.05, 0.05, 0.1, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let dominoIBO, dominoPosVBO;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([
@@ -76,6 +77,14 @@ resizeCanvas();
 window.addEventListener("resize", function(){
     resizeCanvas();
 });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
 function resizeCanvas() {
     c.width = window.innerWidth;
@@ -318,14 +327,14 @@ let fps0 = 0;
     mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [100, 0.2, 100]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < number; i++) {
         let q = quat.fromValues(quatArray[i*4], quatArray[i*4+1], quatArray[i*4+2], quatArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q,
             [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [2, 4, 0.6]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.useProgram(p1);
     gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);

--- a/examples/webgl1/oimo/domino/style.css
+++ b/examples/webgl1/oimo/domino/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/eraser/index.html
+++ b/examples/webgl1/oimo/eraser/index.html
@@ -96,6 +96,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -6,6 +6,7 @@ gl.clearColor(0.7, 0.7, 0.7, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let eraserIBO, eraserPosVBO;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([
@@ -24,6 +25,14 @@ resizeCanvas();
 window.addEventListener("resize", function(){
     resizeCanvas();
 });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
 function resizeCanvas() {
     c.width = window.innerWidth;
@@ -325,14 +334,14 @@ animate();
     mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [13, 0.1, 13]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < max; i++) {
         let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q,
             [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [2, 0.4, 1]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.useProgram(p1);
     gl.bindBuffer(gl.ARRAY_BUFFER, eraserPosVBO);

--- a/examples/webgl1/oimo/eraser/style.css
+++ b/examples/webgl1/oimo/eraser/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/football/index.html
+++ b/examples/webgl1/oimo/football/index.html
@@ -60,6 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -48,6 +48,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -423,7 +424,7 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(model, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, model);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
@@ -436,7 +437,7 @@ function render(timeMs) {
             [p.x, p.y, p.z],
             [item.radius, item.radius, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, model);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -474,6 +475,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl1/oimo/football/style.css
+++ b/examples/webgl1/oimo/football/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/gltf/index.html
+++ b/examples/webgl1/oimo/gltf/index.html
@@ -74,6 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/gltf/index.js
+++ b/examples/webgl1/oimo/gltf/index.js
@@ -13,6 +13,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -732,7 +733,7 @@ function drawPhysicsDebugBox() {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
 
     gl.disable(gl.CULL_FACE);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.enable(gl.CULL_FACE);
 }
 
@@ -845,6 +846,14 @@ async function main() {
     document.addEventListener('click', () => {
         duckBody.linearVelocity.set(0, 5, 0);
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 }
 
 main().catch((err) => {

--- a/examples/webgl1/oimo/gltf/style.css
+++ b/examples/webgl1/oimo/gltf/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/marbles/index.html
+++ b/examples/webgl1/oimo/marbles/index.html
@@ -257,6 +257,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/marbles/index.js
+++ b/examples/webgl1/oimo/marbles/index.js
@@ -32,6 +32,7 @@ let groundTexture;
 let envCubeTexture = null;
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -975,7 +976,7 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(lineModel, [0,0,0,1], groundPos, groundSize);
     gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
@@ -989,7 +990,7 @@ function render(timeMs) {
             [p.x, p.y, p.z],
             [r, r, r]);
         gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -1050,6 +1051,14 @@ async function main() {
 
     groundMesh = createGroundMesh();
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE, { flipY: true });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     try {
         const hdr = await loadHDRTexture(ENV_HDR_URL);
         envCubeTexture = createCubemapFromHDR(hdr, 192);

--- a/examples/webgl1/oimo/marbles/style.css
+++ b/examples/webgl1/oimo/marbles/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/minimum/index.html
+++ b/examples/webgl1/oimo/minimum/index.html
@@ -51,6 +51,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/minimum/index.js
+++ b/examples/webgl1/oimo/minimum/index.js
@@ -4,6 +4,7 @@ let aLoc = [];
 let uLoc = [];
 let mainProgram;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -65,6 +66,14 @@ function initWebGL() {
     window.addEventListener("resize", function(){
         resizeCanvas();
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 }
 
 function resizeCanvas() {
@@ -319,13 +328,13 @@ function draw() {
     mat4.fromRotationTranslationScale(wm, quat.fromValues(gr.x, gr.y, gr.z, gr.w), [gp.x, gp.y, gp.z], [4, 0.1, 4]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     let bp = oimoBox.getPosition();
     let br = oimoBox.getQuaternion();
     mat4.fromRotationTranslationScale(wm, quat.fromValues(br.x, br.y, br.z, br.w), [bp.x, bp.y, bp.z], [1, 1, 1]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.useProgram(mainProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
     gl.vertexAttribPointer(aLoc[0], 3, gl.FLOAT, false, 0, 0);

--- a/examples/webgl1/oimo/minimum/style.css
+++ b/examples/webgl1/oimo/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl1/oimo/shogi/index.html
+++ b/examples/webgl1/oimo/shogi/index.html
@@ -111,6 +111,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/shogi/index.js
+++ b/examples/webgl1/oimo/shogi/index.js
@@ -3,6 +3,7 @@ let gl = c.getContext("experimental-webgl");
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([
@@ -21,6 +22,14 @@ resizeCanvas();
 window.addEventListener("resize", function(){
     resizeCanvas();
 });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
 function resizeCanvas() {
     c.width = window.innerWidth;
@@ -440,14 +449,14 @@ setInterval(function () {
     mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [13, 0.1, 13]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < max; i++) {
         let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q,
             [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.useProgram(p1);
     gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);

--- a/examples/webgl1/oimo/shogi/style.css
+++ b/examples/webgl1/oimo/shogi/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/balls/index.html
+++ b/examples/webgl2/havok/balls/index.html
@@ -63,6 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/balls/index.js
+++ b/examples/webgl2/havok/balls/index.js
@@ -32,6 +32,7 @@ let balls = [];
 let basketWalls = [];
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -324,11 +325,11 @@ function drawPhysicsDebug() {
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [20, 2, 20]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindVertexArray(null);
 
@@ -339,7 +340,7 @@ function drawPhysicsDebug() {
         const rotR = HK.HP_Body_GetOrientation(item.bodyId);
         mat4.fromRotationTranslationScale(model, rotR[1], posR[1], [item.radius, item.radius, item.radius]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+        if (showWireframe) gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
     }
     gl.bindVertexArray(null);
 }
@@ -514,6 +515,14 @@ async function main() {
         alpha:    gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     lineProgram = createProgram(
         gl,

--- a/examples/webgl2/havok/balls/style.css
+++ b/examples/webgl2/havok/balls/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/box/index.html
+++ b/examples/webgl2/havok/box/index.html
@@ -63,6 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -46,6 +46,7 @@ let groundTexture;
 let whiteTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -348,7 +349,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -2, 0], [30, 0.4, 30]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
     for (let i = 0; i < BOX_COUNT; i++) {
@@ -356,7 +357,7 @@ function drawPhysicsDebug() {
         const rotResult = HK.HP_Body_GetOrientation(boxBodyIds[i]);
         mat4.fromRotationTranslationScale(model, rotResult[1], posResult[1], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     gl.bindVertexArray(null);
@@ -502,6 +503,14 @@ async function init() {
     };
 
     gl.useProgram(program);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     gl.uniform1i(uniforms.texture, 0);
 
     lineProgram = createProgram(

--- a/examples/webgl2/havok/box/style.css
+++ b/examples/webgl2/havok/box/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/cone/index.html
+++ b/examples/webgl2/havok/cone/index.html
@@ -63,6 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/cone/index.js
+++ b/examples/webgl2/havok/cone/index.js
@@ -27,6 +27,7 @@ let basketWalls = [];
 const coneShapeCache = new Map();
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -283,11 +284,11 @@ function drawPhysicsDebug() {
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, ground.pos, ground.size);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, wall.pos, wall.size);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindVertexArray(null);
 
@@ -298,7 +299,7 @@ function drawPhysicsDebug() {
         const qResult = HK.HP_Body_GetOrientation(item.body);
         mat4.fromRotationTranslationScale(model, qResult[1], pResult[1], [item.radius, item.height, item.radius]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawArrays(gl.LINES, 0, debugConeMesh.count);
+        if (showWireframe) gl.drawArrays(gl.LINES, 0, debugConeMesh.count);
     }
     gl.bindVertexArray(null);
 }
@@ -570,6 +571,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     lineProgram = createProgram(
         gl,

--- a/examples/webgl2/havok/cone/style.css
+++ b/examples/webgl2/havok/cone/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/domino/index.html
+++ b/examples/webgl2/havok/domino/index.html
@@ -56,6 +56,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/domino/index.js
+++ b/examples/webgl2/havok/domino/index.js
@@ -90,6 +90,7 @@ const modelViewMatrix = mat4.create();
 const viewProjMatrix = mat4.create();
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -134,7 +135,7 @@ function drawPhysicsDebug() {
     mat4.scale(modelMatrix, modelMatrix, [100, 0.2, 100]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
     for (let i = 0; i < DOMINO_COUNT; i++) {
@@ -143,7 +144,7 @@ function drawPhysicsDebug() {
         mat4.fromRotationTranslation(modelMatrix, rotResult[1], posResult[1]);
         mat4.scale(modelMatrix, modelMatrix, [DOMINO_W, DOMINO_H, DOMINO_D]);
         gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     gl.bindVertexArray(null);
@@ -454,6 +455,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     createBoxGeometry();
     initPhysics();

--- a/examples/webgl2/havok/domino/style.css
+++ b/examples/webgl2/havok/domino/style.css
@@ -9,3 +9,17 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/football/index.html
+++ b/examples/webgl2/havok/football/index.html
@@ -63,6 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -56,6 +56,7 @@ let footballTexture;
 let grassTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -128,7 +129,7 @@ function drawPhysicsDebug() {
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
     mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2, 0], [30, 2, 30]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.bindVertexArray(null);
 
     gl.bindVertexArray(debugSphereMesh.vao);
@@ -138,7 +139,7 @@ function drawPhysicsDebug() {
         const rotResult = HK.HP_Body_GetOrientation(ballBodyIds[i]);
         mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [0.5, 0.5, 0.5]);
         gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
-        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+        if (showWireframe) gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
     }
     gl.bindVertexArray(null);
 }
@@ -554,6 +555,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     debugSphereMesh = createDebugWireframeSphereMesh();
 
     sphereMesh = createSphereGeometry(0.5, 18, 24);

--- a/examples/webgl2/havok/football/style.css
+++ b/examples/webgl2/havok/football/style.css
@@ -9,3 +9,17 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf/index.html
+++ b/examples/webgl2/havok/gltf/index.html
@@ -76,6 +76,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf/index.js
+++ b/examples/webgl2/havok/gltf/index.js
@@ -14,6 +14,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -811,7 +812,7 @@ function drawPhysicsDebugBox() {
 
     gl.bindVertexArray(debugBoxMesh.vao);
     gl.disable(gl.CULL_FACE);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.enable(gl.CULL_FACE);
 }
 
@@ -899,6 +900,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     groundMesh = createGroundMesh();
     groundTexture = createSolidTexture(255, 255, 255, 255);

--- a/examples/webgl2/havok/gltf/style.css
+++ b/examples/webgl2/havok/gltf/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.html
@@ -82,6 +82,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1447,7 +1448,7 @@ function drawPhysicsDebug() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, node.debugGLMesh.indexBuffer);
             gl.uniformMatrix4fv(lineUniforms.model, false, node.debugTransformMatrix);
             gl.uniform4fv(lineUniforms.color, color);
-            gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
+            if (showWireframe) gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
         } else {
             // Fallback: bounding-box wireframe
             const model = mat4.clone(node.worldMatrix);
@@ -1458,7 +1459,7 @@ function drawPhysicsDebug() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
             gl.uniformMatrix4fv(lineUniforms.model, false, model);
             gl.uniform4fv(lineUniforms.color, color);
-            gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+            if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
         }
     }
 
@@ -1554,6 +1555,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/style.css
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Filtering/index.html
+++ b/examples/webgl2/havok/gltf_physics_Filtering/index.html
@@ -141,6 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl2/havok/gltf_physics_Filtering/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1337,7 +1338,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1436,6 +1437,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Filtering/style.css
+++ b/examples/webgl2/havok/gltf_physics_Filtering/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.html
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.html
@@ -141,6 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1528,7 +1529,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1627,6 +1628,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_JointTypes/style.css
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
@@ -84,6 +84,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
@@ -15,6 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -905,7 +906,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -998,6 +999,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/style.css
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
@@ -84,6 +84,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
@@ -15,6 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -926,7 +927,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1019,6 +1020,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/style.css
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
@@ -141,6 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1303,7 +1304,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1402,6 +1403,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/style.css
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/gltf_physics_Triggers/index.html
+++ b/examples/webgl2/havok/gltf_physics_Triggers/index.html
@@ -141,6 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl2/havok/gltf_physics_Triggers/index.js
@@ -18,6 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -1344,7 +1345,7 @@ function drawPhysicsDebug() {
         mat4.scale(model, model, node.debugSize);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
         gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
     gl.enable(gl.CULL_FACE);
 }
@@ -1443,6 +1444,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     whiteTexture = createSolidTexture(255, 255, 255, 255);
     debugBoxMesh = createDebugWireframeBoxMesh();

--- a/examples/webgl2/havok/gltf_physics_Triggers/style.css
+++ b/examples/webgl2/havok/gltf_physics_Triggers/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/marbles/index.html
+++ b/examples/webgl2/havok/marbles/index.html
@@ -264,6 +264,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/marbles/index.js
+++ b/examples/webgl2/havok/marbles/index.js
@@ -33,6 +33,7 @@ let groundTexture;
 let envCubeTexture = null;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -730,7 +731,7 @@ function drawPhysicsDebug() {
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
     mat4.fromRotationTranslationScale(model, IDENTITY_QUATERNION, [0, -5, 0], [80, 4, 80]);
     gl.uniformMatrix4fv(lineUniforms.model, false, model);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.bindVertexArray(null);
 
     gl.bindVertexArray(debugSphereMesh.vao);
@@ -741,7 +742,7 @@ function drawPhysicsDebug() {
         const r = marble.radius;
         mat4.fromRotationTranslationScale(model, qResult[1], pResult[1], [r, r, r]);
         gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
+        if (showWireframe) gl.drawArrays(gl.LINES, 0, debugSphereMesh.count);
     }
     gl.bindVertexArray(null);
 }
@@ -1158,6 +1159,14 @@ async function main() {
             return path;
         }
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     initSkybox();
 
     groundMesh = createGroundMesh();

--- a/examples/webgl2/havok/marbles/style.css
+++ b/examples/webgl2/havok/marbles/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/minimum/index.html
+++ b/examples/webgl2/havok/minimum/index.html
@@ -52,6 +52,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/minimum/index.js
+++ b/examples/webgl2/havok/minimum/index.js
@@ -20,6 +20,7 @@ let uniformModelView;
 let uniformTexture;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;
@@ -167,7 +168,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, IDENTITY_QUATERNION, [0, -2.5, 0], [20, 1, 20]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [0.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     const posResult = HK.HP_Body_GetPosition(cubeBodyId);
     checkResult(posResult[0], 'HP_Body_GetPosition debug');
@@ -176,7 +177,7 @@ function drawPhysicsDebug() {
     mat4.fromRotationTranslationScale(modelMatrix, rotResult[1], posResult[1], [5, 5, 5]);
     gl.uniformMatrix4fv(lineUniforms.model, false, modelMatrix);
     gl.uniform4fv(lineUniforms.color, [1.0, 1.0, 0.0, 1.0]);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.bindVertexArray(null);
 }
@@ -430,6 +431,14 @@ async function init() {
         color: gl.getUniformLocation(lineProgram, 'uColor')
     };
     debugBoxMesh = createDebugWireframeBoxMesh();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     createBoxGeometry();
     texture = await loadTexture('../../../../assets/textures/frog.jpg');

--- a/examples/webgl2/havok/minimum/style.css
+++ b/examples/webgl2/havok/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/havok/shogi/index.html
+++ b/examples/webgl2/havok/shogi/index.html
@@ -108,6 +108,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/shogi/index.js
+++ b/examples/webgl2/havok/shogi/index.js
@@ -1,3 +1,4 @@
+let showWireframe = false;
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("webgl2");
@@ -9,6 +10,14 @@ resizeCanvas();
 window.addEventListener("resize", function(){
     resizeCanvas();
 });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
 function resizeCanvas() {
     c.width = window.innerWidth;
@@ -521,7 +530,7 @@ function drawPhysicsDebug() {
     mat4.scale(mMatrix, mMatrix, [13, 0.1, 13]);
     gl.uniformMatrix4fv(lineUniforms.model, false, mMatrix);
     gl.uniform4f(lineUniforms.color, 0, 1, 0, 1);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
 
     gl.uniform4f(lineUniforms.color, 1, 1, 0, 1);
     for (let i = 0; i < max; i++) {
@@ -530,7 +539,7 @@ function drawPhysicsDebug() {
         mat4.fromRotationTranslation(mMatrix, qResult[1], pResult[1]);
         mat4.scale(mMatrix, mMatrix, SHOGI_PHYSICS_SIZE);
         gl.uniformMatrix4fv(lineUniforms.model, false, mMatrix);
-        gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     }
 
     gl.bindVertexArray(null);

--- a/examples/webgl2/havok/shogi/style.css
+++ b/examples/webgl2/havok/shogi/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/balls/index.html
+++ b/examples/webgl2/oimo/balls/index.html
@@ -62,6 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/balls/index.js
+++ b/examples/webgl2/oimo/balls/index.js
@@ -35,6 +35,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
@@ -396,11 +397,11 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(wm, quat.create(), wall.pos, wall.size);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
@@ -411,7 +412,7 @@ function render(timeMs) {
         const q = item.body.getQuaternion();
         mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.radius, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -449,6 +450,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl2/oimo/balls/style.css
+++ b/examples/webgl2/oimo/balls/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/box/index.html
+++ b/examples/webgl2/oimo/box/index.html
@@ -62,6 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -44,6 +44,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -374,14 +375,14 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (const item of boxes) {
         const p = item.body.getPosition();
         const q = item.body.getQuaternion();
         mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -419,6 +420,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl2/oimo/box/style.css
+++ b/examples/webgl2/oimo/box/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/cone/index.html
+++ b/examples/webgl2/oimo/cone/index.html
@@ -62,6 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/cone/index.js
+++ b/examples/webgl2/oimo/cone/index.js
@@ -26,6 +26,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let cylWireVB, cylWireIB, cylWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
@@ -365,11 +366,11 @@ function render(timeMs) {
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     for (const wall of basketWalls) {
         mat4.fromRotationTranslationScale(wm, quat.create(), wall.pos, wall.size);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.bindBuffer(gl.ARRAY_BUFFER, cylWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
@@ -380,7 +381,7 @@ function render(timeMs) {
         const q = item.body.getQuaternion();
         mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.height, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, cylWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -418,6 +419,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     coneMesh = createMeshBuffers(generateConeMesh(48));
     cubeMesh = createMeshBuffers(generateCubeMesh());

--- a/examples/webgl2/oimo/cone/style.css
+++ b/examples/webgl2/oimo/cone/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/domino/index.html
+++ b/examples/webgl2/oimo/domino/index.html
@@ -79,6 +79,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/domino/index.js
+++ b/examples/webgl2/oimo/domino/index.js
@@ -58,6 +58,7 @@ gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let dominoPosVBO;
 let lineVP = mat4.create();
@@ -82,6 +83,14 @@ function resizeCanvas() {
 
 // --- Shader program ---
 let program = gl.createProgram();
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 for (let i = 0; i < 2; i++) {
     let shader = gl.createShader([gl.VERTEX_SHADER, gl.FRAGMENT_SHADER][i]);
     gl.shaderSource(shader, [
@@ -319,13 +328,13 @@ setInterval(function () {
     mat4.fromRotationTranslationScale(wm, quat.create(), [0, -0.1, 0], [100, 0.2, 100]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < number; i++) {
         const q = quat.fromValues(quatArray[i*4], quatArray[i*4+1], quatArray[i*4+2], quatArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [bw*2, bh*2, bd*2]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.useProgram(program);
     gl.bindBuffer(gl.ARRAY_BUFFER, dominoPosVBO);

--- a/examples/webgl2/oimo/domino/style.css
+++ b/examples/webgl2/oimo/domino/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/football/index.html
+++ b/examples/webgl2/oimo/football/index.html
@@ -62,6 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -48,6 +48,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
@@ -416,7 +417,7 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(wm, quat.create(), ground.pos, ground.size);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
@@ -426,7 +427,7 @@ function render(timeMs) {
         const q = item.body.getQuaternion();
         mat4.fromRotationTranslationScale(wm, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [item.radius, item.radius, item.radius]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -464,6 +465,14 @@ async function main() {
         alpha: gl.getUniformLocation(program, 'uAlpha')
     };
     gl.uniform1i(uniforms.texture, 0);
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 
     const wasm = await Module();
     wasm.setup();

--- a/examples/webgl2/oimo/football/style.css
+++ b/examples/webgl2/oimo/football/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/gltf/index.html
+++ b/examples/webgl2/oimo/gltf/index.html
@@ -76,6 +76,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/gltf/index.js
+++ b/examples/webgl2/oimo/gltf/index.js
@@ -12,6 +12,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
+let showWireframe = false;
 let lineAttribs;
 let lineUniforms;
 
@@ -712,7 +713,7 @@ function drawPhysicsDebugBox() {
 
     gl.bindVertexArray(debugBoxMesh.vao);
     gl.disable(gl.CULL_FACE);
-    gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
     gl.enable(gl.CULL_FACE);
 }
 
@@ -822,6 +823,14 @@ async function main() {
     document.addEventListener('click', () => {
         duckBody.linearVelocity.set(0, 5, 0);
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 }
 
 main().catch((err) => {

--- a/examples/webgl2/oimo/gltf/style.css
+++ b/examples/webgl2/oimo/gltf/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/marbles/index.html
+++ b/examples/webgl2/oimo/marbles/index.html
@@ -263,6 +263,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/marbles/index.js
+++ b/examples/webgl2/oimo/marbles/index.js
@@ -21,6 +21,7 @@ let world;
 const marbles = [];
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
@@ -960,7 +961,7 @@ function render(timeMs) {
     mat4.fromRotationTranslationScale(lineModel, quat.create(), [0, -5, 0], [80, 4, 80]);
     gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.bindBuffer(gl.ARRAY_BUFFER, sphWireVB);
     gl.vertexAttribPointer(linePosLoc, 3, gl.FLOAT, false, 0, 0);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, sphWireIB);
@@ -971,7 +972,7 @@ function render(timeMs) {
         const r = marble.radius;
         mat4.fromRotationTranslationScale(lineModel, quat.fromValues(q.x, q.y, q.z, q.w), [p.x, p.y, p.z], [r, r, r]);
         gl.uniformMatrix4fv(lineModelLoc, false, lineModel);
-        gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, sphWireCount, gl.UNSIGNED_SHORT, 0);
     }
 
     requestAnimationFrame(render);
@@ -1030,6 +1031,14 @@ async function main() {
 
     groundMesh = createGroundMesh();
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE, { flipY: true });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
     try {
         const hdr = await loadHDRTexture(ENV_HDR_URL);
         envCubeTexture = createCubemapFromHDR(hdr, 256);

--- a/examples/webgl2/oimo/marbles/style.css
+++ b/examples/webgl2/oimo/marbles/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/minimum/index.html
+++ b/examples/webgl2/oimo/minimum/index.html
@@ -51,6 +51,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/minimum/index.js
+++ b/examples/webgl2/oimo/minimum/index.js
@@ -4,6 +4,7 @@ let attributeLocations = [];
 let uniformLocations = [];
 let mainProgram;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,
@@ -75,6 +76,14 @@ function initWorld() {
         info: false,
         gravity: [0, -9.8, 0]
     });
+
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
 }
 
 function createShader(type, source) {
@@ -265,13 +274,13 @@ function draw() {
     mat4.fromRotationTranslationScale(wm, quat.fromValues(gr.x, gr.y, gr.z, gr.w), [gp.x, gp.y, gp.z], [4, 0.1, 4]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     const bp = boxBody.getPosition();
     const br = boxBody.getQuaternion();
     mat4.fromRotationTranslationScale(wm, quat.fromValues(br.x, br.y, br.z, br.w), [bp.x, bp.y, bp.z], [1, 1, 1]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.useProgram(mainProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexPositionBuffer);
     gl.vertexAttribPointer(attributeLocations[0], 3, gl.FLOAT, false, 0, 0);

--- a/examples/webgl2/oimo/minimum/style.css
+++ b/examples/webgl2/oimo/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgl2/oimo/shogi/index.html
+++ b/examples/webgl2/oimo/shogi/index.html
@@ -107,6 +107,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/shogi/index.js
+++ b/examples/webgl2/oimo/shogi/index.js
@@ -9,6 +9,14 @@ window.addEventListener("resize", function(){
     resizeCanvas();
 });
 
+window.addEventListener('keydown', event => {
+    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});
+
+
 function resizeCanvas() {
     c.width = window.innerWidth;
     c.height = window.innerHeight;
@@ -16,6 +24,7 @@ function resizeCanvas() {
 }
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
+let showWireframe = false;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([
@@ -436,13 +445,13 @@ setInterval(function () {
     mat4.fromRotationTranslationScale(wm, quat.create(), [gp.x, gp.y, gp.z], [13, 0.1, 13]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
-    gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+    if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < max; i++) {
         const q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
-        gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
+        if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }
     gl.useProgram(p1);
     gl.bindBuffer(gl.ARRAY_BUFFER, shogiVBOs[0]);

--- a/examples/webgl2/oimo/shogi/style.css
+++ b/examples/webgl2/oimo/shogi/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Roll out wireframe toggle behavior to WebGL 1.0/2.0 samples that already render physics/debug wireframes
- Add a unified W-key toggle handler (case-insensitive, ignore key repeat)
- Normalize initial state to OFF via showWireframe = false
- Gate all gl.LINES debug draws with showWireframe
- Add/update #hint UI in HTML/CSS to show W: wireframe ON/OFF

## Scope
- examples/webgl1/havok/*
- examples/webgl1/oimo/*
- examples/webgl2/havok/*
- examples/webgl2/oimo/*

## Validation
- Coverage check: keydown=51, showVar=51, htmlHint=51, cssHint=51
- VS Code diagnostics: no errors in examples/webgl1 and examples/webgl2