### PR TITLE
Add W-key wireframe toggle to WebGPU samples

### DIFF
--- a/examples/webgpu/havok/gltf_physics_Filtering/index.html
+++ b/examples/webgpu/havok/gltf_physics_Filtering/index.html
@@ -152,6 +152,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_Filtering/index.js
+++ b/examples/webgpu/havok/gltf_physics_Filtering/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Filtering/Filtering.glb';
-const SHOW_DEBUG_BBOX = false;
+let showWireframe = true;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -1391,7 +1391,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -1508,6 +1508,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_Filtering/style.css
+++ b/examples/webgpu/havok/gltf_physics_Filtering/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/havok/gltf_physics_JointTypes/index.html
+++ b/examples/webgpu/havok/gltf_physics_JointTypes/index.html
@@ -152,6 +152,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgpu/havok/gltf_physics_JointTypes/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/JointTypes/JointTypes.glb';
-const SHOW_DEBUG_BBOX = false;
+let showWireframe = true;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -1582,7 +1582,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -1699,6 +1699,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_JointTypes/style.css
+++ b/examples/webgpu/havok/gltf_physics_JointTypes/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.html
@@ -92,6 +92,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/webgpu/havok/gltf_physics_Materials_Restitution/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
-const SHOW_DEBUG_BBOX = false;
+let showWireframe = true;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -967,7 +967,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -1084,6 +1084,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_Materials_Restitution/style.css
+++ b/examples/webgpu/havok/gltf_physics_Materials_Restitution/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.html
@@ -152,6 +152,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/MotionProperties.glb';
-const SHOW_DEBUG_BBOX = false;
+let showWireframe = true;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -1357,7 +1357,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -1474,6 +1474,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_Motion_Properties/style.css
+++ b/examples/webgpu/havok/gltf_physics_Motion_Properties/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/havok/gltf_physics_Triggers/index.html
+++ b/examples/webgpu/havok/gltf_physics_Triggers/index.html
@@ -152,6 +152,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/havok/gltf_physics_Triggers/index.js
+++ b/examples/webgpu/havok/gltf_physics_Triggers/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 const { mat4, vec3, quat } = glMatrix;
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Triggers/Triggers.glb';
-const SHOW_DEBUG_BBOX = false;
+let showWireframe = true;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -20;
 
