### PR TITLE
Add W-key wireframe toggle to Rhodonite + Havok glTF sample

### DIFF
--- a/examples/rhodonite/havok/gltf/index.html
+++ b/examples/rhodonite/havok/gltf/index.html
@@ -14,6 +14,7 @@
 }
 </script>
 <canvas id="world"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/rhodonite/havok/gltf/index.js
+++ b/examples/rhodonite/havok/gltf/index.js
@@ -14,6 +14,7 @@ let duckExpression, duckRenderPass;
 let groundEntity, wireEntity;
 let expression;
 let started = false;
+let showWireframe = true;
 
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
@@ -188,5 +189,26 @@ const load = async function() {
   };
   draw();
 };
+
+
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  if (wireEntity) {
+    wireEntity.getSceneGraph().isVisible = visible;
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) {
+    return;
+  }
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
 
 document.body.onload = load;

--- a/examples/rhodonite/havok/gltf/style.css
+++ b/examples/rhodonite/havok/gltf/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the **W-key wireframe toggle** to `rhodonite/havok/gltf` (the falling Duck sample), which drew the collider as an always-on wireframe box (`wireEntity`) with no way to hide it.

## Changes

- Add `showWireframe` state (default **ON**) and `setWireframeVisible()` that toggles the `wireEntity` scene-graph visibility (`getSceneGraph().isVisible`) and updates the on-screen hint, plus a `W` keydown handler.
- Add the `#hint` element and style to `index.html` / `style.css`.

## Verification

- `node --check` passes; CRLF line endings preserved.

This was the last of the wireframe samples missing the toggle — all backends (three.js, WebGL1/2, WebGPU, Babylon.js, PlayCanvas, Rhodonite) now expose the W toggle, defaulting to wireframe ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
