### PR TITLE
Add W-key wireframe toggle to Rhodonite + Havok shogi sample

### DIFF
--- a/examples/rhodonite/havok/shogi/index.html
+++ b/examples/rhodonite/havok/shogi/index.html
@@ -14,6 +14,7 @@
 }
 </script>
 <canvas id="world"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/rhodonite/havok/shogi/index.js
+++ b/examples/rhodonite/havok/shogi/index.js
@@ -8,6 +8,46 @@ let HK, worldId, engine;
 const entities = [];
 const bodyIds = [];
 
+let showWireframe = true;
+const debugEntities = [];         // all collider wireframes (for the W toggle)
+const pieceDebugEntities = [];    // per-piece wireframes, parallel to bodyIds
+const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+
+// Mirror the other Rhodonite samples: PbrUber + RN_USE_WIREFRAME, with calcBaryCentricCoord()
+// on the mesh so the wireframe shader can draw the edges.
+function makeDebugMaterial(color) {
+  const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: false, isSkinning: false, isMorphing: false });
+  try { mat.addShaderDefine('RN_USE_WIREFRAME'); } catch (e) {}
+  try { mat.setParameter('wireframe', Rn.Vector3.fromCopy3(1, 0, 1)); } catch (e) {}
+  try { mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4(color)); } catch (e) {}
+  return mat;
+}
+
+function createDebugBox(size, pos, color) {
+  const entity = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(color) });
+  entity.getTransform().localScale = Rn.Vector3.fromCopyArray([size[0], size[1], size[2]]);
+  entity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
+  try { entity.getMesh().calcBaryCentricCoord(); } catch (e) {}
+  debugEntities.push(entity);
+  return entity;
+}
+
+// Box wireframe geometry (full size w x h x d, centred on the origin).
+function buildBoxGeometry(w, h, d) {
+  const x = w / 2, y = h / 2, z = d / 2;
+  const positions = new Float32Array([
+    -x, -y, -z,  x, -y, -z,  x, y, -z,  -x, y, -z,
+    -x, -y,  z,  x, -y,  z,  x, y,  z,  -x, y,  z,
+  ]);
+  const indices = new Uint16Array([
+    0, 1, 2, 0, 2, 3,   4, 6, 5, 4, 7, 6,
+    0, 4, 7, 0, 7, 3,   1, 5, 6, 1, 6, 2,
+    3, 7, 6, 3, 6, 2,   0, 5, 1, 0, 4, 5,
+  ]);
+  return { positions, indices };
+}
+
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
   if (!value || typeof value !== 'object') return NaN;
@@ -131,6 +171,7 @@ const load = async function() {
   groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, -2, 0]);
   groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([40, 4, 40]);
   entities.push(groundEntity);
