### PR TITLE
Add W-key wireframe toggle to PlayCanvas gltf_physics_Basic_Shapes sample

### DIFF
--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
@@ -491,6 +491,8 @@ function computeWorldBounds(root) {
     return { center, radius: Math.max(Math.sqrt(dx*dx+dy*dy+dz*dz)*0.5, 6) };
 }
 
+let showWireframe = true;
+
 function init() {
     const canvas = document.getElementById('c');
     const app = new pc.Application(canvas);
@@ -498,6 +500,13 @@ function init() {
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
     window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     app.scene.ambientLight = new pc.Color(0.68, 0.7, 0.76);
     const light = new pc.Entity('light');
@@ -547,8 +556,10 @@ function init() {
             );
             camera.lookAt(center);
 
-            drawPhysicsDebug(app, debugEntities);
-            drawMeshStaticDebug(app, meshStaticEntities);
+            if (showWireframe) {
+                drawPhysicsDebug(app, debugEntities);
+                drawMeshStaticDebug(app, meshStaticEntities);
+            }
 
             for (const body of dynamicBodies) {
                 if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) continue;

--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to `playcanvas/ammo/gltf_physics_Basic_Shapes`, which drew the physics debug wireframe (`app.drawLines`) every frame with no way to hide it.

## Changes

- Add `showWireframe` state (default **ON**) and gate the per-frame debug draw calls (`drawPhysicsDebug` / `drawMeshStaticDebug`) on it.
- Add a `W` keydown handler that flips the flag and updates the on-screen hint.
- Add the `#hint` element and style to `index.html` / `style.css`.

## Verification

- `node --check` passes; CRLF line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
