### PR TITLE
Add WGSL compute skybox and wireframe debug views

### DIFF
--- a/examples/webgpu/wgsl_compute/balls/index.html
+++ b/examples/webgpu/wgsl_compute/balls/index.html
@@ -333,8 +333,77 @@ fn main(
 }
 </script>
 
+<script id="vs-line" type="x-shader/x-vertex">
+struct Camera {
+    viewProjection : mat4x4<f32>,
+}
+
+struct BallState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+
+struct BallInfo {
+    data : vec4<f32>,
+}
+
+struct StaticItem {
+    position : vec4<f32>,
+    scale    : vec4<f32>,
+    color    : vec4<f32>,
+}
+
+struct VSOut {
+    @builtin(position) position : vec4<f32>,
+    @location(0) color : vec4<f32>,
+}
+
+const STATIC_COUNT : u32 = 5u;
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> states : array<BallState>;
+@group(0) @binding(2) var<storage, read> infos : array<BallInfo>;
+@group(0) @binding(3) var<storage, read> statics : array<StaticItem>;
+
+fn rotByQuat(v : vec3<f32>, q : vec4<f32>) -> vec3<f32> {
+    let t = 2.0 * cross(q.xyz, v);
+    return v + q.w * t + cross(q.xyz, t);
+}
+
+@vertex
+fn main(@location(0) position : vec3<f32>, @builtin(instance_index) instance : u32) -> VSOut {
+    var out : VSOut;
+    var worldPos : vec3<f32>;
+
+    if (instance < STATIC_COUNT) {
+        let item = statics[instance];
+        worldPos = position * item.scale.xyz + item.position.xyz;
+        out.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+    } else {
+        let ballIndex = instance - STATIC_COUNT;
+        let state = states[ballIndex];
+        let info = infos[ballIndex].data;
+        worldPos = rotByQuat(position * info.x, state.rotation) + state.position.xyz;
+        out.color = vec4<f32>(1.0, 1.0, 0.0, 1.0);
+    }
+
+    out.position = camera.viewProjection * vec4<f32>(worldPos, 1.0);
+    return out;
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+@fragment
+fn main(@location(0) color : vec4<f32>) -> @location(0) vec4<f32> {
+    return color;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/wgsl_compute/balls/index.js
+++ b/examples/webgpu/wgsl_compute/balls/index.js
@@ -1,6 +1,8 @@
 const computeShaderWGSL = document.getElementById('cs').textContent;
 const vertexShaderWGSL = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
+const lineVertexShaderWGSL = document.getElementById('vs-line').textContent;
+const lineFragmentShaderWGSL = document.getElementById('fs-line').textContent;
 
 const canvas = document.getElementById('c');
 
@@ -27,15 +29,20 @@ const TEXTURE_FILES = [
 ];
 
 let device, context, format, depthTexture;
-let renderPipeline, computePipeline;
+let renderPipeline, computePipeline, linePipeline;
 let sphereMesh, cubeMesh;
+let debugSphereVertexBuffer, debugSphereIndexBuffer, debugBoxVertexBuffer, debugBoxIndexBuffer;
 let cameraBuffer, ballInfoBuffer, staticBuffer, simParamsBuffer;
 let sampler, textureView;
 let stateBuffers = [];
 let renderBindGroups = [];
 let computeBindGroups = [];
+let lineBindGroups = [];
 let currentState = 0;
 let lastTime = -1;
+let showWireframe = true;
+let debugSphereIndexCount = 0;
+let debugBoxIndexCount = 0;
 
 const projectionMatrix = new Float32Array(16);
 const viewMatrix = new Float32Array(16);
@@ -248,6 +255,42 @@ function drawMesh(pass, mesh, instanceCount, firstInstance = 0) {
     pass.drawIndexed(mesh.indexCount, instanceCount, 0, 0, firstInstance);
 }
 
+function createDebugLineMeshes() {
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+    ]);
+    const boxLineIndices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7,
+    ]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = createVertexBuffer(boxLineVerts);
+    debugBoxIndexBuffer = createIndexBuffer(boxLineIndices);
+
+    const sphereSegments = 32;
+    const sphereLineVerts = [];
+    const sphereLineIndices = [];
+    const rings = [[1, 0, 2], [0, 1, 2], [1, 2, 0]];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = ring * sphereSegments;
+        for (let i = 0; i < sphereSegments; i++) {
+            const a = (i / sphereSegments) * Math.PI * 2;
+            const v = [0, 0, 0];
+            v[rings[ring][0]] = Math.cos(a);
+            v[rings[ring][1]] = Math.sin(a);
+            sphereLineVerts.push(...v);
+            sphereLineIndices.push(base + i, base + ((i + 1) % sphereSegments));
+        }
+    }
+    const sphereLineVertsF32 = new Float32Array(sphereLineVerts);
+    const sphereLineIndicesU16 = new Uint16Array(sphereLineIndices);
+    debugSphereIndexCount = sphereLineIndicesU16.length;
+    debugSphereVertexBuffer = createVertexBuffer(sphereLineVertsF32);
+    debugSphereIndexBuffer = createIndexBuffer(sphereLineIndicesU16);
+}
+
 function frame(timeMs) {
     if (lastTime < 0) {
         lastTime = timeMs;
@@ -296,6 +339,19 @@ function frame(timeMs) {
     renderPass.setBindGroup(0, renderBindGroups[currentState]);
     drawMesh(renderPass, sphereMesh, BALL_COUNT);
     drawMesh(renderPass, cubeMesh, STATIC_COUNT, BALL_COUNT);
+
+    if (showWireframe) {
+        renderPass.setPipeline(linePipeline);
+        renderPass.setBindGroup(0, lineBindGroups[currentState]);
+
+        renderPass.setVertexBuffer(0, debugBoxVertexBuffer);
+        renderPass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+        renderPass.drawIndexed(debugBoxIndexCount, STATIC_COUNT, 0, 0, 0);
+
+        renderPass.setVertexBuffer(0, debugSphereVertexBuffer);
+        renderPass.setIndexBuffer(debugSphereIndexBuffer, 'uint16');
+        renderPass.drawIndexed(debugSphereIndexCount, BALL_COUNT, 0, 0, STATIC_COUNT);
+    }
     renderPass.end();
 
     device.queue.submit([encoder.finish()]);
@@ -373,6 +429,22 @@ async function init() {
         depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' },
     });
 
+    linePipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: lineVertexShaderWGSL }),
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }],
+        },
+        fragment: {
+            module: device.createShaderModule({ code: lineFragmentShaderWGSL }),
+            entryPoint: 'main',
+            targets: [{ format }],
+        },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' },
+    });
+
     computePipeline = device.createComputePipeline({
         layout: 'auto',
         compute: {
@@ -380,6 +452,8 @@ async function init() {
             entryPoint: 'main',
         },
     });
+
+    createDebugLineMeshes();
 
     for (let i = 0; i < 2; i++) {
         renderBindGroups.push(device.createBindGroup({
@@ -403,10 +477,27 @@ async function init() {
                 { binding: 3, resource: { buffer: simParamsBuffer } },
             ],
         }));
+
+        lineBindGroups.push(device.createBindGroup({
+            layout: linePipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: cameraBuffer } },
+                { binding: 1, resource: { buffer: stateBuffers[i] } },
+                { binding: 2, resource: { buffer: ballInfoBuffer } },
+                { binding: 3, resource: { buffer: staticBuffer } },
+            ],
+        }));
     }
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     requestAnimationFrame(frame);
 }

