### PR TITLE
Add W-key wireframe toggle to three.js + Havok glTF (Duck) sample

### DIFF
--- a/examples/threejs/havok/gltf/index.html
+++ b/examples/threejs/havok/gltf/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
   "imports": {

--- a/examples/threejs/havok/gltf/index.js
+++ b/examples/threejs/havok/gltf/index.js
@@ -14,6 +14,7 @@ let HK, worldId;
 let scene, camera, renderer, controls;
 let duck, wireframeCube;
 let duckBodyId;
+let showWireframe = true;
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -157,4 +158,26 @@ async function main() {
   loadDuck();
 }
 
-main().catch(console.error);
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  if (wireframeCube) {
+    wireframeCube.visible = visible;
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
+
+main()
+  .then(() => setWireframeVisible(showWireframe))
+  .catch(console.error);

--- a/examples/threejs/havok/gltf/style.css
+++ b/examples/threejs/havok/gltf/style.css
@@ -14,3 +14,18 @@ body {
   width: 100vw;
   height: 100vh;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to `threejs/havok/gltf` (the falling Duck sample) — the only three.js + Havok sample that still lacked it. All other 16 three.js/havok samples already had the toggle.

## Background

This sample already drew the duck's collider as an **always-on green wireframe box** (`wireframeCube`), but offered no way to hide it. The wireframe here is a `THREE.Mesh` with `material.wireframe = true` (not `LineSegments`), so the toggle differs slightly from the other samples.

## Changes

- Add `showWireframe` state (default ON, matching the rest of the repo).
- Add `setWireframeVisible()` that toggles `wireframeCube.visible` and updates the on-screen hint, plus a `W` keydown handler.
- Add the `#hint` element and style to `index.html` / `style.css`.

## Verification

- `node --check` passes; CRLF line endings preserved.
- All 17 three.js/havok samples now expose the W toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