+  createDebugBox([40, 4, 40], [0, -2, 0], DEBUG_COLOR_STATIC);
 
   // Walls
   const wallDefs = [
@@ -147,6 +188,7 @@ const load = async function() {
     wallEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
     wallEntity.getTransform().localScale = Rn.Vector3.fromCopyArray(size);
     entities.push(wallEntity);
+    createDebugBox(size, pos, DEBUG_COLOR_STATIC);
   }
 
   const pieceW = 1.6;
@@ -180,6 +222,24 @@ const load = async function() {
   const sharedMesh = new Rn.Mesh(engine);
   sharedMesh.addPrimitive(sharedPrimitive);
 
+  // Shared box-shaped collider wireframe (one mesh reused by every piece, like the visual mesh,
+  // so the debug pass instances rather than issuing 220 separate draws). The wireframe shader
+  // needs un-indexed geometry + barycentric coords (what MeshComponent.calcBaryCentricCoord does).
+  const pieceWireGeo = buildBoxGeometry(pieceW, pieceH, pieceD * 1.4);
+  const pieceWirePrimitive = Rn.Primitive.createPrimitive(engine, {
+    indices: pieceWireGeo.indices,
+    attributeSemantics: [Rn.VertexAttribute.Position.XYZ],
+    attributes: [pieceWireGeo.positions],
+    material: makeDebugMaterial(DEBUG_COLOR_DYNAMIC),
+    primitiveMode: Rn.PrimitiveMode.Triangles,
+  });
+  const pieceWireMesh = new Rn.Mesh(engine);
+  pieceWireMesh.addPrimitive(pieceWirePrimitive);
+  try {
+    for (const prim of pieceWireMesh.primitives) prim.convertToUnindexedGeometry();
+    pieceWireMesh._calcBaryCentricCoord();
+  } catch (e) { console.warn('[Shogi] baryCentric failed:', e); }
+
   for (let i = 0; i < PIECE_COUNT; i++) {
     const x = (Math.random() - 0.5) * 8;
     const y = 12 + Math.random() * 26;
@@ -204,6 +264,11 @@ const load = async function() {
     const entity = Rn.createMeshEntity(engine);
     entity.getMesh().setMesh(sharedMesh);
     entities.push(entity);
+
+    const debugEntity = Rn.createMeshEntity(engine);
+    debugEntity.getMesh().setMesh(pieceWireMesh);
+    debugEntities.push(debugEntity);
+    pieceDebugEntities.push(debugEntity);
   }
 
   // Camera
@@ -211,8 +276,10 @@ const load = async function() {
   cameraEntity.localPosition = Rn.Vector3.fromCopyArray([18, 24, 34]);
   cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.6, 0.5, 0]);
   const cameraComponent = cameraEntity.getCamera();
-  cameraComponent.zNear = 0.01;
-  cameraComponent.zFar = 1000;
+  // Larger zNear (and tighter zFar) for better depth-buffer precision; the camera orbits far
+  // from the scene, so this avoids z-fighting. (0.01 / 1000 was far too wide a range.)
+  cameraComponent.zNear = 1.0;
+  cameraComponent.zFar = 200;
   cameraComponent.setFovyAndChangeFocalLength(60);
   cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
@@ -235,8 +302,17 @@ const load = async function() {
   renderPass.clearColor = Rn.Vector4.fromCopyArray4([0.17, 0.19, 0.22, 1]);
   renderPass.addEntities(entities);
 
+  // Collider wireframes are drawn in a second pass on top of the model (no depth test).
+  const debugRenderPass = new Rn.RenderPass(engine);
+  debugRenderPass.cameraComponent = cameraComponent;
+  debugRenderPass.toClearColorBuffer = false;
+  try { debugRenderPass.isDepthTest = false; } catch (e) {}
+  debugRenderPass.addEntities(debugEntities);
+
   const expression = new Rn.Expression();
-  expression.addRenderPasses([renderPass]);
+  expression.addRenderPasses([renderPass, debugRenderPass]);
+
+  setWireframeVisible(showWireframe);
 
   // 1 ground + 4 walls = 5 static entities before piece entities
   const physicsEntityOffset = 5;
@@ -251,6 +327,10 @@ const load = async function() {
       const entity = entities[physicsEntityOffset + i];
       entity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
       entity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
+
+      const debugEntity = pieceDebugEntities[i];
+      debugEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
+      debugEntity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
 
       if (pos[1] < -10) {
         const nx = (Math.random() - 0.5) * 8;
@@ -282,5 +362,23 @@ const load = async function() {
 
   draw();
 };
+
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  for (const entity of debugEntities) {
+    try { entity.getSceneGraph().isVisible = visible; } catch (e) {}
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) return;
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
 
 document.body.onload = load;

--- a/examples/rhodonite/havok/shogi/style.css
+++ b/examples/rhodonite/havok/shogi/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the W-key physics-shape wireframe on/off toggle to the Rhodonite + Havok **Falling Shogi** sample, bringing it in line with the other Rhodonite + Havok samples (e.g. the cone sample).

## Changes

- **Box collider wireframes**: each shogi piece's box collider is drawn as a wireframe (orange for dynamic pieces, green for the static ground/walls).
- **Performance**: a single shared wireframe mesh sized to the collider is instanced across all 220 pieces, mirroring the shared visual mesh, so the debug pass instances rather than issuing 220 separate draws.
- **Wireframe rendering**: un-indexed geometry + barycentric coords (`convertToUnindexedGeometry` + `_calcBaryCentricCoord`) with the `RN_USE_WIREFRAME` PbrUber material.
- **Render order**: collider wireframes are drawn in a second render pass on top of the model (`toClearColorBuffer=false`, `isDepthTest=false`).
- **Toggle**: the W key flips visibility via `setWireframeVisible`; a hint div shows the current state (default ON).
- **Depth precision**: `zNear` 0.01→1.0 and `zFar` 1000→200, consistent with the cone sample.

## Files

- `examples/rhodonite/havok/shogi/index.js`
- `examples/rhodonite/havok/shogi/index.html` — added the `#hint` div
- `examples/rhodonite/havok/shogi/style.css` — added `#hint` styles

## Testing

Verified in-browser by the author: piece/ground/wall box colliders render as wireframes and the W key toggles them on/off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
