### PR TITLE
Add W-key wireframe toggle to Babylon.js samples

### DIFF
--- a/examples/babylonjs/ammo/balls/index.html
+++ b/examples/babylonjs/ammo/balls/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/balls/index.js
+++ b/examples/babylonjs/ammo/balls/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/balls/style.css
+++ b/examples/babylonjs/ammo/balls/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/box/index.html
+++ b/examples/babylonjs/ammo/box/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/box/index.js
+++ b/examples/babylonjs/ammo/box/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/box/style.css
+++ b/examples/babylonjs/ammo/box/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/domino/index.html
+++ b/examples/babylonjs/ammo/domino/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/domino/index.js
+++ b/examples/babylonjs/ammo/domino/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/domino/style.css
+++ b/examples/babylonjs/ammo/domino/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/eraser/index.html
+++ b/examples/babylonjs/ammo/eraser/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/eraser/index.js
+++ b/examples/babylonjs/ammo/eraser/index.js
@@ -5,12 +5,17 @@ let canvas;
 const v3 = BABYLON.Vector3;
 const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -21,17 +26,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/eraser/style.css
+++ b/examples/babylonjs/ammo/eraser/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/football/index.html
+++ b/examples/babylonjs/ammo/football/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/football/index.js
+++ b/examples/babylonjs/ammo/football/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/football/style.css
+++ b/examples/babylonjs/ammo/football/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/gltf/index.html
+++ b/examples/babylonjs/ammo/gltf/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/gltf/index.js
+++ b/examples/babylonjs/ammo/gltf/index.js
@@ -1,12 +1,17 @@
 let engine;
 let scene;
 let canvas;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -17,17 +22,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/gltf/style.css
+++ b/examples/babylonjs/ammo/gltf/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/marbles/index.html
+++ b/examples/babylonjs/ammo/marbles/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/marbles/index.js
+++ b/examples/babylonjs/ammo/marbles/index.js
@@ -4,12 +4,17 @@ let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -20,17 +25,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/marbles/style.css
+++ b/examples/babylonjs/ammo/marbles/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/ammo/minimum/index.html
+++ b/examples/babylonjs/ammo/minimum/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/ammo/minimum/index.js
+++ b/examples/babylonjs/ammo/minimum/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/ammo/minimum/style.css
+++ b/examples/babylonjs/ammo/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/balls/index.html
+++ b/examples/babylonjs/cannon/balls/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/balls/index.js
+++ b/examples/babylonjs/cannon/balls/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/cannon/balls/style.css
+++ b/examples/babylonjs/cannon/balls/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/box/index.html
+++ b/examples/babylonjs/cannon/box/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/box/index.js
+++ b/examples/babylonjs/cannon/box/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/cannon/box/style.css
+++ b/examples/babylonjs/cannon/box/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/domino/index.html
+++ b/examples/babylonjs/cannon/domino/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/domino/index.js
+++ b/examples/babylonjs/cannon/domino/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/cannon/domino/style.css
+++ b/examples/babylonjs/cannon/domino/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/eraser/index.html
+++ b/examples/babylonjs/cannon/eraser/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/eraser/index.js
+++ b/examples/babylonjs/cannon/eraser/index.js
@@ -4,12 +4,17 @@ let canvas;
 // to go quicker
 const v3 = BABYLON.Vector3;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -20,17 +25,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/cannon/eraser/style.css
+++ b/examples/babylonjs/cannon/eraser/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/football/index.html
+++ b/examples/babylonjs/cannon/football/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/football/index.js
+++ b/examples/babylonjs/cannon/football/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/cannon/football/style.css
+++ b/examples/babylonjs/cannon/football/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/gltf/index.html
+++ b/examples/babylonjs/cannon/gltf/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/gltf/index.js
+++ b/examples/babylonjs/cannon/gltf/index.js
@@ -1,12 +1,17 @@
 let engine;
 let scene;
 let canvas;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -17,17 +22,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/cannon/gltf/style.css
