### PR TITLE
Add W-key wireframe toggle to PlayCanvas gltf_physics_Motion_Properties sample

### DIFF
--- a/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.html
@@ -14,6 +14,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.js
@@ -533,6 +533,8 @@ function drawPhysicsDebug(app, entities) {
     }
 }
 
+let showWireframe = true;
+
 function init() {
     const canvas = document.getElementById('c');
     const app = new pc.Application(canvas, {
@@ -547,6 +549,13 @@ function init() {
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
     window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     app.scene.toneMapping   = pc.TONEMAP_ACES;
     app.scene.exposure      = 0.8;
@@ -615,8 +624,10 @@ function init() {
         let gravityApplied = false;
 
         app.on('update', dt => {
-            drawPhysicsDebug(app, debugEntities);
-            drawMeshStaticDebug(app, meshStaticEntities);
+            if (showWireframe) {
+                drawPhysicsDebug(app, debugEntities);
+                drawMeshStaticDebug(app, meshStaticEntities);
+            }
 
             // Sync manual Ammo dynamic bodies to PlayCanvas entities + draw debug AABB.
             for (const mb of manualDynamicBodies) {

--- a/examples/playcanvas/ammo/gltf_physics_Motion_Properties/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Motion_Properties/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Follow-up to #282: `playcanvas/ammo/gltf_physics_Motion_Properties` also draws the physics debug wireframe (`app.drawLines`) every frame with no toggle, and was missed in the earlier sweep (the original scan keyed on the word "wireframe", which this file's debug code doesn't contain).

## Changes

- Add `showWireframe` state (default **ON**) and gate the per-frame debug draw calls (`drawPhysicsDebug` / `drawMeshStaticDebug`) on it.
- Add a `W` keydown handler that updates the on-screen hint.
- Add the `#hint` element and style to `index.html` / `style.css`.

## Verification

- `node --check` passes; CRLF preserved.
- A repo-wide rescan (now also keying on `app.drawLines`) confirms **no** wireframe samples remain without the W toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
