### PR TITLE
feat: improve Falling Coins WebGPU WGSL sample

### DIFF
--- a/examples/webgpu/wgsl_compute/coins/index.html
+++ b/examples/webgpu/wgsl_compute/coins/index.html
@@ -7,6 +7,7 @@
 <body>
 
 <script id="cs" type="x-shader/x-compute">
+const COIN_CAPACITY : u32 = 4096u;
 struct CoinState {
     position   : vec4<f32>,
     velocity   : vec4<f32>,
@@ -31,7 +32,6 @@ struct SimParams {
     spawnRange  : f32,
 }
 
-const COIN_CAPACITY : u32 = 2048u;
 const GROUND_HALF : f32 = 13.0;
 const PHYSICS_THICKNESS_SCALE : f32 = 1.0;
 
@@ -115,11 +115,11 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     var angVel = srcStates[i].angularVel.xyz;
 
     let outsideGround = abs(pos.x) > GROUND_HALF + radius || abs(pos.z) > GROUND_HALF + radius;
-    if (pos.y < params.groundY - 8.0 || (outsideGround && pos.y < params.groundY - 1.5)) {
+    if (pos.y < params.groundY - 24.0 || (outsideGround && pos.y < params.groundY - 12.0)) {
         let s = seed + 1.37;
         pos = vec3<f32>(
             (rand(s) - 0.5) * params.spawnRange,
-            params.groundY + 18.0 + rand(s + 1.0) * 14.0,
+            params.groundY + 24.0 + rand(s + 1.0) * 18.0,
             (rand(s + 2.0) - 0.5) * params.spawnRange,
         );
         angVel = vec3<f32>(
@@ -290,7 +290,7 @@ struct VSOut {
     @location(6) worldPosition : vec3<f32>,
 }
 
-const COIN_CAPACITY : u32 = 2048u;
+const COIN_CAPACITY : u32 = 4096u;
 
 @group(0) @binding(0) var<uniform> camera : Camera;
 @group(0) @binding(1) var<storage, read> states : array<CoinState>;

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -9,7 +9,7 @@ const wireFragmentShaderWGSL = document.getElementById('wfs').textContent;
 const canvas = document.getElementById('c');
 
 const ENV_HDR_URL = 'https://cx20.github.io/gltf-test/textures/hdr/papermill.hdr';
-const MAX_COINS = 2048;
+const MAX_COINS = 4096;
 const STATIC_COUNT = 1;
 const STATE_FLOATS = 16;
 const INFO_FLOATS = 12;
@@ -400,7 +400,7 @@ async function createInitialData() {
         const type = COIN_TYPES[Math.min(COIN_TYPES.length - 1, Math.floor(randomFromIndex(coin) * COIN_TYPES.length))];
         const stateBase = coin * STATE_FLOATS;
         states[stateBase + 0] = (randomFromIndex(coin * 3 + 11) - 0.5) * SPAWN_RANGE;
-        states[stateBase + 1] = (randomFromIndex(coin * 7 + 23) + 1.0) * 15.0;
+        states[stateBase + 1] = (randomFromIndex(coin * 7 + 23) + 1.2) * 18.0;
         states[stateBase + 2] = (randomFromIndex(coin * 5 + 17) - 0.5) * SPAWN_RANGE;
         states[stateBase + 3] = seed;
         states[stateBase + 4] = 0;
@@ -444,7 +444,7 @@ function createStaticItems() {
 function writeCamera(timeMs) {
     const alpha = -Math.PI / 6;
     const beta = 76 * Math.PI / 180;
-    const radius = 24;
+    const radius = 50;
     const target = [0, -8, 0];
     const eye = [
         target[0] + Math.cos(alpha) * Math.sin(beta) * radius,


### PR DESCRIPTION
## Summary

- Raise camera radius to 50 for wider view
- Increase initial spawn height so coins fall from higher positions
- Delay respawn trigger so coins stay visible before disappearing
- Increase coin count from 2048 to 4096

## Files

- examples/webgpu/wgsl_compute/coins/index.js
- examples/webgpu/wgsl_compute/coins/index.html