+++ b/examples/babylonjs/cannon/gltf/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/marbles/index.html
+++ b/examples/babylonjs/cannon/marbles/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/marbles/index.js
+++ b/examples/babylonjs/cannon/marbles/index.js
@@ -4,12 +4,17 @@ let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -20,17 +25,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/cannon/marbles/style.css
+++ b/examples/babylonjs/cannon/marbles/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/cannon/minimum/index.html
+++ b/examples/babylonjs/cannon/minimum/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/cannon/minimum/index.js
+++ b/examples/babylonjs/cannon/minimum/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/cannon/minimum/style.css
+++ b/examples/babylonjs/cannon/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/balls/index.html
+++ b/examples/babylonjs/havok/balls/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/balls/index.js
+++ b/examples/babylonjs/havok/balls/index.js
@@ -3,12 +3,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -19,17 +24,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/havok/balls/style.css
+++ b/examples/babylonjs/havok/balls/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/box/index.html
+++ b/examples/babylonjs/havok/box/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/box/index.js
+++ b/examples/babylonjs/havok/box/index.js
@@ -55,12 +55,17 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -71,17 +76,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/havok/box/style.css
+++ b/examples/babylonjs/havok/box/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/cone/index.html
+++ b/examples/babylonjs/havok/cone/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/cone/index.js
+++ b/examples/babylonjs/havok/cone/index.js
@@ -5,12 +5,17 @@ let canvas;
 
 const CONE_COUNT = 120;
 const SCALE = 1 / 50;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -21,17 +26,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/cone/style.css
+++ b/examples/babylonjs/havok/cone/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/domino/index.html
+++ b/examples/babylonjs/havok/domino/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/domino/index.js
+++ b/examples/babylonjs/havok/domino/index.js
@@ -55,12 +55,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -71,17 +76,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/havok/domino/style.css
+++ b/examples/babylonjs/havok/domino/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/football/index.html
+++ b/examples/babylonjs/havok/football/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/football/index.js
+++ b/examples/babylonjs/havok/football/index.js
@@ -55,12 +55,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -71,17 +76,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/havok/football/style.css
+++ b/examples/babylonjs/havok/football/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf/index.html
+++ b/examples/babylonjs/havok/gltf/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/gltf/index.js
+++ b/examples/babylonjs/havok/gltf/index.js
@@ -2,12 +2,17 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 let engine;
 let scene;
 let canvas;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf/style.css
