### PR TITLE
Split glTF physics exporter into a reusable module

### DIFF
--- a/examples/babylonjs/havok/gltf_physics_Exporter/gltf-physics-exporter.js
+++ b/examples/babylonjs/havok/gltf_physics_Exporter/gltf-physics-exporter.js
@@ -1,0 +1,360 @@
+// Babylon.js + Havok glTF Physics exporter module.
+// Exposes BABYLON.GLTFPhysicsExport with:
+//   - snapshot(scene)                       capture initial transforms (optional)
+//   - GLBAsync(scene, fileName, options)    export the scene as a .glb with
+//                                           KHR_physics_rigid_bodies + KHR_implicit_shapes
+// Output schema follows eoineoineoin/glTF_Physics_Blender_Exporter so it round-trips
+// through the loader used by the gltf_physics_* samples in this repo.
+
+(function (BABYLON) {
+    if (!BABYLON) {
+        throw new Error('Babylon.js must be loaded before gltf-physics-exporter.js');
+    }
+
+    const SNAPSHOT_KEY = '__gltfPhysicsExportSnapshot';
+
+    const GLB_MAGIC = 0x46546C67;  // 'glTF'
+    const GLB_VERSION = 2;
+    const CHUNK_JSON = 0x4E4F534A; // 'JSON'
+    const CHUNK_BIN  = 0x004E4942; // 'BIN\0'
+
+    function isPhysicsMesh(mesh) {
+        return !!(mesh && (mesh.physicsBody || mesh.aggregate));
+    }
+
+    function snapshot(scene) {
+        scene.meshes.forEach(function (mesh) {
+            if (!isPhysicsMesh(mesh)) {
+                return;
+            }
+            mesh.metadata = mesh.metadata || {};
+            mesh.metadata[SNAPSHOT_KEY] = {
+                position: mesh.position.clone(),
+                rotation: mesh.rotation.clone(),
+                rotationQuaternion: mesh.rotationQuaternion ? mesh.rotationQuaternion.clone() : null
+            };
+        });
+    }
+
+    async function GLBAsync(scene, baseName, options) {
+        options = options || {};
+        const data = collectPhysicsData(scene);
+        const restore = applySnapshots(scene);
+        try {
+            const exportOptions = {
+                shouldExportNode: function (node) {
+                    if (options.shouldExportNode && !options.shouldExportNode(node)) {
+                        return false;
+                    }
+                    return !(node instanceof BABYLON.Light);
+                }
+            };
+
+            const gltfData = await BABYLON.GLTF2Export.GLBAsync(scene, baseName, exportOptions);
+            const fileMap = gltfData.glTFFiles;
+            const glbName = Object.keys(fileMap).find(function (k) { return k.endsWith('.glb'); });
+            if (!glbName) {
+                throw new Error('GLTF2Export did not produce a .glb');
+            }
+
+            const arrayBuffer = await fileMap[glbName].arrayBuffer();
+            const { json, bin } = parseGLB(arrayBuffer);
+
+            injectPhysicsExtensions(json, data);
+
+            const outBuffer = buildGLB(json, bin);
+            if (options.download !== false) {
+                triggerDownload(outBuffer, baseName + '.glb');
+            }
+            return outBuffer;
+        } finally {
+            restore();
+        }
+    }
+
+    // --- physics data collection ---
+
+    function collectPhysicsData(scene) {
+        const shapes = [];
+        const materials = [];
+        const bodies = new Map(); // mesh name -> node-level KHR_physics_rigid_bodies block
+
+        scene.meshes.forEach(function (mesh) {
+            if (!isPhysicsMesh(mesh)) {
+                return;
+            }
+            const body = describeBody(mesh, shapes, materials);
+            if (body) {
+                bodies.set(mesh.name, body);
+            }
+        });
+
+        return { shapes, materials, bodies };
+    }
+
+    function describeBody(mesh, shapes, materials) {
+        const shapeSpec = describeShape(mesh);
+        if (!shapeSpec) {
+            console.warn('[GLTFPhysicsExport] Skipping mesh with unsupported physics shape:', mesh.name);
+            return null;
+        }
+        const shapeIndex = pushUnique(shapes, shapeSpec);
+        const matIndex = pushUnique(materials, describeMaterial(mesh));
+
+        const body = {
+            collider: { geometry: { shape: shapeIndex }, physicsMaterial: matIndex }
+        };
+        const mass = readMass(mesh);
+        if (mass > 0) {
+            body.motion = { mass: mass };
+        }
+        // mass === 0 → static, no motion block (matches the eoineoineoin convention)
+        return body;
+    }
+
+    function describeShape(mesh) {
+        const aggregate = mesh.aggregate;
+        const shape = aggregate && aggregate.shape;
+        if (!shape) {
+            return null;
+        }
+        const bb = mesh.getBoundingInfo().boundingBox;
+        const extents = bb.extendSize; // half-extents in local space
+
+        switch (shape.type) {
+            case BABYLON.PhysicsShapeType.BOX:
+                return { type: 'box', box: { size: [extents.x * 2, extents.y * 2, extents.z * 2] } };
+
+            case BABYLON.PhysicsShapeType.SPHERE: {
+                const radius = Math.max(extents.x, extents.y, extents.z);
+                return { type: 'sphere', sphere: { radius: radius } };
+            }
+
+            case BABYLON.PhysicsShapeType.CAPSULE: {
+                const radius = Math.max(extents.x, extents.z);
+                const height = Math.max(0, extents.y * 2 - radius * 2);
+                return { type: 'capsule', capsule: { height: height, radiusBottom: radius, radiusTop: radius } };
+            }
+
+            case BABYLON.PhysicsShapeType.CYLINDER: {
+                const radius = Math.max(extents.x, extents.z);
+                const height = extents.y * 2;
+                return { type: 'cylinder', cylinder: { height: height, radiusBottom: radius, radiusTop: radius } };
+            }
+
+            default:
+                return null;
+        }
+    }
+
+    function describeMaterial(mesh) {
+        const aggregate = mesh.aggregate;
+        let friction = 0.5;
+        let restitution = 0.0;
+        if (aggregate) {
+            if (aggregate.material) {
+                if (typeof aggregate.material.friction === 'number') friction = aggregate.material.friction;
+                if (typeof aggregate.material.restitution === 'number') restitution = aggregate.material.restitution;
+            }
+            if (aggregate.shape && aggregate.shape.material) {
+                const m = aggregate.shape.material;
+                if (typeof m.friction === 'number') friction = m.friction;
+                if (typeof m.restitution === 'number') restitution = m.restitution;
+            }
+        }
+        return {
+            staticFriction: friction,
+            dynamicFriction: friction,
+            restitution: restitution
+        };
+    }
+
+    function readMass(mesh) {
+        const body = mesh.physicsBody;
+        if (body && typeof body.getMassProperties === 'function') {
+            const mp = body.getMassProperties();
+            if (mp && typeof mp.mass === 'number') {
+                return mp.mass;
+            }
+        }
+        const aggregate = mesh.aggregate;
+        if (aggregate && aggregate._options && typeof aggregate._options.mass === 'number') {
+            return aggregate._options.mass;
+        }
+        return 0;
+    }
+
+    function pushUnique(arr, item) {
+        const key = JSON.stringify(item);
+        for (let i = 0; i < arr.length; i++) {
+            if (JSON.stringify(arr[i]) === key) {
+                return i;
+            }
+        }
+        arr.push(item);
+        return arr.length - 1;
+    }
+
+    // --- snapshot apply / restore ---
+
+    function applySnapshots(scene) {
+        const restore = [];
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh || !mesh.metadata || !mesh.metadata[SNAPSHOT_KEY]) {
+                return;
+            }
+            const snap = mesh.metadata[SNAPSHOT_KEY];
+            restore.push({
+                mesh,
+                position: mesh.position.clone(),
+                rotation: mesh.rotation.clone(),
+                rotationQuaternion: mesh.rotationQuaternion ? mesh.rotationQuaternion.clone() : null
+            });
+            mesh.position.copyFrom(snap.position);
+            if (snap.rotationQuaternion) {
+                mesh.rotationQuaternion = snap.rotationQuaternion.clone();
+            } else {
+                mesh.rotationQuaternion = null;
+                mesh.rotation.copyFrom(snap.rotation);
+            }
+            mesh.computeWorldMatrix(true);
+        });
+        return function () {
+            restore.forEach(function (r) {
+                r.mesh.position.copyFrom(r.position);
+                if (r.rotationQuaternion) {
+                    r.mesh.rotationQuaternion = r.rotationQuaternion;
+                } else {
+                    r.mesh.rotationQuaternion = null;
+                    r.mesh.rotation.copyFrom(r.rotation);
+                }
+                r.mesh.computeWorldMatrix(true);
+            });
+        };
+    }
+
+    // --- glTF JSON injection ---
+
+    function injectPhysicsExtensions(json, data) {
+        const used = new Set(json.extensionsUsed || []);
+        used.add('KHR_implicit_shapes');
+        used.add('KHR_physics_rigid_bodies');
+        json.extensionsUsed = Array.from(used);
+
+        json.extensions = json.extensions || {};
+        json.extensions.KHR_implicit_shapes = { shapes: data.shapes };
+        json.extensions.KHR_physics_rigid_bodies = { physicsMaterials: data.materials };
+
+        if (!Array.isArray(json.nodes)) {
+            return;
+        }
+        json.nodes.forEach(function (node) {
+            const body = data.bodies.get(node.name);
+            if (!body) {
+                return;
+            }
+            node.extensions = node.extensions || {};
+            node.extensions.KHR_physics_rigid_bodies = body;
+        });
+    }
+
+    // --- GLB pack / unpack ---
+
+    function parseGLB(arrayBuffer) {
+        const dv = new DataView(arrayBuffer);
+        if (dv.getUint32(0, true) !== GLB_MAGIC) {
+            throw new Error('Not a GLB');
+        }
+        const totalLength = dv.getUint32(8, true);
+
+        let cursor = 12;
+        let json = null;
+        let bin = null;
+
+        while (cursor < totalLength) {
+            const chunkLength = dv.getUint32(cursor, true);
+            const chunkType   = dv.getUint32(cursor + 4, true);
+            const dataStart   = cursor + 8;
+
+            if (chunkType === CHUNK_JSON) {
+                const bytes = new Uint8Array(arrayBuffer, dataStart, chunkLength);
+                json = JSON.parse(new TextDecoder().decode(bytes));
+            } else if (chunkType === CHUNK_BIN) {
+                // Copy so we don't depend on the source ArrayBuffer staying alive.
+                bin = new Uint8Array(arrayBuffer, dataStart, chunkLength).slice();
+            }
+            cursor = dataStart + chunkLength;
+        }
+
+        if (!json) {
+            throw new Error('GLB has no JSON chunk');
+        }
+        return { json, bin };
+    }
+
+    function buildGLB(json, bin) {
+        const jsonText = JSON.stringify(json);
+        const jsonBytes = new TextEncoder().encode(jsonText);
+        const jsonPadded = padTo4(jsonBytes, 0x20); // ASCII space
+
+        let binPadded = null;
+        if (bin && bin.byteLength > 0) {
+            binPadded = padTo4(bin, 0x00);
+        }
+
+        const headerSize = 12;
+        const jsonChunkSize = 8 + jsonPadded.byteLength;
+        const binChunkSize = binPadded ? 8 + binPadded.byteLength : 0;
+        const totalSize = headerSize + jsonChunkSize + binChunkSize;
+
+        const out = new ArrayBuffer(totalSize);
+        const dv = new DataView(out);
+        const u8 = new Uint8Array(out);
+
+        dv.setUint32(0, GLB_MAGIC, true);
+        dv.setUint32(4, GLB_VERSION, true);
+        dv.setUint32(8, totalSize, true);
+
+        dv.setUint32(12, jsonPadded.byteLength, true);
+        dv.setUint32(16, CHUNK_JSON, true);
+        u8.set(jsonPadded, 20);
+
+        if (binPadded) {
+            const binStart = 20 + jsonPadded.byteLength;
+            dv.setUint32(binStart, binPadded.byteLength, true);
+            dv.setUint32(binStart + 4, CHUNK_BIN, true);
+            u8.set(binPadded, binStart + 8);
+        }
+
+        return out;
+    }
+
+    function padTo4(bytes, fill) {
+        const remainder = bytes.byteLength % 4;
+        if (remainder === 0) {
+            return bytes;
+        }
+        const pad = 4 - remainder;
+        const padded = new Uint8Array(bytes.byteLength + pad);
+        padded.set(bytes, 0);
+        padded.fill(fill, bytes.byteLength);
+        return padded;
+    }
+
+    function triggerDownload(arrayBuffer, filename) {
+        const blob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    }
+
+    BABYLON.GLTFPhysicsExport = {
+        snapshot: snapshot,
+        GLBAsync: GLBAsync
+    };
+})(typeof window !== 'undefined' ? window.BABYLON : undefined);

