### PR TITLE
fix: harden W-key wireframe toggles in WebGPU samples

### DIFF
--- a/examples/webgpu/havok/balls/index.js
+++ b/examples/webgpu/havok/balls/index.js
@@ -617,7 +617,8 @@ async function main() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/box/index.js
+++ b/examples/webgpu/havok/box/index.js
@@ -535,7 +535,8 @@ async function init() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/cone/index.js
+++ b/examples/webgpu/havok/cone/index.js
@@ -650,7 +650,8 @@ async function main() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/domino/index.js
+++ b/examples/webgpu/havok/domino/index.js
@@ -544,7 +544,8 @@ async function init() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/football/index.js
+++ b/examples/webgpu/havok/football/index.js
@@ -610,7 +610,8 @@ async function init() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/gltf/index.js
+++ b/examples/webgpu/havok/gltf/index.js
@@ -904,7 +904,8 @@ async function main() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgpu/havok/gltf_physics_Basic_Shapes/index.js
@@ -1646,7 +1646,8 @@ async function main() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/marbles/index.js
+++ b/examples/webgpu/havok/marbles/index.js
@@ -1138,7 +1138,8 @@ async function main() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/minimum/index.js
+++ b/examples/webgpu/havok/minimum/index.js
@@ -503,7 +503,8 @@ async function init() {
     window.addEventListener('resize', resize);
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/shogi/index.js
+++ b/examples/webgpu/havok/shogi/index.js
@@ -145,7 +145,8 @@ async function init() {
     });
 
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         const hint = document.getElementById('hint');
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -706,7 +706,8 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });

--- a/examples/webgpu/wgsl_compute/cone/index.js
+++ b/examples/webgpu/wgsl_compute/cone/index.js
@@ -464,7 +464,8 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });

--- a/examples/webgpu/wgsl_compute/gltf/index.js
+++ b/examples/webgpu/wgsl_compute/gltf/index.js
@@ -561,7 +561,8 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
@@ -812,7 +812,8 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
@@ -769,7 +769,8 @@ async function init() {
 
     // ── W key toggle ──────────────────────────────────────────────────────
     window.addEventListener('keydown', e => {
-        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        const isWKey = e.code === 'KeyW' || e.key === 'w' || e.key === 'W';
+        if (!isWKey || e.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent =
             'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
@@ -735,7 +735,8 @@ async function init() {
 
     // ── W key toggle ──────────────────────────────────────────────────────
     window.addEventListener('keydown', e => {
-        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        const isWKey = e.code === 'KeyW' || e.key === 'w' || e.key === 'W';
+        if (!isWKey || e.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent =
             'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
@@ -837,7 +837,8 @@ async function init() {
     resize();
     window.addEventListener('resize', resize);
     window.addEventListener('keydown', event => {
-        if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -565,7 +565,8 @@ async function init() {
 
     // Toggle wireframe with W key
     window.addEventListener('keydown', e => {
-        if (e.key.toLowerCase() !== 'w' || e.repeat) return;
+        const isWKey = e.code === 'KeyW' || e.key === 'w' || e.key === 'W';
+        if (!isWKey || e.repeat) return;
         showWireframe = !showWireframe;
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });


### PR DESCRIPTION
## Summary
- add KeyW fallback (event.code) for wireframe toggle handlers
- keep existing event.key checks and event.repeat guard
- cover both WebGPU Havok and WGSL Compute samples that use W-key wireframe toggle

## Why
Some environments may not reliably trigger the previous event.key.toLowerCase() === 'w' condition alone. This makes the toggle more robust while preserving current behavior.

## Scope
- 18 files updated
- no rendering logic changes beyond key matching

## Validation
- searched for legacy key.toLowerCase() !== 'w' pattern in examples/webgpu/havok and examples/webgpu/wgsl_compute
- confirmed no diagnostics errors for updated WebGPU folders
