### PR TITLE
Add W-key wireframe toggle to three.js samples and default all wireframes to ON

### DIFF
--- a/examples/babylonjs/havok/shogi/index.html
+++ b/examples/babylonjs/havok/shogi/index.html
@@ -9,7 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/shogi/index.js
+++ b/examples/babylonjs/havok/shogi/index.js
@@ -8,7 +8,7 @@ const PIECE_COUNT = 220;
 const BOX_HALF_EXTENT = 5 * PHYSICS_SCALE;
 const SPAWN_MARGIN = 0.6 * PHYSICS_SCALE;
 
-let showWireframe = false;
+let showWireframe = true;
 let physicsViewer = null;
 const trackedBodies = [];
 const trackedImpostors = [];

--- a/examples/threejs/cannon-es/gltf_physics_Materials_Friction/index.html
+++ b/examples/threejs/cannon-es/gltf_physics_Materials_Friction/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/cannon-es/gltf_physics_Materials_Friction/index.js
+++ b/examples/threejs/cannon-es/gltf_physics_Materials_Friction/index.js
@@ -7,6 +7,7 @@ const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/m
 const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 // cannon-es approximates the friction force as (mu * gravity) instead of scaling it by the
 // actual contact normal force, so it grips far harder than real Coulomb friction on a slope
 // (anything above ~0.005 effective friction sticks here). Scale the glTF friction values down