--- a/examples/webgpu/wgsl_compute/balls/style.css
+++ b/examples/webgpu/wgsl_compute/balls/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}

--- a/examples/webgpu/wgsl_compute/marbles/index.html
+++ b/examples/webgpu/wgsl_compute/marbles/index.html
@@ -436,8 +436,122 @@ fn main(
 }
 </script>
 
+<script id="skybox-vs" type="x-shader/x-vertex">
+struct SkyboxUniforms {
+    projection : mat4x4<f32>,
+    viewNoTranslation : mat4x4<f32>,
+    exposure : f32,
+    _pad0 : vec3<f32>,
+};
+
+struct VSOut {
+    @builtin(position) position : vec4<f32>,
+    @location(0) dir : vec3<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : SkyboxUniforms;
+
+@vertex
+fn main(@location(0) position : vec3<f32>) -> VSOut {
+    var out : VSOut;
+    out.dir = position;
+    let pos = uniforms.projection * uniforms.viewNoTranslation * vec4<f32>(position, 1.0);
+    out.position = vec4<f32>(pos.xy, pos.w, pos.w);
+    return out;
+}
+</script>
+
+<script id="skybox-fs" type="x-shader/x-fragment">
+struct SkyboxUniforms {
+    projection : mat4x4<f32>,
+    viewNoTranslation : mat4x4<f32>,
+    exposure : f32,
+    _pad0 : vec3<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms : SkyboxUniforms;
+@group(0) @binding(1) var texSampler : sampler;
+@group(0) @binding(2) var envCubeTex : texture_cube<f32>;
+
+@fragment
+fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
+    var env = textureSample(envCubeTex, texSampler, normalize(dir)).rgb * uniforms.exposure;
+    env = env / (env + vec3<f32>(1.0));
+    env = pow(env, vec3<f32>(1.0 / 2.2));
+    return vec4<f32>(env, 1.0);
+}
+</script>
+
+<script id="vs-line" type="x-shader/x-vertex">
+struct Camera {
+    viewProjection : mat4x4<f32>,
+    cameraPos      : vec4<f32>,
+}
+
+struct MarbleState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+
+struct MarbleInfo {
+    data : vec4<f32>,
+}
+
+struct StaticItem {
+    position : vec4<f32>,
+    scale    : vec4<f32>,
+    color    : vec4<f32>,
+}
+
+struct VSOut {
+    @builtin(position) position : vec4<f32>,
+    @location(0) color : vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> states : array<MarbleState>;
+@group(0) @binding(2) var<storage, read> infos : array<MarbleInfo>;
+@group(0) @binding(3) var<storage, read> statics : array<StaticItem>;
+
+fn rotByQuat(v : vec3<f32>, q : vec4<f32>) -> vec3<f32> {
+    let t = 2.0 * cross(q.xyz, v);
+    return v + q.w * t + cross(q.xyz, t);
+}
+
+@vertex
+fn main(@location(0) position : vec3<f32>, @builtin(instance_index) instance : u32) -> VSOut {
+    var out : VSOut;
+    var worldPos : vec3<f32>;
+
+    if (instance == 0u) {
+        let item = statics[0];
+        worldPos = position * item.scale.xyz + item.position.xyz;
+        out.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+    } else {
+        let marbleIndex = instance - 1u;
+        let state = states[marbleIndex];
+        let info = infos[marbleIndex].data;
+        worldPos = rotByQuat(position * info.x, state.rotation) + state.position.xyz;
+        out.color = vec4<f32>(1.0, 1.0, 0.0, 1.0);
+    }
+
+    out.position = camera.viewProjection * vec4<f32>(worldPos, 1.0);
+    return out;
+}
+</script>
+
+<script id="fs-line" type="x-shader/x-fragment">
+@fragment
+fn main(@location(0) color : vec4<f32>) -> @location(0) vec4<f32> {
+    return color;
+}
+</script>
+
 <canvas id="c" width="465" height="465"></canvas>
 
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/wgsl_compute/marbles/index.js
+++ b/examples/webgpu/wgsl_compute/marbles/index.js
@@ -1,6 +1,10 @@
 const computeShaderWGSL = document.getElementById('cs').textContent;
 const vertexShaderWGSL = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
+const skyboxVertexShaderWGSL = document.getElementById('skybox-vs').textContent;
+const skyboxFragmentShaderWGSL = document.getElementById('skybox-fs').textContent;
+const lineVertexShaderWGSL = document.getElementById('vs-line').textContent;
+const lineFragmentShaderWGSL = document.getElementById('fs-line').textContent;
 
 const canvas = document.getElementById('c');
 
@@ -20,19 +24,26 @@ const SPAWN_HEIGHT = 7.0;
 const MARBLE_SCALE = 1.0;
 
 let device, context, format, depthTexture;
-let renderPipeline, computePipeline;
+let renderPipeline, computePipeline, skyboxPipeline, linePipeline;
 let cubeMesh;
-let cameraBuffer, marbleInfoBuffer, staticBuffer, simParamsBuffer;
+let skyboxVertexBuffer, debugSphereVertexBuffer, debugSphereIndexBuffer, debugBoxVertexBuffer, debugBoxIndexBuffer;
+let cameraBuffer, skyboxUniformBuffer, marbleInfoBuffer, staticBuffer, simParamsBuffer;
 let sampler, whiteTextureView, blackCubeTextureView, envCubeTextureView, groundMaterial;
+let skyboxBindGroup;
 let marbleTemplates = [];
 let stateBuffers = [];
 let renderBindGroups = [];
 let computeBindGroups = [];
+let lineBindGroups = [];
 let currentState = 0;
 let lastTime = -1;
+let showWireframe = true;
+let debugSphereIndexCount = 0;
+let debugBoxIndexCount = 0;
 
 const projectionMatrix = new Float32Array(16);
 const viewMatrix = new Float32Array(16);
+const viewNoTranslationMatrix = new Float32Array(16);
 const viewProjectionMatrix = new Float32Array(16);
 
 function resize() {
@@ -158,7 +169,7 @@ function createSolidCubeTextureView(color = [0, 0, 0, 255]) {
     const texture = device.createTexture({
         size: [1, 1, 6],
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
     });
     for (let face = 0; face < 6; face++) {
         device.queue.copyExternalImageToTexture(
@@ -735,6 +746,78 @@ function drawMesh(pass, mesh, instanceCount, firstInstance = 0) {
     pass.drawIndexed(mesh.indexCount, instanceCount, 0, 0, firstInstance);
 }
 
+function drawSkybox(encoder, colorView) {
+    if (!skyboxPipeline || !skyboxBindGroup) return;
+
+    viewNoTranslationMatrix.set(viewMatrix);
+    viewNoTranslationMatrix[12] = 0;
+    viewNoTranslationMatrix[13] = 0;
+    viewNoTranslationMatrix[14] = 0;
+
+    const skyboxUniformData = new Float32Array(40);
+    skyboxUniformData.set(projectionMatrix, 0);
+    skyboxUniformData.set(viewNoTranslationMatrix, 16);
+    skyboxUniformData[32] = 1.0;
+    device.queue.writeBuffer(skyboxUniformBuffer, 0, skyboxUniformData);
+
+    const pass = encoder.beginRenderPass({
+        colorAttachments: [{
+            view: colorView,
+            clearValue: { r: 0.12, g: 0.12, b: 0.14, a: 1.0 },
+            loadOp: 'clear',
+            storeOp: 'store',
+        }],
+        depthStencilAttachment: {
+            view: depthTexture.createView(),
+            depthClearValue: 1.0,
+            depthLoadOp: 'clear',
+            depthStoreOp: 'store',
+        },
+    });
+
+    pass.setPipeline(skyboxPipeline);
+    pass.setBindGroup(0, skyboxBindGroup);
+    pass.setVertexBuffer(0, skyboxVertexBuffer);
+    pass.draw(36, 1, 0, 0);
+    pass.end();
+}
+
+function createDebugLineMeshes() {
+    const boxLineVerts = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,   0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,   0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+    ]);
+    const boxLineIndices = new Uint16Array([
+        0, 1, 1, 2, 2, 3, 3, 0,
+        4, 5, 5, 6, 6, 7, 7, 4,
+        0, 4, 1, 5, 2, 6, 3, 7,
+    ]);
+    debugBoxIndexCount = boxLineIndices.length;
+    debugBoxVertexBuffer = createVertexBuffer(boxLineVerts);
+    debugBoxIndexBuffer = createIndexBuffer(boxLineIndices);
+
+    const sphereSegments = 32;
+    const sphereLineVerts = [];
+    const sphereLineIndices = [];
+    const rings = [[1, 0, 2], [0, 1, 2], [1, 2, 0]];
+    for (let ring = 0; ring < 3; ring++) {
+        const base = ring * sphereSegments;
+        for (let i = 0; i < sphereSegments; i++) {
+            const a = (i / sphereSegments) * Math.PI * 2;
+            const v = [0, 0, 0];
+            v[rings[ring][0]] = Math.cos(a);
+            v[rings[ring][1]] = Math.sin(a);
+            sphereLineVerts.push(...v);
+            sphereLineIndices.push(base + i, base + ((i + 1) % sphereSegments));
+        }
+    }
+    const sphereLineVertsF32 = new Float32Array(sphereLineVerts);
+    const sphereLineIndicesU16 = new Uint16Array(sphereLineIndices);
+    debugSphereIndexCount = sphereLineIndicesU16.length;
+    debugSphereVertexBuffer = createVertexBuffer(sphereLineVertsF32);
+    debugSphereIndexBuffer = createIndexBuffer(sphereLineIndicesU16);
+}
+
 function frame(timeMs) {
     if (lastTime < 0) {
         lastTime = timeMs;
@@ -764,17 +847,18 @@ function frame(timeMs) {
         currentState = 1 - currentState;
     }
 
+    const colorView = context.getCurrentTexture().createView();
+    drawSkybox(encoder, colorView);
+
     const renderPass = encoder.beginRenderPass({
         colorAttachments: [{
-            view: context.getCurrentTexture().createView(),
-            clearValue: { r: 0.97, g: 0.97, b: 0.98, a: 1.0 },
-            loadOp: 'clear',
+            view: colorView,
+            loadOp: 'load',
             storeOp: 'store',
         }],
         depthStencilAttachment: {
             view: depthTexture.createView(),
-            depthClearValue: 1.0,
-            depthLoadOp: 'clear',
+            depthLoadOp: 'load',
             depthStoreOp: 'store',
         },
     });
@@ -790,6 +874,19 @@ function frame(timeMs) {
     }
     renderPass.setBindGroup(1, groundMaterial.bindGroup);
     drawMesh(renderPass, cubeMesh, STATIC_COUNT, MARBLE_COUNT);
+
+    if (showWireframe) {
+        renderPass.setPipeline(linePipeline);
+        renderPass.setBindGroup(0, lineBindGroups[currentState]);
+
+        renderPass.setVertexBuffer(0, debugBoxVertexBuffer);
+        renderPass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
+        renderPass.drawIndexed(debugBoxIndexCount, 1, 0, 0, 0);
+
+        renderPass.setVertexBuffer(0, debugSphereVertexBuffer);
+        renderPass.setIndexBuffer(debugSphereIndexBuffer, 'uint16');
+        renderPass.drawIndexed(debugSphereIndexCount, MARBLE_COUNT, 0, 0, 1);
+    }
     renderPass.end();
 
     device.queue.submit([encoder.finish()]);
@@ -883,6 +980,38 @@ async function init() {
         depthStencil: { format: 'depth24plus', depthWriteEnabled: true, depthCompare: 'less' },
     });
 
+    skyboxPipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: skyboxVertexShaderWGSL }),
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }],
+        },
+        fragment: {
+            module: device.createShaderModule({ code: skyboxFragmentShaderWGSL }),
+            entryPoint: 'main',
+            targets: [{ format }],
+        },
+        primitive: { topology: 'triangle-list', cullMode: 'none' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' },
+    });
+
+    linePipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: lineVertexShaderWGSL }),
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }],
+        },
+        fragment: {
+            module: device.createShaderModule({ code: lineFragmentShaderWGSL }),
+            entryPoint: 'main',
+            targets: [{ format }],
+        },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' },
+    });
+
     computePipeline = device.createComputePipeline({
         layout: 'auto',
         compute: {
@@ -891,6 +1020,36 @@ async function init() {
         },
     });
     assignMaterialBindGroups();
+
+    const skyboxVerts = new Float32Array([
+        -1, -1, -1,  1, -1, -1,  1,  1, -1,
+        -1, -1, -1,  1,  1, -1, -1,  1, -1,
+        -1, -1,  1,  1, -1,  1,  1,  1,  1,
+        -1, -1,  1,  1,  1,  1, -1,  1,  1,
+        -1, -1, -1, -1,  1, -1, -1,  1,  1,
+        -1, -1, -1, -1,  1,  1, -1, -1,  1,
+         1, -1, -1,  1,  1, -1,  1,  1,  1,
+         1, -1, -1,  1,  1,  1,  1, -1,  1,
+        -1, -1, -1, -1, -1,  1,  1, -1,  1,
+        -1, -1, -1,  1, -1,  1,  1, -1, -1,
+        -1,  1, -1, -1,  1,  1,  1,  1,  1,
+        -1,  1, -1,  1,  1,  1,  1,  1, -1,
+    ]);
+    skyboxVertexBuffer = createVertexBuffer(skyboxVerts);
+    skyboxUniformBuffer = device.createBuffer({
+        size: 40 * 4,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    skyboxBindGroup = device.createBindGroup({
+        layout: skyboxPipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: skyboxUniformBuffer } },
+            { binding: 1, resource: sampler },
+            { binding: 2, resource: envCubeTextureView || blackCubeTextureView },
+        ],
+    });
+
+    createDebugLineMeshes();
 
     for (let i = 0; i < 2; i++) {
         renderBindGroups.push(device.createBindGroup({
@@ -912,10 +1071,27 @@ async function init() {
                 { binding: 3, resource: { buffer: simParamsBuffer } },
             ],
         }));
+
+        lineBindGroups.push(device.createBindGroup({
+            layout: linePipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: cameraBuffer } },
+                { binding: 1, resource: { buffer: stateBuffers[i] } },
+                { binding: 2, resource: { buffer: marbleInfoBuffer } },
+                { binding: 3, resource: { buffer: staticBuffer } },
+            ],
+        }));
     }
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
     requestAnimationFrame(frame);
 }
 

--- a/examples/webgpu/wgsl_compute/marbles/style.css
+++ b/examples/webgpu/wgsl_compute/marbles/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add skybox rendering to the WebGPU WGSL compute Falling Marbles sample
- add W-key wireframe debug overlays to WebGPU WGSL compute Falling Balls and Falling Marbles
- render debug boxes and spheres directly from the WGSL compute state buffers

## Verification
- VS Code problems check: no errors for modified files
- git diff --check
- manually verified WGSL compute Balls and Marbles pages render and W toggles wireframes