@@ -1398,7 +1398,7 @@ function render(timeMs) {
 
     drawDuckNodes(pass);
 
-    if (SHOW_DEBUG_BBOX) {
+    if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -1515,6 +1515,13 @@ async function main() {
 
     resize();
     window.addEventListener('resize', resize);
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     debugBoxMesh = createDebugLineMesh();
     debugLineUniformBuffer = device.createBuffer({

--- a/examples/webgpu/havok/gltf_physics_Triggers/style.css
+++ b/examples/webgpu/havok/gltf_physics_Triggers/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/balls/index.html
+++ b/examples/webgpu/oimo/balls/index.html
@@ -84,6 +84,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/balls/index.js
+++ b/examples/webgpu/oimo/balls/index.js
@@ -1,4 +1,5 @@
 import Module from 'https://esm.run/manifold-3d';
+let showWireframe = true;
 const { mat4, vec3, quat } = glMatrix;
 
 const BALL_COUNT = 180;
@@ -401,6 +402,7 @@ function render(timeMs) {
     }
 
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, lineVtxBuf);
     pass.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -415,6 +417,7 @@ function render(timeMs) {
         pass.drawIndexed(sphWireCount);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -533,4 +536,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/balls/style.css
+++ b/examples/webgpu/oimo/balls/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/box/index.html
+++ b/examples/webgpu/oimo/box/index.html
@@ -84,6 +84,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/box/index.js
+++ b/examples/webgpu/oimo/box/index.js
@@ -1,4 +1,5 @@
 import Module from 'https://esm.run/manifold-3d';
+let showWireframe = true;
 const { mat4, vec3, quat } = glMatrix;
 
 const DOT_ROWS = [
@@ -381,6 +382,7 @@ function render(timeMs) {
     }
 
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, lineVtxBuf);
     pass.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -391,6 +393,7 @@ function render(timeMs) {
         pass.drawIndexed(24);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -507,4 +510,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/box/style.css
+++ b/examples/webgpu/oimo/box/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/cone/index.html
+++ b/examples/webgpu/oimo/cone/index.html
@@ -84,6 +84,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/cone/index.js
+++ b/examples/webgpu/oimo/cone/index.js
@@ -1,4 +1,5 @@
 const { mat4, vec3, quat } = glMatrix;
+let showWireframe = true;
 
 const CONE_COUNT = 160;
 const BASKET_HALF = 3.0;
@@ -388,6 +389,7 @@ function render(timeMs) {
     }
 
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, lineVtxBuf);
     pass.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -402,6 +404,7 @@ function render(timeMs) {
         pass.drawIndexed(cylWireCount);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -508,4 +511,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/cone/style.css
+++ b/examples/webgpu/oimo/cone/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/domino/index.html
+++ b/examples/webgpu/oimo/domino/index.html
@@ -96,6 +96,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/domino/index.js
+++ b/examples/webgpu/oimo/domino/index.js
@@ -1,4 +1,5 @@
 // WebGPU + Oimo.js Domino Example
+let showWireframe = true;
 // forked from gaziya's "Domino (WebGL2 + Oimo.js)" http://jsdo.it/gaziya/46vq
 
 // ‥‥‥‥‥‥‥‥‥‥‥‥‥□□□
@@ -396,6 +397,7 @@ function render() {
         lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
     }
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     passEncoder.setPipeline(linePipeline);
     passEncoder.setVertexBuffer(0, lineVtxBuf);
     passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -404,9 +406,19 @@ function render() {
         passEncoder.drawIndexed(24);
     }
 
+    }
     passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(render);
 }
 
 init();
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});

--- a/examples/webgpu/oimo/domino/style.css
+++ b/examples/webgpu/oimo/domino/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/football/index.html
+++ b/examples/webgpu/oimo/football/index.html
@@ -84,6 +84,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/football/index.js
+++ b/examples/webgpu/oimo/football/index.js
@@ -1,4 +1,5 @@
 import Module from 'https://esm.run/manifold-3d';
+let showWireframe = true;
 const { mat4, vec3, quat } = glMatrix;
 
 const DOT_ROWS = [
@@ -420,6 +421,7 @@ function render(timeMs) {
     }
 
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, lineVtxBuf);
     pass.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -432,6 +434,7 @@ function render(timeMs) {
         pass.drawIndexed(sphWireCount);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -556,4 +559,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/football/style.css
+++ b/examples/webgpu/oimo/football/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/gltf/index.html
+++ b/examples/webgpu/oimo/gltf/index.html
@@ -92,6 +92,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/gltf/index.js
+++ b/examples/webgpu/oimo/gltf/index.js
@@ -1,4 +1,5 @@
 const { mat4, vec3, quat } = glMatrix;
+let showWireframe = true;
 
 const DUCK_GLTF_URL = 'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
 const FALL_SCALE = 5.0;
@@ -698,6 +699,7 @@ function render(timeMs) {
 
         writeLineUniforms(debugLineUniformBuffer, debugModel, [0.0, 1.0, 0.0, 1.0]);
 
+        if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setBindGroup(0, debugLineBindGroup);
         pass.setVertexBuffer(0, debugBoxMesh.positionBuffer);
@@ -705,6 +707,7 @@ function render(timeMs) {
         pass.drawIndexed(debugBoxMesh.indexCount, 1, 0, 0, 0);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -839,4 +842,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/gltf/style.css
+++ b/examples/webgpu/oimo/gltf/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/marbles/index.html
+++ b/examples/webgpu/oimo/marbles/index.html
@@ -302,6 +302,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/marbles/index.js
+++ b/examples/webgpu/oimo/marbles/index.js
@@ -1,4 +1,5 @@
 const { mat4, vec3, quat } = glMatrix;
+let showWireframe = true;
 
 const MARBLES_GLTF_URL = 'https://cx20.github.io/gltf-test/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
 const GROUND_TEXTURE_FILE = '../../../../assets/textures/grass.jpg';
@@ -903,6 +904,7 @@ function render(timeMs) {
     }
 
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     pass.setPipeline(linePipeline);
     pass.setVertexBuffer(0, lineVtxBuf);
     pass.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -915,6 +917,7 @@ function render(timeMs) {
         pass.drawIndexed(sphWireCount);
     }
 
+    }
     pass.end();
     device.queue.submit([encoder.finish()]);
 
@@ -1094,4 +1097,13 @@ async function main() {
 
 main().catch((err) => {
     console.error(err);
+});
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
 });

--- a/examples/webgpu/oimo/marbles/style.css
+++ b/examples/webgpu/oimo/marbles/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/minimum/index.html
+++ b/examples/webgpu/oimo/minimum/index.html
@@ -67,6 +67,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/minimum/index.js
+++ b/examples/webgpu/oimo/minimum/index.js
@@ -1,4 +1,5 @@
 const vertexShaderWGSL = document.getElementById('vs').textContent;
+let showWireframe = true;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 
 let canvas;
@@ -465,6 +466,7 @@ async function render() {
         lineUniformData.set(lineVP, s1); lineUniformData.set(bm, s1 + 16);
         lineUniformData[s1+32] = 1; lineUniformData[s1+33] = 1; lineUniformData[s1+34] = 0; lineUniformData[s1+35] = 1;
         device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+        if (showWireframe) {
         passEncoder.setPipeline(linePipeline);
         passEncoder.setVertexBuffer(0, lineVtxBuf);
         passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -473,6 +475,7 @@ async function render() {
         passEncoder.setBindGroup(0, lineBG, [LINE_ALIGN]);
         passEncoder.drawIndexed(24);
 
+        }
         passEncoder.end();
         device.queue.submit([commandEncoder.finish()]);
     }
@@ -481,3 +484,11 @@ async function render() {
 }
 
 init();
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});

--- a/examples/webgpu/oimo/minimum/style.css
+++ b/examples/webgpu/oimo/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/oimo/shogi/index.html
+++ b/examples/webgpu/oimo/shogi/index.html
@@ -117,6 +117,7 @@ fn main() -> @location(0) vec4<f32> { return uniforms.color; }
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/oimo/shogi/index.js
+++ b/examples/webgpu/oimo/shogi/index.js
@@ -1,4 +1,5 @@
 const vertexShaderWGSL   = document.getElementById('vs').textContent;
+let showWireframe = true;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 const groundVertWGSL     = document.getElementById('gvs').textContent;
 const groundFragWGSL     = document.getElementById('gfs').textContent;
@@ -540,6 +541,7 @@ function render() {
         lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;
     }
     device.queue.writeBuffer(lineUniformBuf, 0, lineUniformData);
+    if (showWireframe) {
     passEncoder.setPipeline(linePipeline);
     passEncoder.setVertexBuffer(0, lineVtxBuf);
     passEncoder.setIndexBuffer(lineIdxBuf, 'uint16');
@@ -548,9 +550,19 @@ function render() {
         passEncoder.drawIndexed(24);
     }
 
+    }
     passEncoder.end();
     device.queue.submit([commandEncoder.finish()]);
     requestAnimationFrame(render);
 }
 
 init();
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});

