### PR TITLE
Fix Havok materials friction wireframe debug rendering

### DIFF
--- a/examples/webgl1/havok/balls/index.js
+++ b/examples/webgl1/havok/balls/index.js
@@ -529,7 +529,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -519,7 +519,8 @@ async function init() {
     gl.useProgram(program);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/cone/index.js
+++ b/examples/webgl1/havok/cone/index.js
@@ -653,7 +653,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -454,7 +454,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -580,7 +580,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf/index.js
+++ b/examples/webgl1/havok/gltf/index.js
@@ -922,7 +922,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
@@ -1557,7 +1557,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl1/havok/gltf_physics_Filtering/index.js
@@ -1310,7 +1310,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1428,7 +1428,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.js
@@ -1501,7 +1501,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1619,7 +1619,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
@@ -513,6 +513,9 @@ async function buildModel(url) {
         worldScale: vec3.fromValues(1, 1, 1),
         bodyId: null,
         debugSize: null,
+        debugShapeType: 'box',
+        debugGLMesh: null,
+        debugTransformMatrix: null,
         initialPosition: null,
         initialRotation: null,
         physicsExt: node.extensions ? node.extensions.KHR_physics_rigid_bodies : null
@@ -785,29 +788,89 @@ function applyPhysicsMaterial(shapeId, materialDef) {
 }
 
 function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
-    if (!shapeDef || shapeDef.type !== 'box' || !shapeDef.box) {
-        throw new Error('This sample currently supports KHR_implicit_shapes box colliders only.');
+    if (!shapeDef) {
+        throw new Error('Invalid KHR_implicit_shapes definition.');
     }
 
-    const size = [
-        Math.abs(shapeDef.box.size[0] * node.worldScale[0]),
-        Math.abs(shapeDef.box.size[1] * node.worldScale[1]),
-        Math.abs(shapeDef.box.size[2] * node.worldScale[2])
-    ];
+    let shapeId;
+    let size;
+    let shapeType = shapeDef.type;
+    let volume = 0.0001;
 
-    const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
-    checkResult(created[0], 'HP_Shape_CreateBox');
-    const shapeId = created[1];
+    if (shapeDef.type === 'box' && shapeDef.box) {
+        const boxSize = shapeDef.box.size || [1, 1, 1];
+        size = [
+            Math.abs(boxSize[0] * node.worldScale[0]),
+            Math.abs(boxSize[1] * node.worldScale[1]),
+            Math.abs(boxSize[2] * node.worldScale[2])
+        ];
+
+        const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
+        checkResult(created[0], 'HP_Shape_CreateBox');
+        shapeId = created[1];
+        volume = Math.max(size[0] * size[1] * size[2], 0.0001);
+    } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
+        const baseRadius = shapeDef.sphere.radius !== undefined ? shapeDef.sphere.radius : 0.5;
+        const maxScale = Math.max(
+            Math.abs(node.worldScale[0]),
+            Math.abs(node.worldScale[1]),
+            Math.abs(node.worldScale[2])
+        );
+        const radius = Math.max(Math.abs(baseRadius * maxScale), 0.0001);
+        const created = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
+        checkResult(created[0], 'HP_Shape_CreateSphere');
+        shapeId = created[1];
+        size = [radius * 2, radius * 2, radius * 2];
+        volume = Math.max((4.0 / 3.0) * Math.PI * radius * radius * radius, 0.0001);
+    } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
+        const capsuleDef = shapeDef.capsule;
+        const radiusTop = capsuleDef.radiusTop !== undefined ? capsuleDef.radiusTop : 0.5;
+        const radiusBottom = capsuleDef.radiusBottom !== undefined ? capsuleDef.radiusBottom : 0.5;
+        const height = capsuleDef.height !== undefined ? capsuleDef.height : 1.0;
+        const avgRadius = (radiusTop + radiusBottom) * 0.5;
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledRadius = Math.max(avgRadius * scaleXZ, 0.0001);
+        const scaledHalfShaft = Math.max(height * Math.abs(node.worldScale[1]) * 0.5, 0);
+        const created = HK.HP_Shape_CreateCapsule([0, -scaledHalfShaft, 0], [0, scaledHalfShaft, 0], scaledRadius);
+        checkResult(created[0], 'HP_Shape_CreateCapsule');
+        shapeId = created[1];
+        size = [scaledRadius * 2, scaledHalfShaft * 2 + scaledRadius * 2, scaledRadius * 2];
+        volume = Math.max(Math.PI * scaledRadius * scaledRadius * (scaledHalfShaft * 2) + (4.0 / 3.0) * Math.PI * scaledRadius * scaledRadius * scaledRadius, 0.0001);
+    } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
+        const cylDef = shapeDef.cylinder;
+        const cRadiusTop = cylDef.radiusTop !== undefined ? cylDef.radiusTop : 0.5;
+        const cRadiusBottom = cylDef.radiusBottom !== undefined ? cylDef.radiusBottom : 0.5;
+        const cHeight = cylDef.height !== undefined ? cylDef.height : 1.0;
+        const maxCylRadius = Math.max(Math.max(cRadiusTop, cRadiusBottom), 0.0001);
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledCylRadius = Math.max(maxCylRadius * scaleXZ, 0.0001);
+        const scaledCylHalfHeight = Math.max(cHeight * Math.abs(node.worldScale[1]) * 0.5, 0.0001);
+        if (typeof HK.HP_Shape_CreateCylinder === 'function') {
+            const created = HK.HP_Shape_CreateCylinder([0, -scaledCylHalfHeight, 0], [0, scaledCylHalfHeight, 0], scaledCylRadius);
+            checkResult(created[0], 'HP_Shape_CreateCylinder');
+            shapeId = created[1];
+        } else {
+            const s = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+            const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, s);
+            checkResult(created[0], 'HP_Shape_CreateBox');
+            shapeId = created[1];
+            shapeType = 'box';
+        }
+        size = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+        volume = Math.max(Math.PI * scaledCylRadius * scaledCylRadius * scaledCylHalfHeight * 2, 0.0001);
+    } else {
+        throw new Error('Unsupported KHR_implicit_shapes collider type: ' + String(shapeDef.type));
+    }
 
     if (motionDef) {
-        const volume = Math.max(size[0] * size[1] * size[2], 0.0001);
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
 
     applyPhysicsMaterial(shapeId, materialDef);
 
-    return { shapeId, size };
+    return { shapeId, size, shapeType };
 }
 
 function initPhysics() {
@@ -834,7 +897,7 @@ function initPhysics() {
             ? materialDefs[node.physicsExt.collider.physicsMaterial]
             : null;
 
-        const { shapeId, size } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
+        const { shapeId, size, shapeType } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
         const position = vec3.create();
         const rotation = quat.create();
         mat4.getTranslation(position, node.restWorldMatrix);
@@ -843,6 +906,8 @@ function initPhysics() {
         node.initialPosition = [position[0], position[1], position[2]];
         node.initialRotation = [rotation[0], rotation[1], rotation[2], rotation[3]];
         node.debugSize = size;
+        node.debugShapeType = shapeType;
+        node.debugTransformMatrix = mat4.create();
 
         const motionType = motionDef ? HK.MotionType.DYNAMIC : HK.MotionType.STATIC;
         node.bodyId = createBody(shapeId, motionType, node.initialPosition, node.initialRotation, !!motionDef);
@@ -863,12 +928,92 @@ function updatePhysicsTransforms() {
 
         const position = pResult[1];
         const rotation = qResult[1];
+        const rot = quat.fromValues(rotation[0], rotation[1], rotation[2], rotation[3]);
+        const pos = vec3.fromValues(position[0], position[1], position[2]);
         mat4.fromRotationTranslationScale(
             node.worldMatrix,
-            quat.fromValues(rotation[0], rotation[1], rotation[2], rotation[3]),
-            vec3.fromValues(position[0], position[1], position[2]),
+            rot,
+            pos,
             node.worldScale
         );
+
+        if (node.debugTransformMatrix) {
+            mat4.fromRotationTranslation(node.debugTransformMatrix, rot, pos);
+        }
+    }
+}
+
+function buildPhysicsDebugMeshes() {
+    if (typeof HK.HP_Shape_CreateDebugDisplayGeometry !== 'function') {
+        return;
+    }
+
+    for (const node of physicsNodes) {
+        if (node.debugShapeType === 'box') {
+            continue;
+        }
+
+        const shapeRes = HK.HP_Body_GetShape(node.bodyId);
+        if (!shapeRes) continue;
+
+        const geomRes = HK.HP_Shape_CreateDebugDisplayGeometry(shapeRes[1]);
+        if (!geomRes) continue;
+
+        const geomHandle = geomRes[1];
+        let infoRes;
+        try {
+            infoRes = HK.HP_DebugGeometry_GetInfo(geomHandle);
+        } catch (_e) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        if (!infoRes) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        const info = infoRes[1];
+        const posOffset = info[0];
+        const numVerts = info[1];
+        const triOffset = info[2];
+        const numTris = info[3];
+
+        const positions = new Float32Array(HK.HEAPU8.buffer, posOffset, numVerts * 3).slice();
+        const triIndices = new Uint32Array(HK.HEAPU8.buffer, triOffset, numTris * 3).slice();
+        HK.HP_DebugGeometry_Release(geomHandle);
+
+        if (numVerts === 0 || numTris === 0) continue;
+
+        const lineIndices = new Uint32Array(numTris * 6);
+        for (let tri = 0; tri < numTris; tri++) {
+            const i0 = triIndices[tri * 3 + 0];
+            const i1 = triIndices[tri * 3 + 1];
+            const i2 = triIndices[tri * 3 + 2];
+            lineIndices[tri * 6 + 0] = i0;
+            lineIndices[tri * 6 + 1] = i1;
+            lineIndices[tri * 6 + 2] = i1;
+            lineIndices[tri * 6 + 3] = i2;
+            lineIndices[tri * 6 + 4] = i2;
+            lineIndices[tri * 6 + 5] = i0;
+        }
+
+        const positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+        const indexBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+        const useUint32 = !!extUint;
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, useUint32 ? lineIndices : new Uint16Array(lineIndices), gl.STATIC_DRAW);
+
+        node.debugTransformMatrix = mat4.create();
+        node.debugGLMesh = {
+            positionBuffer,
+            indexBuffer,
+            count: lineIndices.length,
+            indexType: useUint32 ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT
+        };
     }
 }
 
@@ -895,20 +1040,36 @@ function drawPhysicsDebug() {
     gl.useProgram(lineProgram);
     gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
 
-    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.positionBuffer);
-    gl.enableVertexAttribArray(lineAttribs.position);
-    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
-    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
-
+    const wasDepthTestEnabled = gl.isEnabled(gl.DEPTH_TEST);
+    gl.disable(gl.DEPTH_TEST);
     gl.disable(gl.CULL_FACE);
     for (const node of physicsNodes) {
-        const model = mat4.clone(node.worldMatrix);
-        mat4.scale(model, model, node.debugSize);
-        gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        const color = node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0];
+
+        if (node.debugGLMesh && node.debugTransformMatrix) {
+            gl.bindBuffer(gl.ARRAY_BUFFER, node.debugGLMesh.positionBuffer);
+            gl.enableVertexAttribArray(lineAttribs.position);
+            gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, node.debugGLMesh.indexBuffer);
+            gl.uniformMatrix4fv(lineUniforms.model, false, node.debugTransformMatrix);
+            gl.uniform4fv(lineUniforms.color, color);
+            gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
+        } else {
+            const model = node.debugTransformMatrix ? mat4.clone(node.debugTransformMatrix) : mat4.clone(node.worldMatrix);
+            mat4.scale(model, model, node.debugSize);
+            gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.positionBuffer);
+            gl.enableVertexAttribArray(lineAttribs.position);
+            gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
+            gl.uniformMatrix4fv(lineUniforms.model, false, model);
+            gl.uniform4fv(lineUniforms.color, color);
+            gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        }
     }
     gl.enable(gl.CULL_FACE);
