### PR TITLE
feat: add W-key wireframe toggle to WebGPU Havok glTF samples

### DIFF
--- a/examples/webgpu/havok/gltf/index.html
+++ b/examples/webgpu/havok/gltf/index.html
@@ -92,6 +92,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf/index.js
+++ b/examples/webgpu/havok/gltf/index.js
@@ -4,6 +4,7 @@ const { mat4, vec3, quat } = glMatrix;
 const DUCK_GLTF_URL = 'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
 const FALL_SCALE = 5.0;
 const SHOW_DEBUG_BBOX = true;
+let showWireframe = SHOW_DEBUG_BBOX;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 
 let canvas;
@@ -782,7 +783,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         const pResult = HK.HP_Body_GetPosition(duckBody);
         checkResult(pResult[0], 'HP_Body_GetPosition');
         const qResult = HK.HP_Body_GetOrientation(duckBody);
@@ -902,6 +903,12 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     groundMesh = createGroundMesh();
     groundRenderItem = createTriangleRenderItem(whiteTextureView);

--- a/examples/webgpu/havok/gltf/style.css
+++ b/examples/webgpu/havok/gltf/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.html
@@ -92,6 +92,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.js
@@ -3,6 +3,7 @@ const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/ShapeTypes/ShapeTypes.glb';
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = SHOW_DEBUG_COLLIDERS;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -1521,7 +1522,7 @@ function render(timeMs) {
 
     drawModelNodes(pass);
 
-    if (SHOW_DEBUG_COLLIDERS) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
 
         for (const node of physicsNodes) {
@@ -1644,6 +1645,12 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_Basic_Shapes/style.css
+++ b/examples/webgpu/havok/gltf_physics_Basic_Shapes/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Add W-key wireframe toggle for WebGPU + Havok `gltf` sample
- Add W-key wireframe toggle for WebGPU + Havok `gltf_physics_Basic_Shapes` sample
- Keep default behavior as ON, then allow toggling ON/OFF via `W`
- Add/update hint label (`W: wireframe ON/OFF`) and hint CSS in both samples

## Validation
- Verified toggle-related code paths and hint text in both sample directories
- VS Code diagnostics reported no errors for updated files