--- a/examples/babylonjs/havok/gltf_physics_Exporter/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Exporter/index.html
@@ -14,6 +14,7 @@
   <button id="exportBtn" type="button">Export .glb</button>
   <span id="status"></span>
 </div>
+<script src="gltf-physics-exporter.js"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Exporter/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Exporter/index.js
@@ -1,74 +1,14 @@
-// Babylon.js + Havok scene with glTF Physics exporter (KHR_physics_rigid_bodies + KHR_implicit_shapes).
-// Schema follows eoineoineoin/glTF_Physics_Blender_Exporter so the output round-trips through the
-// loader used by the gltf_physics_* samples in this repo.
+// Demo scene driving gltf-physics-exporter.js.
+// Floor (static) + falling cube (dynamic). Click "Export .glb" to download a
+// .glb with KHR_physics_rigid_bodies + KHR_implicit_shapes; the file
+// round-trips through the loader used by the gltf_physics_* samples here.
 
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 const PHYSICS_SCALE = 1 / 10;
 
-const PHYSICS_SHAPES = []; // index parity for KHR_implicit_shapes
-const PHYSICS_MATERIALS = []; // index parity for KHR_physics_rigid_bodies.physicsMaterials
-const PHYSICS_BODIES = new Map(); // meshName -> { shape, material, motion? }
-
 let engine;
 let scene;
 let canvas;