+    if (wasDepthTestEnabled) {
+        gl.enable(gl.DEPTH_TEST);
+    }
 }
 
 function renderFrame(timeSec) {
@@ -1028,6 +1189,7 @@ window.addEventListener('keydown', event => {
     cameraHeight = Math.max(sizeY * 0.9, 5.5);
 
     initPhysics();
+    buildPhysicsDebugMeshes();
     updatePhysicsTransforms();
 
     requestAnimationFrame((ts) => renderFrame(ts * 0.001));

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
@@ -888,7 +888,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1001,7 +1001,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
@@ -909,7 +909,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1022,7 +1022,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -1276,7 +1276,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1394,7 +1394,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl1/havok/gltf_physics_Triggers/index.js
@@ -1317,7 +1317,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1435,7 +1435,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/marbles/index.js
+++ b/examples/webgl1/havok/marbles/index.js
@@ -1185,7 +1185,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/minimum/index.js
+++ b/examples/webgl1/havok/minimum/index.js
@@ -429,7 +429,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/havok/shogi/index.js
+++ b/examples/webgl1/havok/shogi/index.js
@@ -13,7 +13,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/balls/index.js
+++ b/examples/webgl1/oimo/balls/index.js
@@ -462,7 +462,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -439,7 +439,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/cone/index.js
+++ b/examples/webgl1/oimo/cone/index.js
@@ -434,7 +434,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/domino/index.js
+++ b/examples/webgl1/oimo/domino/index.js
@@ -1,4 +1,4 @@
-﻿// forked from gaziya's "Domino  (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
+// forked from gaziya's "Domino  (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
 // ‥‥‥‥‥‥〓〓〓〓〓‥‥□□□
@@ -79,7 +79,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -27,7 +27,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -477,7 +477,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/gltf/index.js
+++ b/examples/webgl1/oimo/gltf/index.js
@@ -848,7 +848,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/marbles/index.js
+++ b/examples/webgl1/oimo/marbles/index.js
@@ -1053,7 +1053,8 @@ async function main() {
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE, { flipY: true });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/minimum/index.js
+++ b/examples/webgl1/oimo/minimum/index.js
@@ -68,7 +68,8 @@ function initWebGL() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl1/oimo/shogi/index.js
+++ b/examples/webgl1/oimo/shogi/index.js
@@ -24,7 +24,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/balls/index.js
+++ b/examples/webgl2/havok/balls/index.js
@@ -517,7 +517,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -505,7 +505,8 @@ async function init() {
     gl.useProgram(program);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/cone/index.js
+++ b/examples/webgl2/havok/cone/index.js
@@ -573,7 +573,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/domino/index.js
+++ b/examples/webgl2/havok/domino/index.js
@@ -457,7 +457,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -557,7 +557,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf/index.js
+++ b/examples/webgl2/havok/gltf/index.js
@@ -902,7 +902,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
@@ -1557,7 +1557,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl2/havok/gltf_physics_Filtering/index.js
@@ -1320,7 +1320,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1439,7 +1439,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.js
@@ -1511,7 +1511,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1630,7 +1630,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
@@ -513,6 +513,9 @@ async function buildModel(url) {
         worldScale: vec3.fromValues(1, 1, 1),
         bodyId: null,
         debugSize: null,
+        debugShapeType: 'box',
+        debugGLMesh: null,
+        debugTransformMatrix: null,
         initialPosition: null,
         initialRotation: null,
         physicsExt: node.extensions ? node.extensions.KHR_physics_rigid_bodies : null
@@ -785,29 +788,89 @@ function applyPhysicsMaterial(shapeId, materialDef) {
 }
 
 function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
-    if (!shapeDef || shapeDef.type !== 'box' || !shapeDef.box) {
-        throw new Error('This sample currently supports KHR_implicit_shapes box colliders only.');
+    if (!shapeDef) {
+        throw new Error('Invalid KHR_implicit_shapes definition.');
     }
 
-    const size = [
-        Math.abs(shapeDef.box.size[0] * node.worldScale[0]),
-        Math.abs(shapeDef.box.size[1] * node.worldScale[1]),
-        Math.abs(shapeDef.box.size[2] * node.worldScale[2])
-    ];
+    let shapeId;
+    let size;
+    let shapeType = shapeDef.type;
+    let volume = 0.0001;
 
-    const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
-    checkResult(created[0], 'HP_Shape_CreateBox');
-    const shapeId = created[1];
+    if (shapeDef.type === 'box' && shapeDef.box) {
+        const boxSize = shapeDef.box.size || [1, 1, 1];
+        size = [
+            Math.abs(boxSize[0] * node.worldScale[0]),
+            Math.abs(boxSize[1] * node.worldScale[1]),
+            Math.abs(boxSize[2] * node.worldScale[2])
+        ];
+
+        const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
+        checkResult(created[0], 'HP_Shape_CreateBox');
+        shapeId = created[1];
+        volume = Math.max(size[0] * size[1] * size[2], 0.0001);
+    } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
+        const baseRadius = shapeDef.sphere.radius !== undefined ? shapeDef.sphere.radius : 0.5;
+        const maxScale = Math.max(
+            Math.abs(node.worldScale[0]),
+            Math.abs(node.worldScale[1]),
+            Math.abs(node.worldScale[2])
+        );
+        const radius = Math.max(Math.abs(baseRadius * maxScale), 0.0001);
+        const created = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
+        checkResult(created[0], 'HP_Shape_CreateSphere');
+        shapeId = created[1];
+        size = [radius * 2, radius * 2, radius * 2];
+        volume = Math.max((4.0 / 3.0) * Math.PI * radius * radius * radius, 0.0001);
+    } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
+        const capsuleDef = shapeDef.capsule;
+        const radiusTop = capsuleDef.radiusTop !== undefined ? capsuleDef.radiusTop : 0.5;
+        const radiusBottom = capsuleDef.radiusBottom !== undefined ? capsuleDef.radiusBottom : 0.5;
+        const height = capsuleDef.height !== undefined ? capsuleDef.height : 1.0;
+        const avgRadius = (radiusTop + radiusBottom) * 0.5;
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledRadius = Math.max(avgRadius * scaleXZ, 0.0001);
+        const scaledHalfShaft = Math.max(height * Math.abs(node.worldScale[1]) * 0.5, 0);
+        const created = HK.HP_Shape_CreateCapsule([0, -scaledHalfShaft, 0], [0, scaledHalfShaft, 0], scaledRadius);
+        checkResult(created[0], 'HP_Shape_CreateCapsule');
+        shapeId = created[1];
+        size = [scaledRadius * 2, scaledHalfShaft * 2 + scaledRadius * 2, scaledRadius * 2];
+        volume = Math.max(Math.PI * scaledRadius * scaledRadius * (scaledHalfShaft * 2) + (4.0 / 3.0) * Math.PI * scaledRadius * scaledRadius * scaledRadius, 0.0001);
+    } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
+        const cylDef = shapeDef.cylinder;
+        const cRadiusTop = cylDef.radiusTop !== undefined ? cylDef.radiusTop : 0.5;
+        const cRadiusBottom = cylDef.radiusBottom !== undefined ? cylDef.radiusBottom : 0.5;
+        const cHeight = cylDef.height !== undefined ? cylDef.height : 1.0;
+        const maxCylRadius = Math.max(Math.max(cRadiusTop, cRadiusBottom), 0.0001);
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledCylRadius = Math.max(maxCylRadius * scaleXZ, 0.0001);
+        const scaledCylHalfHeight = Math.max(cHeight * Math.abs(node.worldScale[1]) * 0.5, 0.0001);
+        if (typeof HK.HP_Shape_CreateCylinder === 'function') {
+            const created = HK.HP_Shape_CreateCylinder([0, -scaledCylHalfHeight, 0], [0, scaledCylHalfHeight, 0], scaledCylRadius);
+            checkResult(created[0], 'HP_Shape_CreateCylinder');
+            shapeId = created[1];
+        } else {
+            const s = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+            const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, s);
+            checkResult(created[0], 'HP_Shape_CreateBox');
+            shapeId = created[1];
+            shapeType = 'box';
+        }
+        size = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+        volume = Math.max(Math.PI * scaledCylRadius * scaledCylRadius * scaledCylHalfHeight * 2, 0.0001);
+    } else {
+        throw new Error('Unsupported KHR_implicit_shapes collider type: ' + String(shapeDef.type));
+    }
 
     if (motionDef) {
-        const volume = Math.max(size[0] * size[1] * size[2], 0.0001);
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
 
     applyPhysicsMaterial(shapeId, materialDef);
 
-    return { shapeId, size };
+    return { shapeId, size, shapeType };
 }
 
 function initPhysics() {
@@ -834,7 +897,7 @@ function initPhysics() {
             ? materialDefs[node.physicsExt.collider.physicsMaterial]
             : null;
 
-        const { shapeId, size } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
+        const { shapeId, size, shapeType } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
         const position = vec3.create();
         const rotation = quat.create();
         mat4.getTranslation(position, node.restWorldMatrix);
@@ -843,6 +906,8 @@ function initPhysics() {
         node.initialPosition = [position[0], position[1], position[2]];
         node.initialRotation = [rotation[0], rotation[1], rotation[2], rotation[3]];
         node.debugSize = size;
+        node.debugShapeType = shapeType;
+        node.debugTransformMatrix = mat4.create();
 
         const motionType = motionDef ? HK.MotionType.DYNAMIC : HK.MotionType.STATIC;
         node.bodyId = createBody(shapeId, motionType, node.initialPosition, node.initialRotation, !!motionDef);
@@ -863,12 +928,92 @@ function updatePhysicsTransforms() {
 
         const position = pResult[1];
         const rotation = qResult[1];
+        const rot = quat.fromValues(rotation[0], rotation[1], rotation[2], rotation[3]);
+        const pos = vec3.fromValues(position[0], position[1], position[2]);
         mat4.fromRotationTranslationScale(
             node.worldMatrix,
-            quat.fromValues(rotation[0], rotation[1], rotation[2], rotation[3]),
-            vec3.fromValues(position[0], position[1], position[2]),
+            rot,
+            pos,
             node.worldScale
         );
+
+        if (node.debugTransformMatrix) {
+            mat4.fromRotationTranslation(node.debugTransformMatrix, rot, pos);
+        }
+    }
+}
+
+function buildPhysicsDebugMeshes() {
+    if (typeof HK.HP_Shape_CreateDebugDisplayGeometry !== 'function') {
+        return;
+    }
+
+    for (const node of physicsNodes) {
+        if (node.debugShapeType === 'box') {
+            continue;
+        }
+
+        const shapeRes = HK.HP_Body_GetShape(node.bodyId);
+        if (!shapeRes) continue;
+
+        const geomRes = HK.HP_Shape_CreateDebugDisplayGeometry(shapeRes[1]);
+        if (!geomRes) continue;
+
+        const geomHandle = geomRes[1];
+        let infoRes;
+        try {
+            infoRes = HK.HP_DebugGeometry_GetInfo(geomHandle);
+        } catch (_e) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        if (!infoRes) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        const info = infoRes[1];
+        const posOffset = info[0];
+        const numVerts = info[1];
+        const triOffset = info[2];
+        const numTris = info[3];
+
+        const positions = new Float32Array(HK.HEAPU8.buffer, posOffset, numVerts * 3).slice();
+        const triIndices = new Uint32Array(HK.HEAPU8.buffer, triOffset, numTris * 3).slice();
+        HK.HP_DebugGeometry_Release(geomHandle);
+
+        if (numVerts === 0 || numTris === 0) continue;
+
+        const lineIndices = new Uint32Array(numTris * 6);
+        for (let tri = 0; tri < numTris; tri++) {
+            const i0 = triIndices[tri * 3 + 0];
+            const i1 = triIndices[tri * 3 + 1];
+            const i2 = triIndices[tri * 3 + 2];
+            lineIndices[tri * 6 + 0] = i0;
+            lineIndices[tri * 6 + 1] = i1;
+            lineIndices[tri * 6 + 2] = i1;
+            lineIndices[tri * 6 + 3] = i2;
+            lineIndices[tri * 6 + 4] = i2;
+            lineIndices[tri * 6 + 5] = i0;
+        }
+
+        const positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+
+        const indexBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+        const useUint32 = !!extUint;
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, useUint32 ? lineIndices : new Uint16Array(lineIndices), gl.STATIC_DRAW);
+
+        node.debugTransformMatrix = mat4.create();
+        node.debugGLMesh = {
+            positionBuffer,
+            indexBuffer,
+            count: lineIndices.length,
+            indexType: useUint32 ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT
+        };
     }
 }
 
@@ -895,20 +1040,36 @@ function drawPhysicsDebug() {
     gl.useProgram(lineProgram);
     gl.uniformMatrix4fv(lineUniforms.viewProj, false, viewProj);
 
-    gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.positionBuffer);
-    gl.enableVertexAttribArray(lineAttribs.position);
-    gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
-    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
-
+    const wasDepthTestEnabled = gl.isEnabled(gl.DEPTH_TEST);
+    gl.disable(gl.DEPTH_TEST);
     gl.disable(gl.CULL_FACE);
     for (const node of physicsNodes) {
-        const model = mat4.clone(node.worldMatrix);
-        mat4.scale(model, model, node.debugSize);
-        gl.uniformMatrix4fv(lineUniforms.model, false, model);
-        gl.uniform4fv(lineUniforms.color, node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0]);
-        if (showWireframe) gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        const color = node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.2, 0.9, 0.35, 1.0];
+
+        if (node.debugGLMesh && node.debugTransformMatrix) {
+            gl.bindBuffer(gl.ARRAY_BUFFER, node.debugGLMesh.positionBuffer);
+            gl.enableVertexAttribArray(lineAttribs.position);
+            gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, node.debugGLMesh.indexBuffer);
+            gl.uniformMatrix4fv(lineUniforms.model, false, node.debugTransformMatrix);
+            gl.uniform4fv(lineUniforms.color, color);
+            gl.drawElements(gl.LINES, node.debugGLMesh.count, node.debugGLMesh.indexType, 0);
+        } else {
+            const model = node.debugTransformMatrix ? mat4.clone(node.debugTransformMatrix) : mat4.clone(node.worldMatrix);
+            mat4.scale(model, model, node.debugSize);
+            gl.bindBuffer(gl.ARRAY_BUFFER, debugBoxMesh.positionBuffer);
+            gl.enableVertexAttribArray(lineAttribs.position);
+            gl.vertexAttribPointer(lineAttribs.position, 3, gl.FLOAT, false, 0, 0);
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, debugBoxMesh.indexBuffer);
+            gl.uniformMatrix4fv(lineUniforms.model, false, model);
+            gl.uniform4fv(lineUniforms.color, color);
+            gl.drawElements(gl.LINES, debugBoxMesh.count, gl.UNSIGNED_SHORT, 0);
+        }
     }
     gl.enable(gl.CULL_FACE);
