### PR TITLE
Remove trailing whitespace from WebGL1 Oimo domino

### DIFF
--- a/examples/webgl1/oimo/domino/index.js
+++ b/examples/webgl1/oimo/domino/index.js
@@ -344,4 +344,3 @@ let fps0 = 0;
 
     requestAnimationFrame(arguments.callee);
 })();
- 


### PR DESCRIPTION
## Summary
- remove a whitespace-only trailing line from the WebGL1 Oimo domino sample

## Verification
- git diff --cached --check before commit
- rg -n "[ \\t]+$" on the affected WebGL1 Oimo files returned no matches
- VS Code problems check: no errors for the modified file