### PR TITLE
feat: add W-key wireframe toggle to remaining WebGPU Havok samples

### DIFF
--- a/examples/webgpu/havok/balls/index.html
+++ b/examples/webgpu/havok/balls/index.html
@@ -90,6 +90,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/balls/index.js
+++ b/examples/webgpu/havok/balls/index.js
@@ -35,6 +35,7 @@ let sphereMesh;
 let cubeMesh;
 
 let linePipeline;
+let showWireframe = true;
 let debugSphereVertexBuffer;
 let debugSphereIndexBuffer;
 let debugSphereIndexCount = 0;
@@ -436,7 +437,8 @@ function render(timeMs) {
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     for (let i = 0; i <= NUM_WALLS; i++) {
@@ -448,6 +450,8 @@ function render(timeMs) {
     for (let i = 0; i < balls.length; i++) {
         pass.setBindGroup(0, lineBindGroup, [(NUM_WALLS + 1 + i) * LINE_ALIGN]);
         pass.drawIndexed(debugSphereIndexCount);
+    }
+
     }
 
     pass.end();
@@ -611,6 +615,14 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     requestAnimationFrame(render);
 }

--- a/examples/webgpu/havok/balls/style.css
+++ b/examples/webgpu/havok/balls/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/box/index.html
+++ b/examples/webgpu/havok/box/index.html
@@ -90,6 +90,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -49,6 +49,7 @@ let cubeMesh;
 let groundMesh;
 
 let linePipeline;
+let showWireframe = true;
 let debugBoxVertexBuffer;
 let debugBoxIndexBuffer;
 let debugBoxIndexCount = 0;
@@ -445,12 +446,15 @@ function render(timeMs) {
         drawMesh(pass, cubeMesh, boxRenderItems[i].bindGroup);
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     for (let i = 0; i < NUM_LINE_OBJECTS; i++) {
         pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
         pass.drawIndexed(debugBoxIndexCount);
+    }
+
     }
 
     pass.end();
@@ -529,6 +533,14 @@ async function init() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     initPhysics();
     initRenderItems();

--- a/examples/webgpu/havok/box/style.css
+++ b/examples/webgpu/havok/box/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/cone/index.html
+++ b/examples/webgpu/havok/cone/index.html
@@ -90,6 +90,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/cone/index.js
+++ b/examples/webgpu/havok/cone/index.js
@@ -28,6 +28,7 @@ let coneMesh;
 let cubeMesh;
 
 let linePipeline;
+let showWireframe = true;
 let debugConeVertexBuffer;
 let debugConeIndexBuffer;
 let debugConeIndexCount = 0;
@@ -498,7 +499,8 @@ function render(timeMs) {
         drawMesh(pass, cubeMesh, renderItem.bindGroup);
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     for (let i = 0; i <= NUM_WALLS; i++) {
@@ -510,6 +512,8 @@ function render(timeMs) {
     for (let i = 0; i < cones.length; i++) {
         pass.setBindGroup(0, lineBindGroup, [(NUM_WALLS + 1 + i) * LINE_ALIGN]);
         pass.drawIndexed(debugConeIndexCount);
+    }
+
     }
 
     pass.end();
@@ -644,6 +648,14 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     HK = await HavokPhysics({
         locateFile: function (path) {

--- a/examples/webgpu/havok/cone/style.css
+++ b/examples/webgpu/havok/cone/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/domino/index.html
+++ b/examples/webgpu/havok/domino/index.html
@@ -85,6 +85,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/domino/index.js
+++ b/examples/webgpu/havok/domino/index.js
@@ -92,6 +92,7 @@ const dominoUniformBuffers = [];
 const dominoBindGroups = [];
 
 let linePipeline;
+let showWireframe = true;
 let debugBoxVertexBuffer;
 let debugBoxIndexBuffer;
 let debugBoxIndexCount = 0;
@@ -411,12 +412,15 @@ function render(timeMs) {
         pass.drawIndexed(indexCount, 1, 0, 0, 0);
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     for (let i = 0; i < NUM_LINE_OBJECTS; i++) {
         pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
         pass.drawIndexed(debugBoxIndexCount);
+    }
+
     }
 
     pass.end();
@@ -538,6 +542,14 @@ async function init() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     initPhysics();
 

--- a/examples/webgpu/havok/domino/style.css
+++ b/examples/webgpu/havok/domino/style.css
@@ -9,3 +9,18 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/football/index.html
+++ b/examples/webgpu/havok/football/index.html
@@ -93,6 +93,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -60,6 +60,7 @@ let ballUniformBuffers = [];
 let ballBindGroups = [];
 
 let linePipeline;
+let showWireframe = true;
 let debugSphereVertexBuffer;
 let debugSphereIndexBuffer;
 let debugSphereIndexCount = 0;
@@ -443,7 +444,8 @@ function render(timeMs) {
         pass.drawIndexed(sphereMesh.indexCount, 1, 0, 0, 0);
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     pass.setBindGroup(0, lineBindGroup, [0]);
@@ -454,6 +456,8 @@ function render(timeMs) {
     for (let i = 1; i < NUM_LINE_OBJECTS; i++) {
         pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
         pass.drawIndexed(debugSphereIndexCount);
+    }
+
     }
 
     pass.end();
@@ -604,6 +608,14 @@ async function init() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     initPhysics();
 

--- a/examples/webgpu/havok/football/style.css
+++ b/examples/webgpu/havok/football/style.css
@@ -9,3 +9,18 @@ body {
   background: #000;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/marbles/index.html
+++ b/examples/webgpu/havok/marbles/index.html
@@ -308,6 +308,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/marbles/index.js
+++ b/examples/webgpu/havok/marbles/index.js
@@ -37,6 +37,7 @@ let groundRenderItem;
 let groundTextureView;
 
 let linePipeline;
+let showWireframe = true;
 let debugSphereVertexBuffer;
 let debugSphereIndexBuffer;
 let debugSphereIndexCount = 0;
@@ -982,7 +983,8 @@ function render(timeMs) {
         }
     }
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     pass.setBindGroup(0, lineBindGroup, [0]);
@@ -992,6 +994,8 @@ function render(timeMs) {
     for (let i = 1; i < NUM_LINE_OBJECTS; i++) {
         pass.setBindGroup(0, lineBindGroup, [i * LINE_ALIGN]);
         pass.drawIndexed(debugSphereIndexCount);
+    }
+
     }
 
     pass.end();
@@ -1132,6 +1136,14 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     groundMesh = createGroundMesh();
     groundRenderItem = createRenderItem(

--- a/examples/webgpu/havok/marbles/style.css
+++ b/examples/webgpu/havok/marbles/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/minimum/index.html
+++ b/examples/webgpu/havok/minimum/index.html
@@ -73,6 +73,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/minimum/index.js
+++ b/examples/webgpu/havok/minimum/index.js
@@ -29,6 +29,7 @@ let groundBindGroup;
 let cubeBindGroup;
 
 let linePipeline;
+let showWireframe = true;
 let debugBoxVertexBuffer;
 let debugBoxIndexBuffer;
 let debugBoxIndexCount = 0;
@@ -354,13 +355,16 @@ function render(timeMs) {
     pass.setBindGroup(0, cubeBindGroup);
     pass.drawIndexed(indexCount, 1, 0, 0, 0);
 
-    pass.setPipeline(linePipeline);
+    if (showWireframe) {
+pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, debugBoxVertexBuffer);
     pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
     pass.setBindGroup(0, lineBindGroup, [0 * LINE_ALIGN]);
     pass.drawIndexed(debugBoxIndexCount);
     pass.setBindGroup(0, lineBindGroup, [1 * LINE_ALIGN]);
     pass.drawIndexed(debugBoxIndexCount);
+
+    }
 
     pass.end();
     device.queue.submit([encoder.finish()]);
@@ -497,6 +501,14 @@ async function init() {
 
     resize();
     window.addEventListener('resize', resize);
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
 
     initPhysics();
 

--- a/examples/webgpu/havok/minimum/style.css
+++ b/examples/webgpu/havok/minimum/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/havok/shogi/index.html
+++ b/examples/webgpu/havok/shogi/index.html
@@ -124,6 +124,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/shogi/index.js
+++ b/examples/webgpu/havok/shogi/index.js
@@ -20,6 +20,7 @@ const SHOGI_VMAT = new Float32Array([1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,-40,1]);
 let currentPMatrix = null;
 
 let linePipeline;
+let showWireframe = true;
 let debugBoxVertexBuffer;
 let debugBoxIndexBuffer;
 let debugBoxIndexCount = 0;
@@ -141,6 +142,13 @@ async function init() {
         depthTexture = createDepthTexture();
         currentPMatrix = makePerspective(45, canvas.width / canvas.height, 0.1, 1000.0);
         device.queue.writeBuffer(uniformBuffer, 0, currentPMatrix);
+    });
+
+    window.addEventListener('keydown', event => {
+        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     const gpu = navigator['gpu'];
@@ -665,7 +673,7 @@ function render() {
     passEncoder.setBindGroup(0, bindGroup);
     passEncoder.drawIndexed(indexNum, MAX, 0, 0, 0);
 
-    if (linePipeline) {
+    if (showWireframe && linePipeline) {
         passEncoder.setPipeline(linePipeline);
         passEncoder.setVertexBuffer(0, debugBoxVertexBuffer);
         passEncoder.setIndexBuffer(debugBoxIndexBuffer, 'uint16');

--- a/examples/webgpu/havok/shogi/style.css
+++ b/examples/webgpu/havok/shogi/style.css
@@ -10,3 +10,18 @@ body {
   height: 100%;
   background: #fff;
 }
+
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Add W-key wireframe toggle to remaining WebGPU Havok samples that were still defaulting to visible wireframes
- Keep current default behavior as ON, then allow ON/OFF toggle with `W`
- Add/update hint label and hint CSS in each updated sample

## Updated Samples
- examples/webgpu/havok/balls
- examples/webgpu/havok/box
- examples/webgpu/havok/cone
- examples/webgpu/havok/domino
- examples/webgpu/havok/football
- examples/webgpu/havok/marbles
- examples/webgpu/havok/minimum
- examples/webgpu/havok/shogi

## Validation
- Re-scan result for default-on & no-toggle targets: none
- VS Code diagnostics: no errors in updated sample paths