--- a/examples/webgpu/oimo/shogi/style.css
+++ b/examples/webgpu/oimo/shogi/style.css
@@ -10,3 +10,18 @@ body {
   height: 100%;
   background: #fff;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/webgpu/wgsl_compute/minimum/index.html
+++ b/examples/webgpu/wgsl_compute/minimum/index.html
@@ -215,6 +215,7 @@ fn main() -> @location(0) vec4<f32> {
 </script>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/minimum/index.js
+++ b/examples/webgpu/wgsl_compute/minimum/index.js
@@ -1,4 +1,5 @@
 const computeShaderWGSL = document.getElementById('cs').textContent;
+let showWireframe = true;
 const vertexShaderWGSL  = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 
@@ -189,6 +190,7 @@ function frame(timeMs) {
         pass.setBindGroup(0, cubeBindGroup);
         pass.drawIndexed(indexCount);
 
+        if (showWireframe) {
         pass.setPipeline(linePipeline);
         pass.setVertexBuffer(0, debugBoxVertexBuffer);
         pass.setIndexBuffer(debugBoxIndexBuffer, 'uint16');
@@ -197,6 +199,7 @@ function frame(timeMs) {
         pass.setBindGroup(0, lineBindGroup, [1 * LINE_ALIGN]);
         pass.drawIndexed(debugBoxIndexCount);
 
+        }
         pass.end();
     }
 
@@ -346,3 +349,12 @@ async function init() {
 }
 
 init().catch(err => console.error(err));
+
+
+window.addEventListener('keydown', event => {
+    const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+    if (!isWKey || event.repeat) return;
+    showWireframe = !showWireframe;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+});

--- a/examples/webgpu/wgsl_compute/minimum/style.css
+++ b/examples/webgpu/wgsl_compute/minimum/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to the 15 WebGPU samples whose collider/debug wireframes had no runtime toggle.

## Background

- `havok/gltf_physics_*` (Filtering, JointTypes, Materials_Restitution, Motion_Properties, Triggers) gated the debug wireframe on a compile-time `SHOW_DEBUG_BBOX` flag (which was `false`).
- `oimo/*` and `wgsl_compute/minimum` drew the `line-list` debug wireframe unconditionally, with no way to hide it.

## Changes

- **havok/gltf_physics_***: replace `SHOW_DEBUG_BBOX` with a `showWireframe` flag (default **ON**) and add the keydown handler — matching the already-toggled `gltf_physics_Materials_Friction` sample.
- **oimo/{balls,box,cone,domino,football,gltf,marbles,minimum,shogi}** and **wgsl_compute/minimum**: wrap the line-list debug draw in `if (showWireframe)` and add the keydown handler.
- Add the `#hint` element and style to each `index.html` / `style.css`.

Wireframes default to ON; pressing **W** toggles them and updates the hint. 45 files changed (15 × index.js / index.html / style.css).

## Verification

- `node --check` passes on all 15 scripts.
- Diffs are localized to the debug-wireframe code; existing per-file line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