@@ -342,6 +343,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/cannon-es/gltf_physics_Materials_Friction/style.css
+++ b/examples/threejs/cannon-es/gltf_physics_Materials_Friction/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/balls/index.html
+++ b/examples/threejs/havok/balls/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/balls/index.js
+++ b/examples/threejs/havok/balls/index.js
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 const dataSet = [
     { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6 },
@@ -214,4 +215,28 @@ async function main() {
   animate();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/balls/style.css
+++ b/examples/threejs/havok/balls/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/box/index.html
+++ b/examples/threejs/havok/box/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/box/index.js
+++ b/examples/threejs/havok/box/index.js
@@ -46,6 +46,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BOX_SIZE = 1;
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -212,4 +213,28 @@ async function main() {
   animate();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/box/style.css
+++ b/examples/threejs/havok/box/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/coins/index.html
+++ b/examples/threejs/havok/coins/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/coins/index.js
+++ b/examples/threejs/havok/coins/index.js
@@ -31,7 +31,7 @@ const coinInstancedMeshes = {};
 const coinDebugInstancedMeshes = {};
 let groundDebugMesh;
 const coins = [];
-let showWireframe = false;
+let showWireframe = true;
 
 const tmpMatrix = new THREE.Matrix4();
 const tmpPosition = new THREE.Vector3();

--- a/examples/threejs/havok/cone/index.html
+++ b/examples/threejs/havok/cone/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/cone/index.js
+++ b/examples/threejs/havok/cone/index.js
@@ -7,6 +7,7 @@ const CONE_COUNT = 200;
 const CONE_HALF_HEIGHT = 2;
 const CONE_RADIUS = 1;
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -251,4 +252,28 @@ async function main() {
   loop();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/cone/style.css
+++ b/examples/threejs/havok/cone/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/domino/index.html
+++ b/examples/threejs/havok/domino/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/domino/index.js
+++ b/examples/threejs/havok/domino/index.js
@@ -45,6 +45,7 @@ const colorHash = {
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -256,4 +257,28 @@ async function main() {
   animate();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/domino/style.css
+++ b/examples/threejs/havok/domino/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/football/index.html
+++ b/examples/threejs/havok/football/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/football/index.js
+++ b/examples/threejs/havok/football/index.js
@@ -46,6 +46,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BALL_SIZE = 1;
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -213,4 +214,28 @@ async function main() {
   animate();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/football/style.css
+++ b/examples/threejs/havok/football/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/threejs/havok/gltf_physics_Basic_Shapes/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/threejs/havok/gltf_physics_Basic_Shapes/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -637,6 +638,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Basic_Shapes/style.css
+++ b/examples/threejs/havok/gltf_physics_Basic_Shapes/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Filtering/index.html
+++ b/examples/threejs/havok/gltf_physics_Filtering/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Filtering/index.js
+++ b/examples/threejs/havok/gltf_physics_Filtering/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -685,6 +686,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Filtering/style.css
+++ b/examples/threejs/havok/gltf_physics_Filtering/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_JointTypes/index.html
+++ b/examples/threejs/havok/gltf_physics_JointTypes/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/threejs/havok/gltf_physics_JointTypes/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -30;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 // KHR_physics_rigid_bodies axis indices map to Havok ConstraintAxis:
 // linearAxes[i]  → i     (LINEAR_X=0, LINEAR_Y=1, LINEAR_Z=2)
@@ -786,6 +787,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_JointTypes/style.css
+++ b/examples/threejs/havok/gltf_physics_JointTypes/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/threejs/havok/gltf_physics_Materials_Friction/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/threejs/havok/gltf_physics_Materials_Friction/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -395,6 +396,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Materials_Friction/style.css
+++ b/examples/threejs/havok/gltf_physics_Materials_Friction/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/threejs/havok/gltf_physics_Materials_Restitution/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/threejs/havok/gltf_physics_Materials_Restitution/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -406,6 +407,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Materials_Restitution/style.css
+++ b/examples/threejs/havok/gltf_physics_Materials_Restitution/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/threejs/havok/gltf_physics_Motion_Properties/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/threejs/havok/gltf_physics_Motion_Properties/index.js
@@ -8,6 +8,7 @@ const RESET_Y_THRESHOLD = -20;
 const RESET_Y_THRESHOLD_TOP = 50;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -635,6 +636,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Motion_Properties/style.css
+++ b/examples/threejs/havok/gltf_physics_Motion_Properties/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/gltf_physics_Triggers/index.html
+++ b/examples/threejs/havok/gltf_physics_Triggers/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf_physics_Triggers/index.js
+++ b/examples/threejs/havok/gltf_physics_Triggers/index.js
@@ -7,6 +7,7 @@ const FIXED_TIMESTEP = 1 / 60;
 const RESET_Y_THRESHOLD = -20;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK;
 let worldId;
@@ -590,6 +591,30 @@ async function main() {
   animate();
 }
 
-main().catch((error) => {
-  console.error(error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
 });
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/threejs/havok/gltf_physics_Triggers/style.css
+++ b/examples/threejs/havok/gltf_physics_Triggers/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/marbles/index.html
+++ b/examples/threejs/havok/marbles/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/marbles/index.js
+++ b/examples/threejs/havok/marbles/index.js
@@ -7,6 +7,7 @@ const GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMet
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -234,4 +235,28 @@ async function main() {
   loadMarbles();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/marbles/style.css
+++ b/examples/threejs/havok/marbles/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/minimum/index.html
+++ b/examples/threejs/havok/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/minimum/index.js
+++ b/examples/threejs/havok/minimum/index.js
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -139,4 +140,28 @@ async function main() {
   animate();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  scene.traverse((object) => {
+    if (object.isLineSegments) {
+      object.visible = visible;
+    }
+  });
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/minimum/style.css
+++ b/examples/threejs/havok/minimum/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/havok/shogi/index.html
+++ b/examples/threejs/havok/shogi/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/shogi/index.js
+++ b/examples/threejs/havok/shogi/index.js
@@ -11,7 +11,7 @@ const meshes = [];
 const bodyIds = [];
 const debugMeshes = [];
 const staticDebugMeshes = [];
-let showWireframe = false;
+let showWireframe = true;
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);

--- a/examples/webgl1/havok/balls/index.html
+++ b/examples/webgl1/havok/balls/index.html
@@ -61,7 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/balls/index.js
+++ b/examples/webgl1/havok/balls/index.js
@@ -27,7 +27,7 @@ let textures = [];
 let whiteTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/box/index.html
+++ b/examples/webgl1/havok/box/index.html
@@ -61,7 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/box/index.js
+++ b/examples/webgl1/havok/box/index.js
@@ -46,7 +46,7 @@ let groundTexture;
 let whiteTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/cone/index.html
+++ b/examples/webgl1/havok/cone/index.html
@@ -63,7 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/cone/index.js
+++ b/examples/webgl1/havok/cone/index.js
@@ -12,7 +12,7 @@ let canvas;
 let gl;
 let program;
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let attribs;
 let uniforms;
 let lineAttribs;

--- a/examples/webgl1/havok/domino/index.html
+++ b/examples/webgl1/havok/domino/index.html
@@ -54,7 +54,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/domino/index.js
+++ b/examples/webgl1/havok/domino/index.js
@@ -81,7 +81,7 @@ let uniformModelView;
 let uniformColor;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/football/index.html
+++ b/examples/webgl1/havok/football/index.html
@@ -61,7 +61,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/football/index.js
+++ b/examples/webgl1/havok/football/index.js
@@ -52,7 +52,7 @@ let uniformLightDir;
 let uniformAlpha;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/gltf/index.html
+++ b/examples/webgl1/havok/gltf/index.html
@@ -74,7 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf/index.js
+++ b/examples/webgl1/havok/gltf/index.js
@@ -15,7 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.html
@@ -74,7 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl1/havok/gltf_physics_Basic_Shapes/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Filtering/index.html
+++ b/examples/webgl1/havok/gltf_physics_Filtering/index.html
@@ -133,7 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl1/havok/gltf_physics_Filtering/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.html
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.html
@@ -133,7 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.html
@@ -74,7 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Friction/index.js
@@ -15,7 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.html
@@ -74,7 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl1/havok/gltf_physics_Materials_Restitution/index.js
@@ -15,7 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.html
@@ -133,7 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl1/havok/gltf_physics_Motion_Properties/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/gltf_physics_Triggers/index.html
+++ b/examples/webgl1/havok/gltf_physics_Triggers/index.html
@@ -133,7 +133,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl1/havok/gltf_physics_Triggers/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/havok/marbles/index.html
+++ b/examples/webgl1/havok/marbles/index.html
@@ -258,7 +258,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/marbles/index.js
+++ b/examples/webgl1/havok/marbles/index.js
@@ -21,7 +21,7 @@ let skyboxUniforms;
 let skyboxVbo;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/minimum/index.html
+++ b/examples/webgl1/havok/minimum/index.html
@@ -50,7 +50,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/minimum/index.js
+++ b/examples/webgl1/havok/minimum/index.js
@@ -20,7 +20,7 @@ let uniformModelView;
 let uniformTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl1/havok/shogi/index.html
+++ b/examples/webgl1/havok/shogi/index.html
@@ -95,7 +95,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/havok/shogi/index.js
+++ b/examples/webgl1/havok/shogi/index.js
@@ -1,7 +1,7 @@
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("experimental-webgl");
-let showWireframe = false;
+let showWireframe = true;
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);

--- a/examples/webgl1/oimo/balls/index.html
+++ b/examples/webgl1/oimo/balls/index.html
@@ -60,7 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/balls/index.js
+++ b/examples/webgl1/oimo/balls/index.js
@@ -35,7 +35,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/box/index.html
+++ b/examples/webgl1/oimo/box/index.html
@@ -60,7 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/box/index.js
+++ b/examples/webgl1/oimo/box/index.js
@@ -44,7 +44,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/cone/index.html
+++ b/examples/webgl1/oimo/cone/index.html
@@ -60,7 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/cone/index.js
+++ b/examples/webgl1/oimo/cone/index.js
@@ -26,7 +26,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB, cylWireVB, cylWireIB, cylWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/domino/index.html
+++ b/examples/webgl1/oimo/domino/index.html
@@ -77,7 +77,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/domino/index.js
+++ b/examples/webgl1/oimo/domino/index.js
@@ -58,7 +58,7 @@ gl.clearColor(0.05, 0.05, 0.1, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let dominoIBO, dominoPosVBO;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl1/oimo/eraser/index.html
+++ b/examples/webgl1/oimo/eraser/index.html
@@ -96,7 +96,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -6,7 +6,7 @@ gl.clearColor(0.7, 0.7, 0.7, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let eraserIBO, eraserPosVBO;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl1/oimo/football/index.html
+++ b/examples/webgl1/oimo/football/index.html
@@ -60,7 +60,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/football/index.js
+++ b/examples/webgl1/oimo/football/index.js
@@ -48,7 +48,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/gltf/index.html
+++ b/examples/webgl1/oimo/gltf/index.html
@@ -74,7 +74,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/gltf/index.js
+++ b/examples/webgl1/oimo/gltf/index.js
@@ -13,7 +13,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl1/oimo/marbles/index.html
+++ b/examples/webgl1/oimo/marbles/index.html
@@ -257,7 +257,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/marbles/index.js
+++ b/examples/webgl1/oimo/marbles/index.js
@@ -32,7 +32,7 @@ let groundTexture;
 let envCubeTexture = null;
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB, sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/minimum/index.html
+++ b/examples/webgl1/oimo/minimum/index.html
@@ -51,7 +51,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/minimum/index.js
+++ b/examples/webgl1/oimo/minimum/index.js
@@ -4,7 +4,7 @@ let aLoc = [];
 let uLoc = [];
 let mainProgram;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl1/oimo/shogi/index.html
+++ b/examples/webgl1/oimo/shogi/index.html
@@ -111,7 +111,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl1/oimo/shogi/index.js
+++ b/examples/webgl1/oimo/shogi/index.js
@@ -3,7 +3,7 @@ let gl = c.getContext("experimental-webgl");
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.enable(gl.DEPTH_TEST);
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl2/havok/balls/index.html
+++ b/examples/webgl2/havok/balls/index.html
@@ -63,7 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/balls/index.js
+++ b/examples/webgl2/havok/balls/index.js
@@ -32,7 +32,7 @@ let balls = [];
 let basketWalls = [];
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/box/index.html
+++ b/examples/webgl2/havok/box/index.html
@@ -63,7 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/box/index.js
+++ b/examples/webgl2/havok/box/index.js
@@ -46,7 +46,7 @@ let groundTexture;
 let whiteTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/cone/index.html
+++ b/examples/webgl2/havok/cone/index.html
@@ -63,7 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/cone/index.js
+++ b/examples/webgl2/havok/cone/index.js
@@ -27,7 +27,7 @@ let basketWalls = [];
 const coneShapeCache = new Map();
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/domino/index.html
+++ b/examples/webgl2/havok/domino/index.html
@@ -56,7 +56,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/domino/index.js
+++ b/examples/webgl2/havok/domino/index.js
@@ -90,7 +90,7 @@ const modelViewMatrix = mat4.create();
 const viewProjMatrix = mat4.create();
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/football/index.html
+++ b/examples/webgl2/havok/football/index.html
@@ -63,7 +63,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/football/index.js
+++ b/examples/webgl2/havok/football/index.js
@@ -56,7 +56,7 @@ let footballTexture;
 let grassTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/gltf/index.html
+++ b/examples/webgl2/havok/gltf/index.html
@@ -76,7 +76,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf/index.js
+++ b/examples/webgl2/havok/gltf/index.js
@@ -14,7 +14,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.html
@@ -82,7 +82,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgl2/havok/gltf_physics_Basic_Shapes/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Filtering/index.html
+++ b/examples/webgl2/havok/gltf_physics_Filtering/index.html
@@ -141,7 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgl2/havok/gltf_physics_Filtering/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.html
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.html
@@ -141,7 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.html
@@ -84,7 +84,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Friction/index.js
@@ -15,7 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.html
@@ -84,7 +84,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgl2/havok/gltf_physics_Materials_Restitution/index.js
@@ -15,7 +15,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.html
@@ -141,7 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgl2/havok/gltf_physics_Motion_Properties/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/gltf_physics_Triggers/index.html
+++ b/examples/webgl2/havok/gltf_physics_Triggers/index.html
@@ -141,7 +141,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgl2/havok/gltf_physics_Triggers/index.js
@@ -18,7 +18,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/havok/marbles/index.html
+++ b/examples/webgl2/havok/marbles/index.html
@@ -264,7 +264,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/marbles/index.js
+++ b/examples/webgl2/havok/marbles/index.js
@@ -33,7 +33,7 @@ let groundTexture;
 let envCubeTexture = null;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/minimum/index.html
+++ b/examples/webgl2/havok/minimum/index.html
@@ -52,7 +52,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/minimum/index.js
+++ b/examples/webgl2/havok/minimum/index.js
@@ -20,7 +20,7 @@ let uniformModelView;
 let uniformTexture;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 let debugBoxMesh;

--- a/examples/webgl2/havok/shogi/index.html
+++ b/examples/webgl2/havok/shogi/index.html
@@ -108,7 +108,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/havok/shogi/index.js
+++ b/examples/webgl2/havok/shogi/index.js
@@ -1,4 +1,4 @@
-let showWireframe = false;
+let showWireframe = true;
 const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/HavokPhysics.wasm';
 let c = document.getElementById("c");
 let gl = c.getContext("webgl2");

--- a/examples/webgl2/oimo/balls/index.html
+++ b/examples/webgl2/oimo/balls/index.html
@@ -62,7 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/balls/index.js
+++ b/examples/webgl2/oimo/balls/index.js
@@ -35,7 +35,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl2/oimo/box/index.html
+++ b/examples/webgl2/oimo/box/index.html
@@ -62,7 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/box/index.js
+++ b/examples/webgl2/oimo/box/index.js
@@ -44,7 +44,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl2/oimo/cone/index.html
+++ b/examples/webgl2/oimo/cone/index.html
@@ -62,7 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/cone/index.js
+++ b/examples/webgl2/oimo/cone/index.js
@@ -26,7 +26,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let cylWireVB, cylWireIB, cylWireCount;
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl2/oimo/domino/index.html
+++ b/examples/webgl2/oimo/domino/index.html
@@ -79,7 +79,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/domino/index.js
+++ b/examples/webgl2/oimo/domino/index.js
@@ -58,7 +58,7 @@ gl.enable(gl.DEPTH_TEST);
 gl.depthFunc(gl.LEQUAL);
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let dominoPosVBO;
 let lineVP = mat4.create();

--- a/examples/webgl2/oimo/football/index.html
+++ b/examples/webgl2/oimo/football/index.html
@@ -62,7 +62,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/football/index.js
+++ b/examples/webgl2/oimo/football/index.js
@@ -48,7 +48,7 @@ let view = mat4.create();
 let model = mat4.create();
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl2/oimo/gltf/index.html
+++ b/examples/webgl2/oimo/gltf/index.html
@@ -76,7 +76,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/gltf/index.js
+++ b/examples/webgl2/oimo/gltf/index.js
@@ -12,7 +12,7 @@ let attribs;
 let uniforms;
 
 let lineProgram;
-let showWireframe = false;
+let showWireframe = true;
 let lineAttribs;
 let lineUniforms;
 

--- a/examples/webgl2/oimo/marbles/index.html
+++ b/examples/webgl2/oimo/marbles/index.html
@@ -263,7 +263,7 @@ void main() {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/marbles/index.js
+++ b/examples/webgl2/oimo/marbles/index.js
@@ -21,7 +21,7 @@ let world;
 const marbles = [];
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let sphWireVB, sphWireIB, sphWireCount;
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgl2/oimo/minimum/index.html
+++ b/examples/webgl2/oimo/minimum/index.html
@@ -51,7 +51,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/minimum/index.js
+++ b/examples/webgl2/oimo/minimum/index.js
@@ -4,7 +4,7 @@ let attributeLocations = [];
 let uniformLocations = [];
 let mainProgram;
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 const BOX_WIRE_VERTS = new Float32Array([
     -0.5,-0.5,-0.5,  0.5,-0.5,-0.5,  0.5, 0.5,-0.5, -0.5, 0.5,-0.5,

--- a/examples/webgl2/oimo/shogi/index.html
+++ b/examples/webgl2/oimo/shogi/index.html
@@ -107,7 +107,7 @@ void main() {
 
 <canvas id="c" width="465" height="465"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgl2/oimo/shogi/index.js
+++ b/examples/webgl2/oimo/shogi/index.js
@@ -25,7 +25,7 @@ function resizeCanvas() {
 }
 
 let lineProgram, linePosLoc, lineVPLoc, lineModelLoc, lineColorLoc;
-let showWireframe = false;
+let showWireframe = true;
 let boxWireVB, boxWireIB;
 let lineVP = mat4.create();
 const BOX_WIRE_VERTS = new Float32Array([

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.html
@@ -93,7 +93,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/havok/gltf_physics_Materials_Friction/index.js
@@ -12,7 +12,7 @@ let format;
 
 let trianglePipeline;
 let linePipeline;
-let showWireframe = false;
+let showWireframe = true;
 let textureSampler;
 let depthTexture;
 let whiteTextureView;

--- a/examples/webgpu/wgsl_compute/coins/index.html
+++ b/examples/webgpu/wgsl_compute/coins/index.html
@@ -481,7 +481,7 @@ fn main(@location(0) dir : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <canvas id="c"></canvas>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -40,7 +40,7 @@ let computeBindGroups = [];
 let currentState = 0;
 let coinCount = 0;
 let lastTime = -1;
-let showWireframe = false;
+let showWireframe = true;
 
 const projectionMatrix = new Float32Array(16);
 const viewMatrix = new Float32Array(16);

--- a/examples/webgpu/wgsl_compute/cone/index.html
+++ b/examples/webgpu/wgsl_compute/cone/index.html
@@ -398,7 +398,7 @@ fn main(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/cone/index.js
+++ b/examples/webgpu/wgsl_compute/cone/index.js
@@ -30,7 +30,7 @@ let computeBindGroups = [];
 let wireBindGroups = [];
 let currentState = 0;
 let lastTime = -1;
-let showWireframe = false;
+let showWireframe = true;
 
 const projectionMatrix = new Float32Array(16);
 const viewMatrix = new Float32Array(16);

--- a/examples/webgpu/wgsl_compute/gltf/index.html
+++ b/examples/webgpu/wgsl_compute/gltf/index.html
@@ -279,7 +279,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c" width="465" height="465"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf/index.js
+++ b/examples/webgpu/wgsl_compute/gltf/index.js
@@ -26,7 +26,7 @@ let duckModel, groundMesh, wireMesh;
 let stateBuffer, simParamsBuffer, groundUniformBuffer, groundBindGroup, wireUniformBuffer, wireBindGroup;
 let computeBindGroup;
 let renderBindGroups = new Map();
-let showWireframe = false;
+let showWireframe = true;
 let lastTime = -1;
 let duckHalfExtents = [1, 1, 1];
 let duckCenter = [0, 0, 0];

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.html
@@ -336,7 +336,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Basic_Shapes/index.js
@@ -34,7 +34,7 @@ let wireBindGroups = [];
 let meshWireItems = [];
 let bodyRecords = [];
 let staticTriangleCount = 0;
-let showWireframe = false;
+let showWireframe = true;
 let lastTime = -1;
 
 const projectionMatrix = new Float32Array(16);

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.html
@@ -330,7 +330,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Friction/index.js
@@ -208,7 +208,7 @@ let floorRenderUBO, floorRenderBG;
 let floorWireUBO, floorWireBG;
 
 let computePipeline;
-let showWireframe = false;
+let showWireframe = true;
 let renderModel = null;
 
 // Camera: match the WebGPU + Havok sample framing.

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.html
@@ -238,7 +238,7 @@ fn main() -> @location(0) vec4<f32> {
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Materials_Restitution/index.js
@@ -203,7 +203,7 @@ let floorRenderUBO, floorRenderBG;
 let floorWireUBO, floorWireBG;
 
 let computePipeline;
-let showWireframe = false;
+let showWireframe = true;
 let renderModel = null;
 
 // Camera: match the WebGPU + Havok sample framing.

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.html
@@ -390,7 +390,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 
 <canvas id="c"></canvas>
 <div id="hint">
-    W: wireframe OFF
+    W: wireframe ON
 </div>
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/wgsl_compute/gltf_physics_Motion_Properties/index.js
@@ -36,7 +36,7 @@ let meshWireItems = [];
 let bodyRecords = [];
 let staticTriangleCount = 0;
 let staticCeilingY = 100000;
-let showWireframe = false;
+let showWireframe = true;
 let lastTime = -1;
 
 const projectionMatrix = new Float32Array(16);

--- a/examples/webgpu/wgsl_compute/shogi/index.html
+++ b/examples/webgpu/wgsl_compute/shogi/index.html
@@ -403,7 +403,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
-<div id="hint">W: wireframe OFF</div>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -260,7 +260,7 @@ let uniformBuffer, renderBindGroupA, renderBindGroupB, pipeline;
 let groundPipeline, groundVBuffer, groundIBuffer, groundMVPBuffer, groundBindGroup, groundICount;
 let wirePipeline, wireVBuffer, wireIBuffer, wireICount;
 let wireBindGroupA, wireBindGroupB;
-let showWireframe = false;
+let showWireframe = true;
 let srcBuffer, dstBuffer;
 let computePipeline, computeBindGroupA, computeBindGroupB;
 let simParamsBuffer;


### PR DESCRIPTION
## Summary

Adds a **W-key wireframe toggle** to the three.js samples that render physics colliders but lacked one, and **defaults every wireframe-toggle sample to wireframe ON** so the physics shapes are visible on load. This unifies the behavior across all backends.

## Background

Several samples already had a W-key toggle for the debug collider wireframes (shogi, coins, and the WebGL1/WebGL2/WebGPU/Babylon.js samples), but:
- The three.js Havok and cannon-es collider samples only *showed* the wireframes, with no way to hide them.
- The initial state was inconsistent (most existing toggles defaulted to OFF).

## Changes

- **New toggle (15 three.js samples):** 14 `threejs/havok/*` + `threejs/cannon-es/gltf_physics_Materials_Friction`. Adds `setWireframeVisible()` (toggles every collider wireframe via `scene.traverse` — only debug `LineSegments` exist in these scenes), a `keydown` handler (`W`), and a `#hint` element + style, matching the existing samples.
- **Default ON (all backends):** flips every `showWireframe` initial value to `true` and the hint text to `W: wireframe ON` across three.js, WebGL1, WebGL2, WebGPU, and Babylon.js. Each rendering style applies the initial state correctly (three.js `.visible`, raw WebGL/WebGPU/Babylon `if (showWireframe)` at draw).

171 files changed in total.

## Verification

- No `showWireframe = false` (any form) and no `W: wireframe OFF` hint text remain.
- `node --check` passes on representative scripts; CRLF line endings preserved (no mixed endings).

W now toggles the collider wireframes on/off in every sample, starting visible, with the hint reflecting the current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
