### PR TITLE
Add W-key wireframe toggle to three.js oimo/oimophysics/rapier glTF samples

### DIFF
--- a/examples/threejs/oimo/gltf/index.html
+++ b/examples/threejs/oimo/gltf/index.html
@@ -6,6 +6,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/oimo/1.0.9/oimo.js"></script>
 </head>
 <body>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimo/gltf/index.js
+++ b/examples/threejs/oimo/gltf/index.js
@@ -8,6 +8,7 @@ let camera, scene, renderer, duck, plane,
     cubeSize = 1;
 
 let wireframeCube;
+let showWireframe = true;
 let controls;
 
 let cubeSizeX = 16/16*5;
@@ -193,3 +194,23 @@ document.addEventListener('click', function () {
     //body.applyImpulse(body.position, new OIMO.Vec3(0, 5, 0));   // TODO:
     body.linearVelocity.set(0, 5, 0);
 }, false);
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (wireframeCube) {
+        wireframeCube.visible = visible;
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (event) {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});

--- a/examples/threejs/oimo/gltf/style.css
+++ b/examples/threejs/oimo/gltf/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/oimophysics/gltf/index.html
+++ b/examples/threejs/oimophysics/gltf/index.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.jsdelivr.net/gh/saharan/OimoPhysics@1.2.2/bin/js/OimoPhysics.js"></script>
 </head>
 <body>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimophysics/gltf/index.js
+++ b/examples/threejs/oimophysics/gltf/index.js
@@ -8,6 +8,7 @@ let camera, scene, renderer, duck, plane,
     cubeSize = 1;
 
 let wireframeCube;
+let showWireframe = true;
 let controls;
 
 let cubeSizeX = 16/16*5;
@@ -187,3 +188,23 @@ initThree();
 document.addEventListener('click', function() {
     body.setLinearVelocity(new OIMO.Vec3(0, 5, 0));
 }, false);
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (wireframeCube) {
+        wireframeCube.visible = visible;
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (event) {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});

--- a/examples/threejs/oimophysics/gltf/style.css
+++ b/examples/threejs/oimophysics/gltf/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/rapier/gltf/index.html
+++ b/examples/threejs/rapier/gltf/index.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/rapier/gltf/index.js
+++ b/examples/threejs/rapier/gltf/index.js
@@ -6,6 +6,7 @@ import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 let world, body;
 let camera, scene, renderer, duck, plane;
 let wireframeCube;
+let showWireframe = true;
 let controls;
 
 const cubeSizeX = 16 / 16 * 5;
@@ -134,3 +135,23 @@ init();
 document.addEventListener('click', function() {
     body.setLinvel({ x: 0, y: 5, z: 0 }, true);
 }, false);
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (wireframeCube) {
+        wireframeCube.visible = visible;
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (event) {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});

--- a/examples/threejs/rapier/gltf/style.css
+++ b/examples/threejs/rapier/gltf/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to the three.js + oimo / OimoPhysics / rapier falling-glTF (Duck) samples. These drew the collider as an always-on wireframe box (`wireframeCube`) with no way to hide it, unlike the already-fixed havok glTF sample.

## Changes

For each of `threejs/oimo/gltf`, `threejs/oimophysics/gltf`, `threejs/rapier/gltf`:
- Add `showWireframe` state (default **ON**) and `setWireframeVisible()` that toggles `wireframeCube.visible` and updates the on-screen hint, plus a `W` keydown handler.
- Add the `#hint` element and style to `index.html` / `style.css`.

The wireframe here is a `THREE.Mesh` (`material.wireframe`), so the toggle flips `wireframeCube.visible` directly.

## Verification

- `node --check` passes; CRLF line endings preserved (no mixed endings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
