### PR TITLE
Add W-key wireframe toggle to Falling Shogi (three.js + Babylon.js)

### DIFF
--- a/examples/babylonjs/havok/shogi/index.html
+++ b/examples/babylonjs/havok/shogi/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe OFF</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/shogi/index.js
+++ b/examples/babylonjs/havok/shogi/index.js
@@ -7,12 +7,18 @@ const PHYSICS_SCALE = 1 / 10;
 const PIECE_COUNT = 220;
 const BOX_HALF_EXTENT = 5 * PHYSICS_SCALE;
 const SPAWN_MARGIN = 0.6 * PHYSICS_SCALE;
+
+let showWireframe = false;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -23,17 +29,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/shogi/style.css
+++ b/examples/babylonjs/havok/shogi/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/shogi/index.html
+++ b/examples/threejs/havok/shogi/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe OFF</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/shogi/index.js
+++ b/examples/threejs/havok/shogi/index.js
@@ -4,13 +4,14 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const PIECE_COUNT = 220;
-const SHOW_DEBUG_COLLIDERS = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
 const meshes = [];
 const bodyIds = [];
 const debugMeshes = [];
+const staticDebugMeshes = [];
+let showWireframe = false;
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -160,14 +161,14 @@ function initPhysics() {
   const wallMat = new THREE.MeshLambertMaterial({ color: 0x3D4143, transparent: true, opacity: 0.4 });
 
   createStaticBox([40, 4, 40], [0, -2, 0], groundMat);
-  if (SHOW_DEBUG_COLLIDERS) {
-    const dbg = new THREE.LineSegments(
-      new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
-      new THREE.LineBasicMaterial({ color: 0x44ee88 })
-    );
-    dbg.position.set(0, -2, 0);
-    scene.add(dbg);
-  }
+  const groundDbg = new THREE.LineSegments(
+    new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
+    new THREE.LineBasicMaterial({ color: 0x44ee88 })
+  );
+  groundDbg.position.set(0, -2, 0);
+  groundDbg.visible = showWireframe;
+  scene.add(groundDbg);
+  staticDebugMeshes.push(groundDbg);
 
   const wallData = [
     { size: [10, 10,  1], pos: [ 0, 5, -5] },
@@ -177,14 +178,14 @@ function initPhysics() {
   ];
   for (const { size, pos } of wallData) {
     createStaticBox(size, pos, wallMat);
-    if (SHOW_DEBUG_COLLIDERS) {
-      const dbg = new THREE.LineSegments(
-        new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
-        new THREE.LineBasicMaterial({ color: 0x44ee88 })
-      );
-      dbg.position.set(pos[0], pos[1], pos[2]);
-      scene.add(dbg);
-    }
+    const wallDbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+      new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    wallDbg.position.set(pos[0], pos[1], pos[2]);
+    wallDbg.visible = showWireframe;
+    scene.add(wallDbg);
+    staticDebugMeshes.push(wallDbg);
   }
 
   const pieceW = 1.6;
@@ -222,14 +223,13 @@ function initPhysics() {
     mesh.receiveShadow = true;
     scene.add(mesh);
     meshes.push(mesh);
-    if (SHOW_DEBUG_COLLIDERS) {
-      const dbg = new THREE.LineSegments(
-        new THREE.EdgesGeometry(new THREE.BoxGeometry(pieceW, pieceH, pieceD * 1.4)),
-        new THREE.LineBasicMaterial({ color: 0xff8844 })
-      );
-      scene.add(dbg);
-      debugMeshes.push(dbg);
-    }
+    const dbg = new THREE.LineSegments(
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(pieceW, pieceH, pieceD * 1.4)),
+      new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    dbg.visible = showWireframe;
+    scene.add(dbg);
+    debugMeshes.push(dbg);
   }
 }
 
@@ -240,7 +240,7 @@ function updatePhysics() {
     const [, ori] = HK.HP_Body_GetOrientation(bodyIds[i]);
     meshes[i].position.set(pos[0], pos[1], pos[2]);
     meshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
-    if (SHOW_DEBUG_COLLIDERS && debugMeshes[i]) {
+    if (debugMeshes[i]) {
       debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
       debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
     }
@@ -264,10 +264,26 @@ function loop() {
   requestAnimationFrame(loop);
 }
 
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  for (const dbg of staticDebugMeshes) dbg.visible = visible;
+  for (const dbg of debugMeshes) dbg.visible = visible;
+  const hint = document.getElementById('hint');
+  if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
 async function main() {
   HK = await HavokPhysics();
   initThree();
   initPhysics();
+
+  window.addEventListener('keydown', (e) => {
+    if (e.repeat) return;
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+      setWireframeVisible(!showWireframe);
+    }
+  });
+
   setInterval(updatePhysics, 1000 / 60);
   loop();
 }

--- a/examples/threejs/havok/shogi/style.css
+++ b/examples/threejs/havok/shogi/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Both Falling Shogi samples used to render their physics debug wireframes permanently. This PR replaces that with a runtime toggle (default OFF), bound to the `W` key, matching the existing convention used by the Falling Coins samples.

### three.js / Havok / shogi (`examples/threejs/havok/shogi/`)
- Drop the `SHOW_DEBUG_COLLIDERS` compile-time constant.
- Track every debug `LineSegments` (ground box, walls, shogi pieces) so a single `setWireframeVisible(visible)` call can flip them all.
- Default `showWireframe = false`; all debug meshes are created hidden.

### Babylon.js / Havok / shogi (`examples/babylonjs/havok/shogi/`)
- `setupPhysicsDebugWireframe` now records each discovered body / impostor into `trackedBodies` / `trackedImpostors` instead of calling `showImpostor` / `showBody` immediately on sight.
- `setWireframeVisible(visible)` drives `PhysicsViewer.show*` / `hide*` over the tracked collections on demand.
- Default `showWireframe = false`.

### UI
- Both samples gain a small `<div id=\"hint\">W: wireframe OFF</div>` badge (top-left, monospace, semi-transparent) — same styling as the coins samples.

## Test plan

- [ ] Open `examples/threejs/havok/shogi/index.html`; confirm no wireframes shown on load. Press `W`; confirm green box around ground / walls and orange box around each piece appear, the hint flips to `ON`. Press `W` again to hide.
- [ ] Open `examples/babylonjs/havok/shogi/index.html`; confirm no debug wireframes shown on load. Press `W`; confirm `PhysicsViewer` wireframes appear over each impostor/body. Press `W` again to hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)