-
-function registerShape(spec) {
-    PHYSICS_SHAPES.push(spec);
-    return PHYSICS_SHAPES.length - 1;
-}
-
-function registerMaterial(spec) {
-    PHYSICS_MATERIALS.push(spec);
-    return PHYSICS_MATERIALS.length - 1;
-}
-
-function tagBody(mesh, body) {
-    PHYSICS_BODIES.set(mesh.name, body);
-    mesh.metadata = mesh.metadata || {};
-    mesh.metadata.initialPosition = mesh.position.clone();
-    mesh.metadata.initialRotation = mesh.rotation.clone();
-    mesh.metadata.initialRotationQuaternion = mesh.rotationQuaternion ? mesh.rotationQuaternion.clone() : null;
-}
-
-function withInitialPose(scene, fn) {
-    // The Havok body updates the mesh transform each frame, so by the time the user
-    // clicks Export the cube is mid-fall. Snap the mesh back to its initial transform
-    // for the duration of the export, then restore.
-    const restore = [];
-    PHYSICS_BODIES.forEach(function (_body, name) {
-        const mesh = scene.getMeshByName(name);
-        if (!mesh || !mesh.metadata || !mesh.metadata.initialPosition) {
-            return;
-        }
-        restore.push({
-            mesh,
-            position: mesh.position.clone(),
-            rotation: mesh.rotation.clone(),
-            rotationQuaternion: mesh.rotationQuaternion ? mesh.rotationQuaternion.clone() : null
-        });
-        mesh.position.copyFrom(mesh.metadata.initialPosition);
-        if (mesh.metadata.initialRotationQuaternion) {
-            mesh.rotationQuaternion = mesh.metadata.initialRotationQuaternion.clone();
-        } else {
-            mesh.rotationQuaternion = null;
-            mesh.rotation.copyFrom(mesh.metadata.initialRotation);
-        }
-        mesh.computeWorldMatrix(true);
-    });
-    return Promise.resolve(fn()).finally(function () {
-        restore.forEach(function (r) {
-            r.mesh.position.copyFrom(r.position);
-            if (r.rotationQuaternion) {
-                r.mesh.rotationQuaternion = r.rotationQuaternion;
-            } else {
-                r.mesh.rotationQuaternion = null;
-                r.mesh.rotation.copyFrom(r.rotation);
-            }
-            r.mesh.computeWorldMatrix(true);
-        });
-    });
-}
 
 async function init() {
     canvas = document.querySelector('#c');
@@ -83,6 +23,10 @@ async function init() {
     engine = new BABYLON.Engine(canvas, true);
     scene = createScene();
 
+    // Capture initial pose before physics moves anything, so a later Export
+    // ships the scene's initial setup instead of the cube's mid-fall state.
+    BABYLON.GLTFPhysicsExport.snapshot(scene);
+
     engine.runRenderLoop(function () {
         scene.render();
     });
@@ -93,7 +37,7 @@ async function init() {
         exportBtn.disabled = true;
         status.textContent = 'Exporting...';
         try {
-            await exportSceneAsGLB(scene, 'minimum_physics');
+            await BABYLON.GLTFPhysicsExport.GLBAsync(scene, 'minimum_physics');
             status.textContent = 'Exported minimum_physics.glb';
         } catch (err) {
             console.error(err);
@@ -117,7 +61,7 @@ function createScene() {
     camera.attachControl(canvas, true);
 
     // Lights are only added for the preview canvas — the loader side supplies its own
-    // lighting, so we exclude them from the export via shouldExportNode below.
+    // lighting, so gltf-physics-exporter.js excludes them from the .glb.
     const hemiLight = new BABYLON.HemisphericLight('hemiLight', new BABYLON.Vector3(0, 1, 0), scene);
     hemiLight.intensity = 0.9;
     const dirLight = new BABYLON.DirectionalLight('dirLight', new BABYLON.Vector3(-0.4, -1.0, -0.3), scene);
@@ -127,23 +71,16 @@ function createScene() {
     const material = new BABYLON.StandardMaterial('material', scene);
     material.diffuseTexture = new BABYLON.Texture('../../../../assets/textures/frog.jpg', scene);
 
-    const groundSize = { width: 200 * PHYSICS_SCALE, height: 0.1, depth: 200 * PHYSICS_SCALE };
-    const ground = BABYLON.MeshBuilder.CreateBox('ground', groundSize, scene);
+    const ground = BABYLON.MeshBuilder.CreateBox('ground', {
+        width: 200 * PHYSICS_SCALE, height: 0.1, depth: 200 * PHYSICS_SCALE
+    }, scene);
     ground.material = material;
     ground.position.y = -20 * PHYSICS_SCALE;
     ground.aggregate = new BABYLON.PhysicsAggregate(
         ground, BABYLON.PhysicsShapeType.BOX,
         { mass: 0, friction: 0.1, restitution: 0.1 }, scene);
 
-    const groundShape = registerShape({ type: 'box', box: { size: [groundSize.width, groundSize.height, groundSize.depth] } });
-    const groundMat = registerMaterial({ staticFriction: 0.1, dynamicFriction: 0.1, restitution: 0.1 });
-    tagBody(ground, {
-        collider: { geometry: { shape: groundShape }, physicsMaterial: groundMat }
-        // no motion → static
-    });
-
-    const cubeEdge = 50 * PHYSICS_SCALE;
-    const cube = BABYLON.MeshBuilder.CreateBox('cube', { size: cubeEdge }, scene);
+    const cube = BABYLON.MeshBuilder.CreateBox('cube', { size: 50 * PHYSICS_SCALE }, scene);
     cube.material = material;
     cube.position.y = 100 * PHYSICS_SCALE;
     cube.rotation.x = Math.PI * 10 / 180;
@@ -152,169 +89,11 @@ function createScene() {
         cube, BABYLON.PhysicsShapeType.BOX,
         { mass: 1, friction: 0.2, restitution: 0.5 }, scene);
 
-    const cubeShape = registerShape({ type: 'box', box: { size: [cubeEdge, cubeEdge, cubeEdge] } });
-    const cubeMat = registerMaterial({ staticFriction: 0.2, dynamicFriction: 0.2, restitution: 0.5 });
-    tagBody(cube, {
-        motion: { mass: 1 },
-        collider: { geometry: { shape: cubeShape }, physicsMaterial: cubeMat }
-    });
-
     scene.registerBeforeRender(function () {
         scene.activeCamera.alpha += Math.PI * 1.0 / 180.0 * scene.getAnimationRatio();
     });
 
     return scene;
-}
-
-// --- GLB exporter with physics extensions ---
-
-const GLB_MAGIC = 0x46546C67;        // 'glTF'
-const GLB_VERSION = 2;
-const CHUNK_JSON = 0x4E4F534A;       // 'JSON'
-const CHUNK_BIN  = 0x004E4942;       // 'BIN\0'
-
-async function exportSceneAsGLB(scene, baseName) {
-    await withInitialPose(scene, async function () {
-        const gltfData = await BABYLON.GLTF2Export.GLBAsync(scene, baseName, {
-            shouldExportNode: function (node) {
-                // Strip lights — the consuming side supplies its own lighting.
-                return !(node instanceof BABYLON.Light);
-            }
-        });
-        const fileMap = gltfData.glTFFiles;
-        const glbName = Object.keys(fileMap).find(function (k) { return k.endsWith('.glb'); });
-        if (!glbName) {
-            throw new Error('GLTF2Export did not produce a .glb');
-        }
-
-        const arrayBuffer = await fileMap[glbName].arrayBuffer();
-        const { json, bin } = parseGLB(arrayBuffer);
-
-        injectPhysicsExtensions(json);
-
-        const outBuffer = buildGLB(json, bin);
-        triggerDownload(outBuffer, baseName + '.glb');
-    });
-}
-
-function parseGLB(arrayBuffer) {
-    const dv = new DataView(arrayBuffer);
-    if (dv.getUint32(0, true) !== GLB_MAGIC) {
-        throw new Error('Not a GLB');
-    }
-    const totalLength = dv.getUint32(8, true);
-
-    let cursor = 12;
-    let json = null;
-    let bin = null;
-
-    while (cursor < totalLength) {
-        const chunkLength = dv.getUint32(cursor, true);
-        const chunkType   = dv.getUint32(cursor + 4, true);
-        const dataStart   = cursor + 8;
-
-        if (chunkType === CHUNK_JSON) {
-            const bytes = new Uint8Array(arrayBuffer, dataStart, chunkLength);
-            json = JSON.parse(new TextDecoder().decode(bytes));
-        } else if (chunkType === CHUNK_BIN) {
-            // Copy so we don't depend on the source ArrayBuffer staying alive.
-            bin = new Uint8Array(arrayBuffer, dataStart, chunkLength).slice();
-        }
-        cursor = dataStart + chunkLength;
-    }
-
-    if (!json) {
-        throw new Error('GLB has no JSON chunk');
-    }
-    return { json, bin };
-}
-
-function injectPhysicsExtensions(json) {
-    const extensionsUsed = new Set(json.extensionsUsed || []);
-    extensionsUsed.add('KHR_implicit_shapes');
-    extensionsUsed.add('KHR_physics_rigid_bodies');
-    json.extensionsUsed = Array.from(extensionsUsed);
-
-    json.extensions = json.extensions || {};
-    json.extensions.KHR_implicit_shapes = { shapes: PHYSICS_SHAPES };
-    json.extensions.KHR_physics_rigid_bodies = { physicsMaterials: PHYSICS_MATERIALS };
-
-    // Map node name -> physics body description, then walk gltf nodes.
-    if (!Array.isArray(json.nodes)) {
-        return;
-    }
-    json.nodes.forEach(function (node) {
-        const body = PHYSICS_BODIES.get(node.name);
-        if (!body) {
-            return;
-        }
-        node.extensions = node.extensions || {};
-        node.extensions.KHR_physics_rigid_bodies = body;
-    });
-}
-
-function buildGLB(json, bin) {
-    const jsonText = JSON.stringify(json);
-    const jsonBytes = new TextEncoder().encode(jsonText);
-    const jsonPadded = padTo4(jsonBytes, 0x20); // ASCII space
-
-    let binPadded = null;
-    if (bin && bin.byteLength > 0) {
-        binPadded = padTo4(bin, 0x00);
-    }
-
-    const headerSize = 12;
-    const jsonChunkSize = 8 + jsonPadded.byteLength;
-    const binChunkSize = binPadded ? 8 + binPadded.byteLength : 0;
-    const totalSize = headerSize + jsonChunkSize + binChunkSize;
-
-    const out = new ArrayBuffer(totalSize);
-    const dv = new DataView(out);
-    const u8 = new Uint8Array(out);
-
-    // Header
-    dv.setUint32(0, GLB_MAGIC, true);
-    dv.setUint32(4, GLB_VERSION, true);
-    dv.setUint32(8, totalSize, true);
-
-    // JSON chunk
-    dv.setUint32(12, jsonPadded.byteLength, true);
-    dv.setUint32(16, CHUNK_JSON, true);
-    u8.set(jsonPadded, 20);
-
-    // BIN chunk
-    if (binPadded) {
-        const binStart = 20 + jsonPadded.byteLength;
-        dv.setUint32(binStart, binPadded.byteLength, true);
-        dv.setUint32(binStart + 4, CHUNK_BIN, true);
-        u8.set(binPadded, binStart + 8);
-    }
-
-    return out;
-}
-
-function padTo4(bytes, fill) {
-    const remainder = bytes.byteLength % 4;
-    if (remainder === 0) {
-        return bytes;
-    }
-    const pad = 4 - remainder;
-    const padded = new Uint8Array(bytes.byteLength + pad);
-    padded.set(bytes, 0);
-    padded.fill(fill, bytes.byteLength);
-    return padded;
-}
-
-function triggerDownload(arrayBuffer, filename) {
-    const blob = new Blob([arrayBuffer], { type: 'model/gltf-binary' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
 }
 
 init();


### PR DESCRIPTION
## Summary
- Extracts the GLB + `KHR_physics_rigid_bodies` / `KHR_implicit_shapes` export logic out of the sample's `index.js` into a standalone `gltf-physics-exporter.js` that exposes a small `BABYLON.GLTFPhysicsExport` API.
- The sample's `index.js` is now a short demo scene that calls `GLTFPhysicsExport.snapshot` once at startup and `GLBAsync` on button click.

## API
```js
BABYLON.GLTFPhysicsExport.snapshot(scene);                              // optional: capture initial pose
await BABYLON.GLTFPhysicsExport.GLBAsync(scene, fileName, options);     // export
```

- `snapshot(scene)` — records the current transform of every mesh with a `physicsBody` / `aggregate`. Calling this before physics ticks lets `GLBAsync` ship the scene's initial setup instead of whatever mid-fall state happens to be current.
- `GLBAsync(scene, fileName, options)` — returns the GLB `ArrayBuffer`; downloads as `<fileName>.glb` unless `options.download === false`. A caller-provided `options.shouldExportNode` is composed with the module's built-in light filter.

## Auto-discovery
The module walks `scene.meshes` and derives the physics extension data from each mesh's `PhysicsAggregate` / `PhysicsBody`:

- **Shape** is read from `aggregate.shape.type` and sized from the mesh bounding box; box / sphere / capsule / cylinder map to `KHR_implicit_shapes` entries.
- **Material** (`staticFriction` / `dynamicFriction` / `restitution`) is read from `aggregate.shape.material` (falling back to `aggregate.material`).
- **Mass** is read from `physicsBody.getMassProperties().mass`; `mass === 0` is exported as static (no `motion` block), `mass > 0` as dynamic with `motion.mass`.
- Duplicate shapes and materials are deduplicated by index.

Lights are excluded from the export by default since consuming apps supply their own lighting.

## Test plan
- [x] Open `examples/babylonjs/havok/gltf_physics_Exporter/index.html`; floor + falling cube render as before.
- [x] Click "Export .glb"; `minimum_physics.glb` is downloaded.
- [x] Load the exported `.glb` in an external Babylon.js + Havok glTF physics viewer: floor and cube appear with the frog texture, gravity pulls the cube onto the floor, both extensions are detected with the same values as before the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)