+++ b/examples/babylonjs/havok/gltf/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Basic_Shapes/index.js
@@ -42,12 +42,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -58,17 +63,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Basic_Shapes/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Basic_Shapes/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Filtering/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Filtering/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Filtering/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Filtering/index.js
@@ -42,12 +42,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -58,17 +63,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Filtering/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Filtering/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_JointTypes/index.html
+++ b/examples/babylonjs/havok/gltf_physics_JointTypes/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/babylonjs/havok/gltf_physics_JointTypes/index.js
@@ -42,12 +42,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -58,17 +63,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_JointTypes/style.css
+++ b/examples/babylonjs/havok/gltf_physics_JointTypes/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/index.js
@@ -41,12 +41,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -57,17 +62,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Materials_Friction/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Friction/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/index.js
@@ -41,12 +41,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -57,17 +62,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Materials_Restitution/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Materials_Restitution/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/index.js
@@ -42,12 +42,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -58,17 +63,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Motion_Properties/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Motion_Properties/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/gltf_physics_Triggers/index.html
+++ b/examples/babylonjs/havok/gltf_physics_Triggers/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs/havok/gltf_physics_Triggers/index.js
+++ b/examples/babylonjs/havok/gltf_physics_Triggers/index.js
@@ -42,12 +42,17 @@ function registerPhysicsExtensions() {
 
     physicsExtensionsRegistered = true;
 }
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -58,17 +63,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector('#c');
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/gltf_physics_Triggers/style.css
+++ b/examples/babylonjs/havok/gltf_physics_Triggers/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/marbles/index.html
+++ b/examples/babylonjs/havok/marbles/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/marbles/index.js
+++ b/examples/babylonjs/havok/marbles/index.js
@@ -5,12 +5,17 @@ let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -21,17 +26,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/marbles/style.css
+++ b/examples/babylonjs/havok/marbles/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/havok/minimum/index.html
+++ b/examples/babylonjs/havok/minimum/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/minimum/index.js
+++ b/examples/babylonjs/havok/minimum/index.js
@@ -3,12 +3,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -19,17 +24,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     globalThis.HK = await HavokPhysics({

--- a/examples/babylonjs/havok/minimum/style.css
+++ b/examples/babylonjs/havok/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/balls/index.html
+++ b/examples/babylonjs/oimo/balls/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/balls/index.js
+++ b/examples/babylonjs/oimo/balls/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/100;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/oimo/balls/style.css
+++ b/examples/babylonjs/oimo/balls/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/box/index.html
+++ b/examples/babylonjs/oimo/box/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/box/index.js
+++ b/examples/babylonjs/oimo/box/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;const FPS = 60;    // default is 60 FPS
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/oimo/box/style.css
+++ b/examples/babylonjs/oimo/box/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/domino/index.html
+++ b/examples/babylonjs/oimo/domino/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/domino/index.js
+++ b/examples/babylonjs/oimo/domino/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/oimo/domino/style.css
+++ b/examples/babylonjs/oimo/domino/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/eraser/index.html
+++ b/examples/babylonjs/oimo/eraser/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/eraser/index.js
+++ b/examples/babylonjs/oimo/eraser/index.js
@@ -4,12 +4,17 @@ let canvas;
 // to go quicker
 const v3 = BABYLON.Vector3;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -20,17 +25,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/oimo/eraser/style.css
+++ b/examples/babylonjs/oimo/eraser/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/football/index.html
+++ b/examples/babylonjs/oimo/football/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/football/index.js
+++ b/examples/babylonjs/oimo/football/index.js
@@ -54,12 +54,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -70,17 +75,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
 
     canvas = document.querySelector("#c");

--- a/examples/babylonjs/oimo/football/style.css
+++ b/examples/babylonjs/oimo/football/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/gltf/index.html
+++ b/examples/babylonjs/oimo/gltf/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/gltf/index.js
+++ b/examples/babylonjs/oimo/gltf/index.js
@@ -1,12 +1,17 @@
 let engine;
 let scene;
 let canvas;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -17,17 +22,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/oimo/gltf/style.css
+++ b/examples/babylonjs/oimo/gltf/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/marbles/index.html
+++ b/examples/babylonjs/oimo/marbles/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/marbles/index.js
+++ b/examples/babylonjs/oimo/marbles/index.js
@@ -4,12 +4,17 @@ let canvas;
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -20,17 +25,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/oimo/marbles/style.css
+++ b/examples/babylonjs/oimo/marbles/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/babylonjs/oimo/minimum/index.html
+++ b/examples/babylonjs/oimo/minimum/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/oimo/minimum/index.js
+++ b/examples/babylonjs/oimo/minimum/index.js
@@ -2,12 +2,17 @@ let engine;
 let scene;
 let canvas;
 const PHYSICS_SCALE = 1/10;
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
 function setupPhysicsDebugWireframe(scene) {
     if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
         return;
     }
 
-    const physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
     const seenImpostors = new WeakSet();
     const seenBodies = new WeakSet();
 
@@ -18,17 +23,60 @@ function setupPhysicsDebugWireframe(scene) {
             }
 
             if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
-                physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
                 seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
             }
 
             if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
-                physicsViewer.showBody(mesh.physicsBody);
                 seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
             }
         });
     });
 }
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 async function init() {
     canvas = document.querySelector("#c");
     engine = new BABYLON.Engine(canvas, true);

--- a/examples/babylonjs/oimo/minimum/style.css
+++ b/examples/babylonjs/oimo/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to all Babylon.js samples that drew the physics debug wireframe always-on. Only the `shogi` sample previously had the toggle; this brings the remaining **39 samples** (ammo / cannon / havok / oimo) in line with it and with the rest of the repo.

## Changes

For each sample:
- `setupPhysicsDebugWireframe()` now tracks the bodies/impostors registered with `BABYLON.Debug.PhysicsViewer` and gates their display on a `showWireframe` flag (default **ON**).
- Adds `setWireframeVisible()` that shows/hides the tracked debug shapes and updates the on-screen hint, plus a `W` keydown handler.
- Adds the `#hint` element and style to `index.html` / `style.css`.

The `setupPhysicsDebugWireframe()` body is replaced with the same toggle-aware version already used by the `shogi` sample, so the behavior is consistent.

117 files changed (39 samples × index.js / index.html / style.css).

## Verification

- `node --check` passes on representative scripts.
- All Babylon.js wireframe samples now expose the W toggle; diffs are localized to the debug-wireframe code (existing line endings preserved per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