+    if (wasDepthTestEnabled) {
+        gl.enable(gl.DEPTH_TEST);
+    }
 }
 
 function renderFrame(timeSec) {
@@ -1028,6 +1189,7 @@ window.addEventListener('keydown', event => {
     cameraHeight = Math.max(sizeY * 0.9, 5.5);
 
     initPhysics();
+    buildPhysicsDebugMeshes();
     updatePhysicsTransforms();
 
     requestAnimationFrame((ts) => renderFrame(ts * 0.001));

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
@@ -888,7 +888,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1001,7 +1001,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
@@ -909,7 +909,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1022,7 +1022,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -1286,7 +1286,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1405,7 +1405,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl2/havok/gltf_physics_Triggers/index.js
@@ -1327,7 +1327,7 @@ function resetDynamicBodiesIfNeeded() {
 }
 
 function drawPhysicsDebug() {
-    if (!SHOW_DEBUG_COLLIDERS) {
+    if (!showWireframe) {
         return;
     }
 
@@ -1446,7 +1446,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/marbles/index.js
+++ b/examples/webgl2/havok/marbles/index.js
@@ -1161,7 +1161,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/minimum/index.js
+++ b/examples/webgl2/havok/minimum/index.js
@@ -433,7 +433,8 @@ async function init() {
     debugBoxMesh = createDebugWireframeBoxMesh();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/havok/shogi/index.js
+++ b/examples/webgl2/havok/shogi/index.js
@@ -12,7 +12,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/balls/index.js
+++ b/examples/webgl2/oimo/balls/index.js
@@ -452,7 +452,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -422,7 +422,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/cone/index.js
+++ b/examples/webgl2/oimo/cone/index.js
@@ -421,7 +421,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/domino/index.js
+++ b/examples/webgl2/oimo/domino/index.js
@@ -85,7 +85,8 @@ function resizeCanvas() {
 let program = gl.createProgram();
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -467,7 +467,8 @@ async function main() {
     gl.uniform1i(uniforms.texture, 0);
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/gltf/index.js
+++ b/examples/webgl2/oimo/gltf/index.js
@@ -825,7 +825,8 @@ async function main() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/marbles/index.js
+++ b/examples/webgl2/oimo/marbles/index.js
@@ -1033,7 +1033,8 @@ async function main() {
     groundTexture = await loadTexture(GROUND_TEXTURE_FILE, { flipY: true });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/minimum/index.js
+++ b/examples/webgl2/oimo/minimum/index.js
@@ -78,7 +78,8 @@ function initWorld() {
     });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgl2/oimo/shogi/index.js
+++ b/examples/webgl2/oimo/shogi/index.js
@@ -10,7 +10,8 @@ window.addEventListener("resize", function(){
 });
 
 window.addEventListener('keydown', event => {
-    if (event.key.toLowerCase() !== 'w' || event.repeat) return;
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
     showWireframe = !showWireframe;
     const hint = document.getElementById('hint');
     if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
@@ -93,6 +93,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
+<div id="hint">W: wireframe OFF</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
@@ -2,7 +2,6 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
-const SHOW_DEBUG_BBOX = false;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -13,6 +12,7 @@ let format;
 
 let trianglePipeline;
 let linePipeline;
+let showWireframe = false;
 let textureSampler;
 let depthTexture;
 let whiteTextureView;
@@ -537,6 +537,11 @@ async function buildDuckModel(url) {
         physicsExt: node.extensions ? node.extensions.KHR_physics_rigid_bodies : null,
         bodyId: null,
         debugSize: [1, 1, 1],
+        debugShapeType: 'box',
+        debugGPUMesh: null,
+        debugTransformMatrix: null,
+        debugLineUniformBuffer: null,
+        debugLineBindGroup: null,
         initialPosition: null,
         initialRotation: null
     }));
@@ -751,29 +756,89 @@ function applyPhysicsMaterial(shapeId, materialDef) {
 }
 
 function createPhysicsShape(node, shapeDef, motionDef, materialDef) {
-    if (!shapeDef || shapeDef.type !== 'box' || !shapeDef.box) {
-        throw new Error('This sample currently supports KHR_implicit_shapes box colliders only.');
+    if (!shapeDef) {
+        throw new Error('Invalid KHR_implicit_shapes definition.');
     }
 
-    const size = [
-        Math.abs(shapeDef.box.size[0] * node.worldScale[0]),
-        Math.abs(shapeDef.box.size[1] * node.worldScale[1]),
-        Math.abs(shapeDef.box.size[2] * node.worldScale[2])
-    ];
+    let shapeId;
+    let size;
+    let shapeType = shapeDef.type;
+    let volume = 0.0001;
 
-    const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
-    checkResult(created[0], 'HP_Shape_CreateBox');
-    const shapeId = created[1];
+    if (shapeDef.type === 'box' && shapeDef.box) {
+        const boxSize = shapeDef.box.size || [1, 1, 1];
+        size = [
+            Math.abs(boxSize[0] * node.worldScale[0]),
+            Math.abs(boxSize[1] * node.worldScale[1]),
+            Math.abs(boxSize[2] * node.worldScale[2])
+        ];
+
+        const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
+        checkResult(created[0], 'HP_Shape_CreateBox');
+        shapeId = created[1];
+        volume = Math.max(size[0] * size[1] * size[2], 0.0001);
+    } else if (shapeDef.type === 'sphere' && shapeDef.sphere) {
+        const baseRadius = shapeDef.sphere.radius !== undefined ? shapeDef.sphere.radius : 0.5;
+        const maxScale = Math.max(
+            Math.abs(node.worldScale[0]),
+            Math.abs(node.worldScale[1]),
+            Math.abs(node.worldScale[2])
+        );
+        const radius = Math.max(Math.abs(baseRadius * maxScale), 0.0001);
+        const created = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
+        checkResult(created[0], 'HP_Shape_CreateSphere');
+        shapeId = created[1];
+        size = [radius * 2, radius * 2, radius * 2];
+        volume = Math.max((4.0 / 3.0) * Math.PI * radius * radius * radius, 0.0001);
+    } else if (shapeDef.type === 'capsule' && shapeDef.capsule) {
+        const capsuleDef = shapeDef.capsule;
+        const radiusTop = capsuleDef.radiusTop !== undefined ? capsuleDef.radiusTop : 0.5;
+        const radiusBottom = capsuleDef.radiusBottom !== undefined ? capsuleDef.radiusBottom : 0.5;
+        const height = capsuleDef.height !== undefined ? capsuleDef.height : 1.0;
+        const avgRadius = (radiusTop + radiusBottom) * 0.5;
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledRadius = Math.max(avgRadius * scaleXZ, 0.0001);
+        const scaledHalfShaft = Math.max(height * Math.abs(node.worldScale[1]) * 0.5, 0);
+        const created = HK.HP_Shape_CreateCapsule([0, -scaledHalfShaft, 0], [0, scaledHalfShaft, 0], scaledRadius);
+        checkResult(created[0], 'HP_Shape_CreateCapsule');
+        shapeId = created[1];
+        size = [scaledRadius * 2, scaledHalfShaft * 2 + scaledRadius * 2, scaledRadius * 2];
+        volume = Math.max(Math.PI * scaledRadius * scaledRadius * (scaledHalfShaft * 2) + (4.0 / 3.0) * Math.PI * scaledRadius * scaledRadius * scaledRadius, 0.0001);
+    } else if (shapeDef.type === 'cylinder' && shapeDef.cylinder) {
+        const cylDef = shapeDef.cylinder;
+        const cRadiusTop = cylDef.radiusTop !== undefined ? cylDef.radiusTop : 0.5;
+        const cRadiusBottom = cylDef.radiusBottom !== undefined ? cylDef.radiusBottom : 0.5;
+        const cHeight = cylDef.height !== undefined ? cylDef.height : 1.0;
+        const maxCylRadius = Math.max(Math.max(cRadiusTop, cRadiusBottom), 0.0001);
+        const scaleXZ = Math.max(Math.abs(node.worldScale[0]), Math.abs(node.worldScale[2]));
+        const scaledCylRadius = Math.max(maxCylRadius * scaleXZ, 0.0001);
+        const scaledCylHalfHeight = Math.max(cHeight * Math.abs(node.worldScale[1]) * 0.5, 0.0001);
+        if (typeof HK.HP_Shape_CreateCylinder === 'function') {
+            const created = HK.HP_Shape_CreateCylinder([0, -scaledCylHalfHeight, 0], [0, scaledCylHalfHeight, 0], scaledCylRadius);
+            checkResult(created[0], 'HP_Shape_CreateCylinder');
+            shapeId = created[1];
+        } else {
+            const s = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+            const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, s);
+            checkResult(created[0], 'HP_Shape_CreateBox');
+            shapeId = created[1];
+            shapeType = 'box';
+        }
+        size = [scaledCylRadius * 2, scaledCylHalfHeight * 2, scaledCylRadius * 2];
+        volume = Math.max(Math.PI * scaledCylRadius * scaledCylRadius * scaledCylHalfHeight * 2, 0.0001);
+    } else {
+        throw new Error('Unsupported KHR_implicit_shapes collider type: ' + String(shapeDef.type));
+    }
 
     if (motionDef) {
-        const volume = Math.max(size[0] * size[1] * size[2], 0.0001);
-        const density = motionDef.mass !== undefined ? motionDef.mass / volume : 1;
+        const specMass = motionDef.mass !== undefined ? motionDef.mass : undefined;
+        const density = (specMass !== undefined && specMass > 0) ? specMass / volume : 1;
         checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
     }
 
     applyPhysicsMaterial(shapeId, materialDef);
 
-    return { shapeId, size };
+    return { shapeId, size, shapeType };
 }
 
 function initPhysics() {
@@ -800,7 +865,7 @@ function initPhysics() {
             ? materialDefs[node.physicsExt.collider.physicsMaterial]
             : null;
 
-        const { shapeId, size } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
+        const { shapeId, size, shapeType } = createPhysicsShape(node, shapeDef, motionDef, materialDef);
 
         const p = vec3.create();
         const q = quat.create();
@@ -810,6 +875,16 @@ function initPhysics() {
         node.initialPosition = [p[0], p[1], p[2]];
         node.initialRotation = [q[0], q[1], q[2], q[3]];
         node.debugSize = size;
+        node.debugShapeType = shapeType;
+        node.debugTransformMatrix = mat4.create();
+        node.debugLineUniformBuffer = device.createBuffer({
+            size: 144,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+        });
+        node.debugLineBindGroup = device.createBindGroup({
+            layout: linePipeline.getBindGroupLayout(0),
+            entries: [{ binding: 0, resource: { buffer: node.debugLineUniformBuffer } }]
+        });
 
         const motionType = motionDef ? HK.MotionType.DYNAMIC : HK.MotionType.STATIC;
         node.bodyId = createBody(shapeId, motionType, node.initialPosition, node.initialRotation, !!motionDef);
@@ -817,6 +892,92 @@ function initPhysics() {
         if (motionDef) {
             dynamicNodes.push(node);
         }
+    }
+}
+
+function buildPhysicsDebugMeshes() {
+    if (typeof HK.HP_Shape_CreateDebugDisplayGeometry !== 'function') {
+        return;
+    }
+
+    for (const node of physicsNodes) {
+        if (node.debugShapeType === 'box') {
+            continue;
+        }
+
+        const shapeRes = HK.HP_Body_GetShape(node.bodyId);
+        if (!shapeRes) continue;
+
+        const geomRes = HK.HP_Shape_CreateDebugDisplayGeometry(shapeRes[1]);
+        if (!geomRes) continue;
+
+        const geomHandle = geomRes[1];
+        let infoRes;
+        try {
+            infoRes = HK.HP_DebugGeometry_GetInfo(geomHandle);
+        } catch (_e) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        if (!infoRes) {
+            HK.HP_DebugGeometry_Release(geomHandle);
+            continue;
+        }
+
+        const info = infoRes[1];
+        const posOffset = info[0];
+        const numVerts = info[1];
+        const triOffset = info[2];
+        const numTris = info[3];
+
+        const positions = new Float32Array(HK.HEAPU8.buffer, posOffset, numVerts * 3).slice();
+        const triIndices = new Uint32Array(HK.HEAPU8.buffer, triOffset, numTris * 3).slice();
+        HK.HP_DebugGeometry_Release(geomHandle);
+
+        if (numVerts === 0 || numTris === 0) continue;
+
+        const lineIndices = new Uint32Array(numTris * 6);
+        for (let tri = 0; tri < numTris; tri++) {
+            const i0 = triIndices[tri * 3 + 0];
+            const i1 = triIndices[tri * 3 + 1];
+            const i2 = triIndices[tri * 3 + 2];
+            lineIndices[tri * 6 + 0] = i0;
+            lineIndices[tri * 6 + 1] = i1;
+            lineIndices[tri * 6 + 2] = i1;
+            lineIndices[tri * 6 + 3] = i2;
+            lineIndices[tri * 6 + 4] = i2;
+            lineIndices[tri * 6 + 5] = i0;
+        }
+
+        const positionBuffer = device.createBuffer({
+            size: positions.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        });
+        device.queue.writeBuffer(positionBuffer, 0, positions);
+
+        const indexBuffer = device.createBuffer({
+            size: lineIndices.byteLength,
+            usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST
+        });
+        device.queue.writeBuffer(indexBuffer, 0, lineIndices);
+
+        const uniformBuffer = device.createBuffer({
+            size: 144,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+        });
+        const bindGroup = device.createBindGroup({
+            layout: linePipeline.getBindGroupLayout(0),
+            entries: [{ binding: 0, resource: { buffer: uniformBuffer } }]
+        });
+
+        node.debugGPUMesh = {
+            positionBuffer,
+            indexBuffer,
+            indexCount: lineIndices.length,
+            uniformBuffer,
+            bindGroup
+        };
     }
 }
 
@@ -829,13 +990,19 @@ function updatePhysicsTransforms() {
 
         const p = pResult[1];
         const q = qResult[1];
+        const rot = quat.fromValues(q[0], q[1], q[2], q[3]);
+        const pos = vec3.fromValues(p[0], p[1], p[2]);
 
         mat4.fromRotationTranslationScale(
             node.worldMatrix,
-            quat.fromValues(q[0], q[1], q[2], q[3]),
-            vec3.fromValues(p[0], p[1], p[2]),
+            rot,
+            pos,
             node.worldScale
         );
+
+        if (node.debugTransformMatrix) {
+            mat4.fromRotationTranslation(node.debugTransformMatrix, rot, pos);
+        }
     }
 }
 
@@ -946,21 +1113,29 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
-        pass.setBindGroup(0, debugLineBindGroup);
-        pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
-        pass.setIndexBuffer(debugBoxMesh.indexBuffer, 'uint16');
 
         for (const node of physicsNodes) {
-            const debugModel = mat4.clone(node.worldMatrix);
-            mat4.scale(debugModel, debugModel, node.debugSize);
-            writeLineUniforms(
-                debugLineUniformBuffer,
-                debugModel,
-                node.physicsExt.motion ? [1.0, 0.35, 0.2, 1.0] : [0.0, 1.0, 0.0, 1.0]
-            );
-            pass.drawIndexed(debugBoxMesh.indexCount, 1, 0, 0, 0);
+            const color = node.physicsExt.motion ? [0.0, 1.0, 1.0, 1.0] : [0.0, 1.0, 0.0, 1.0];
+
+            if (node.debugGPUMesh && node.debugTransformMatrix) {
+                writeLineUniforms(node.debugGPUMesh.uniformBuffer, node.debugTransformMatrix, color);
+                pass.setBindGroup(0, node.debugGPUMesh.bindGroup);
+                pass.setVertexBuffer(0, node.debugGPUMesh.positionBuffer);
+                pass.setIndexBuffer(node.debugGPUMesh.indexBuffer, 'uint32');
+                pass.drawIndexed(node.debugGPUMesh.indexCount, 1, 0, 0, 0);
+            } else {
+                const debugModel = mat4.clone(node.debugTransformMatrix || node.worldMatrix);
+                mat4.scale(debugModel, debugModel, node.debugSize);
+                const uniformBuffer = node.debugLineUniformBuffer || debugLineUniformBuffer;
+                const bindGroup = node.debugLineBindGroup || debugLineBindGroup;
+                writeLineUniforms(uniformBuffer, debugModel, color);
+                pass.setBindGroup(0, bindGroup);
+                pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
+                pass.setIndexBuffer(debugBoxMesh.indexBuffer, 'uint16');
+                pass.drawIndexed(debugBoxMesh.indexCount, 1, 0, 0, 0);
+            }
         }
     }
 
@@ -1047,7 +1222,7 @@ async function main() {
         depthStencil: {
             format: 'depth24plus',
             depthWriteEnabled: false,
-            depthCompare: 'less-equal'
+            depthCompare: 'always'
         }
     });
 
@@ -1063,6 +1238,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({
@@ -1090,6 +1272,7 @@ async function main() {
     cameraHeight = Math.max(sizeY * 0.9, 5.5);
 
     initPhysics();
+    buildPhysicsDebugMeshes();
     updatePhysicsTransforms();
     requestAnimationFrame(render);
 }

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/style.css
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add runtime W-key wireframe toggles for WebGPU Havok Materials_Friction
- render box colliders with 12-edge OBB wireframes instead of Havok triangle debug edges
- keep non-box debug geometry support and per-node WebGPU line uniforms

## Verification
- VS Code problems check: no errors for modified files
- manually verified WebGL2 Materials_Friction wireframes show box outlines without diagonals