### PR TITLE
Fix Havok JointTypes joints not forming (three.js, WebGL1/2, WebGPU)

### DIFF
--- a/examples/threejs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/threejs/havok/gltf_physics_JointTypes/index.js
@@ -401,6 +401,25 @@ function getHKMotorType(type) {
   return 0;
 }
 
+// HK.ConstraintAxis is an enum whose members are objects ({value:N}), not plain numbers. The
+// constraint setters require those enum members for the axis argument; passing the raw 0..5 index
+// silently fails to lock the axis (the joint then has no effect). Resolve to the enum member.
+function getHKAxis(isAngular, index) {
+  const A = HK.ConstraintAxis;
+  if (A) {
+    const v = isAngular
+      ? [A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z][index]
+      : [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z][index];
+    if (v !== undefined && v !== null) return v;
+  }
+  return (isAngular ? ANGULAR_AXIS_BASE : LINEAR_AXIS_BASE) + index;
+}
+function allHKAxes() {
+  const A = HK.ConstraintAxis;
+  if (A) return [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z, A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z];
+  return [0, 1, 2, 3, 4, 5];
+}
+
 function configureConstraintAxes(constraintId, jointDef) {
   if (!jointDef || typeof HK.HP_Constraint_SetAxisMode !== 'function') return;
 
@@ -409,15 +428,15 @@ function configureConstraintAxes(constraintId, jointDef) {
   const LOCKED = getHKAxisMode('LOCKED');
 
   // Default: all 6 axes are FREE
-  for (let axis = 0; axis < 6; axis++) {
+  for (const axis of allHKAxes()) {
     HK.HP_Constraint_SetAxisMode(constraintId, axis, FREE);
   }
 
   // Apply limits from the joint definition
   for (const limit of (jointDef.limits || [])) {
     const axisIndices = limit.linearAxes
-      ? limit.linearAxes.map(a => LINEAR_AXIS_BASE + a)
-      : limit.angularAxes.map(a => ANGULAR_AXIS_BASE + a);
+      ? limit.linearAxes.map(a => getHKAxis(false, a))
+      : limit.angularAxes.map(a => getHKAxis(true, a));
 
     const min = limit.min ?? 0;
     const max = limit.max ?? 0;
@@ -446,9 +465,7 @@ function configureConstraintAxes(constraintId, jointDef) {
 
   // Apply drives (motors)
   for (const drive of (jointDef.drives || [])) {
-    const axis = drive.type === 'angular'
-      ? ANGULAR_AXIS_BASE + drive.axis
-      : LINEAR_AXIS_BASE + drive.axis;
+    const axis = getHKAxis(drive.type === 'angular', drive.axis);
 
     const hasSpring = drive.stiffness !== undefined && drive.stiffness > 0;
     const hasPosTarget = drive.positionTarget !== undefined && drive.positionTarget !== 0;
@@ -559,6 +576,7 @@ function setupJoint(jointNodeIndex, jointNodeObject, connectedBodyId, parentBody
   if (typeof HK.HP_Constraint_SetEnabled === 'function') {
     HK.HP_Constraint_SetEnabled(constraintId, true);
   }
+
   return true;
 }
 

--- a/examples/threejs/havok/gltf_physics_JointTypes/index.js
+++ b/examples/threejs/havok/gltf_physics_JointTypes/index.js
@@ -486,11 +486,16 @@ function configureConstraintAxes(constraintId, jointDef) {
 }
 
 function setupJoint(jointNodeIndex, jointNodeObject, connectedBodyId, parentBodyId, jointDef, enableCollision) {
-  if (!parentBodyId || !connectedBodyId) return;
-  if (typeof HK.HP_Constraint_Create !== 'function') return;
+  if (!parentBodyId || !connectedBodyId) return false;
+  if (typeof HK.HP_Constraint_Create !== 'function') return false;
 
   const created = HK.HP_Constraint_Create();
-  if (!created || created[0] !== HK.Result.RESULT_OK) return;
+  if (!created) return false;
+  // Compare numerically: HK.Result.RESULT_OK is an enum object, so a strict !== check always
+  // fails and would (wrongly) abort every joint.
+  const rc = enumToNumber(created[0]);
+  const ok = enumToNumber(HK.Result.RESULT_OK);
+  if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc !== ok) return false;
   const constraintId = created[1];
 
   // Assign bodies: parent = body owning the joint node, child = connectedNode's body
@@ -554,6 +559,7 @@ function setupJoint(jointNodeIndex, jointNodeObject, connectedBodyId, parentBody
   if (typeof HK.HP_Constraint_SetEnabled === 'function') {
     HK.HP_Constraint_SetEnabled(constraintId, true);
   }
+  return true;
 }
 
 function setObjectWorldTransform(object, worldPosition, worldQuaternion) {
@@ -597,6 +603,18 @@ function resetDynamicBodiesIfNeeded() {
 // Find the nearest ancestor node that owns a physics body
 function findAncestorBodyId(nodeIndex) {
   let idx = parentOf.get(nodeIndex);
+  while (idx !== undefined) {
+    if (nodeIndexToBodyId.has(idx)) return nodeIndexToBodyId.get(idx);
+    idx = parentOf.get(idx);
+  }
+  return undefined;
+}
+
+// Resolve the body for a node, checking the node itself first then climbing ancestors. The joint's
+// connectedNode points at an anchor child ("jointSpaceB") that has no body of its own, so the body
+// lives on one of its ancestors.
+function resolveBodyId(nodeIndex) {
+  let idx = nodeIndex;
   while (idx !== undefined) {
     if (nodeIndexToBodyId.has(idx)) return nodeIndexToBodyId.get(idx);
     idx = parentOf.get(idx);
@@ -713,17 +731,19 @@ async function loadModelAndBuildPhysics() {
   });
 
   // Phase 2: Create joints
+  let jointsFound = 0, jointsCreated = 0;
   for (let i = 0; i < (json.nodes || []).length; i++) {
     const nodeDef = json.nodes[i];
     const physicsExt = nodeDef?.extensions?.KHR_physics_rigid_bodies;
     if (!physicsExt?.joint) continue;
+    jointsFound++;
 
     const jointExt = physicsExt.joint;
     const jointDef = physicsJoints[jointExt.joint];
     if (!jointDef) continue;
 
     const connectedNodeIndex = jointExt.connectedNode;
-    const connectedBodyId = nodeIndexToBodyId.get(connectedNodeIndex);
+    const connectedBodyId = resolveBodyId(connectedNodeIndex);
     if (connectedBodyId === undefined) {
       console.warn('[Havok] Joint connectedNode', connectedNodeIndex, 'has no body');
       continue;
@@ -739,10 +759,13 @@ async function loadModelAndBuildPhysics() {
     if (!jointNodeObject) continue;
 
     try {
-      setupJoint(i, jointNodeObject, connectedBodyId, parentBodyId, jointDef, jointExt.enableCollision);
+      if (setupJoint(i, jointNodeObject, connectedBodyId, parentBodyId, jointDef, jointExt.enableCollision)) jointsCreated++;
     } catch (e) {
       console.warn('[Havok] setupJoint failed for node', i, ':', e.message);
     }
+  }
+  if (jointsCreated < jointsFound) {
+    console.warn('[Havok] only', jointsCreated, 'of', jointsFound, 'joints created');
   }
 }
 

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.js
@@ -932,6 +932,25 @@ function getHKMotorType(type) {
     return 0;
 }
 
+// HK.ConstraintAxis is an enum whose members are objects ({value:N}), not plain numbers. The
+// constraint setters require those enum members for the axis argument; passing the raw 0..5 index
+// silently fails to lock the axis (the joint then has no effect). Resolve to the enum member.
+function getHKAxis(isAngular, index) {
+    const A = HK.ConstraintAxis;
+    if (A) {
+        const v = isAngular
+            ? [A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z][index]
+            : [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z][index];
+        if (v !== undefined && v !== null) return v;
+    }
+    return (isAngular ? ANGULAR_AXIS_BASE : LINEAR_AXIS_BASE) + index;
+}
+function allHKAxes() {
+    const A = HK.ConstraintAxis;
+    if (A) return [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z, A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z];
+    return [0, 1, 2, 3, 4, 5];
+}
+
 function configureConstraintAxes(constraintId, jointDef) {
     if (!jointDef || typeof HK.HP_Constraint_SetAxisMode !== 'function') return;
 
@@ -939,14 +958,14 @@ function configureConstraintAxes(constraintId, jointDef) {
     const LIMITED = getHKAxisMode('LIMITED');
     const LOCKED = getHKAxisMode('LOCKED');
 
-    for (let axis = 0; axis < 6; axis++) {
+    for (const axis of allHKAxes()) {
         HK.HP_Constraint_SetAxisMode(constraintId, axis, FREE);
     }
 
     for (const limit of (jointDef.limits || [])) {
         const axisIndices = limit.linearAxes
-            ? limit.linearAxes.map(a => LINEAR_AXIS_BASE + a)
-            : limit.angularAxes.map(a => ANGULAR_AXIS_BASE + a);
+            ? limit.linearAxes.map(a => getHKAxis(false, a))
+            : limit.angularAxes.map(a => getHKAxis(true, a));
 
         const min = limit.min ?? 0;
         const max = limit.max ?? 0;
@@ -973,9 +992,7 @@ function configureConstraintAxes(constraintId, jointDef) {
     }
 
     for (const drive of (jointDef.drives || [])) {
-        const axis = drive.type === 'angular'
-            ? ANGULAR_AXIS_BASE + drive.axis
-            : LINEAR_AXIS_BASE + drive.axis;
+        const axis = getHKAxis(drive.type === 'angular', drive.axis);
 
         const hasSpring = drive.stiffness !== undefined && drive.stiffness > 0;
         const hasPosTarget = drive.positionTarget !== undefined && drive.positionTarget !== 0;

--- a/examples/webgl1/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl1/havok/gltf_physics_JointTypes/index.js
@@ -1017,7 +1017,12 @@ function setupJoint(jointNodeIndex, parentBodyId, connectedBodyId, jointDef, ena
     if (typeof HK.HP_Constraint_Create !== 'function') return;
 
     const created = HK.HP_Constraint_Create();
-    if (!created || created[0] !== HK.Result.RESULT_OK) return;
+    if (!created) return;
+    // HK.Result.RESULT_OK is an enum object; compare numerically (a strict !== always fails and
+    // would wrongly abort every joint, leaving all bodies unconstrained).
+    const rc = enumToNumber(created[0]);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc !== ok) return;
     const constraintId = created[1];
 
     HK.HP_Constraint_SetParentBody(constraintId, parentBodyId);
@@ -1456,9 +1461,17 @@ function initPhysics() {
             parentIdx = parentOf.get(parentIdx);
         }
 
-        const connectedBodyId = connectedNodeIndex !== undefined
-            ? nodeIndexToBodyId.get(connectedNodeIndex)
-            : null;
+        // Resolve the connected body by climbing ancestors: connectedNode points at an anchor
+        // child ("jointSpaceB") whose body lives on an ancestor, not on the node itself.
+        let connectedBodyId = null;
+        let connectedIdx = connectedNodeIndex;
+        while (connectedIdx !== undefined) {
+            if (nodeIndexToBodyId.has(connectedIdx)) {
+                connectedBodyId = nodeIndexToBodyId.get(connectedIdx);
+                break;
+            }
+            connectedIdx = parentOf.get(connectedIdx);
+        }
 
         if (parentBodyId && connectedBodyId) {
             const enableCollision = node.physicsExt.joint.enableCollision === true;

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.js
@@ -944,6 +944,25 @@ function getHKMotorType(type) {
     return 0;
 }
 
+// HK.ConstraintAxis is an enum whose members are objects ({value:N}), not plain numbers. The
+// constraint setters require those enum members for the axis argument; passing the raw 0..5 index
+// silently fails to lock the axis (the joint then has no effect). Resolve to the enum member.
+function getHKAxis(isAngular, index) {
+    const A = HK.ConstraintAxis;
+    if (A) {
+        const v = isAngular
+            ? [A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z][index]
+            : [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z][index];
+        if (v !== undefined && v !== null) return v;
+    }
+    return (isAngular ? ANGULAR_AXIS_BASE : LINEAR_AXIS_BASE) + index;
+}
+function allHKAxes() {
+    const A = HK.ConstraintAxis;
+    if (A) return [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z, A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z];
+    return [0, 1, 2, 3, 4, 5];
+}
+
 function configureConstraintAxes(constraintId, jointDef) {
     if (!jointDef || typeof HK.HP_Constraint_SetAxisMode !== 'function') return;
 
@@ -951,14 +970,14 @@ function configureConstraintAxes(constraintId, jointDef) {
     const LIMITED = getHKAxisMode('LIMITED');
     const LOCKED = getHKAxisMode('LOCKED');
 
-    for (let axis = 0; axis < 6; axis++) {
+    for (const axis of allHKAxes()) {
         HK.HP_Constraint_SetAxisMode(constraintId, axis, FREE);
     }
 
     for (const limit of (jointDef.limits || [])) {
         const axisIndices = limit.linearAxes
-            ? limit.linearAxes.map(a => LINEAR_AXIS_BASE + a)
-            : limit.angularAxes.map(a => ANGULAR_AXIS_BASE + a);
+            ? limit.linearAxes.map(a => getHKAxis(false, a))
+            : limit.angularAxes.map(a => getHKAxis(true, a));
 
         const min = limit.min ?? 0;
         const max = limit.max ?? 0;
@@ -985,9 +1004,7 @@ function configureConstraintAxes(constraintId, jointDef) {
     }
 
     for (const drive of (jointDef.drives || [])) {
-        const axis = drive.type === 'angular'
-            ? ANGULAR_AXIS_BASE + drive.axis
-            : LINEAR_AXIS_BASE + drive.axis;
+        const axis = getHKAxis(drive.type === 'angular', drive.axis);
 
         const hasSpring = drive.stiffness !== undefined && drive.stiffness > 0;
         const hasPosTarget = drive.positionTarget !== undefined && drive.positionTarget !== 0;

--- a/examples/webgl2/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgl2/havok/gltf_physics_JointTypes/index.js
@@ -1029,7 +1029,12 @@ function setupJoint(jointNodeIndex, parentBodyId, connectedBodyId, jointDef, ena
     if (typeof HK.HP_Constraint_Create !== 'function') return;
 
     const created = HK.HP_Constraint_Create();
-    if (!created || created[0] !== HK.Result.RESULT_OK) return;
+    if (!created) return;
+    // HK.Result.RESULT_OK is an enum object; compare numerically (a strict !== always fails and
+    // would wrongly abort every joint, leaving all bodies unconstrained).
+    const rc = enumToNumber(created[0]);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc !== ok) return;
     const constraintId = created[1];
 
     HK.HP_Constraint_SetParentBody(constraintId, parentBodyId);
@@ -1466,9 +1471,17 @@ function initPhysics() {
             parentIdx = parentOf.get(parentIdx);
         }
 
-        const connectedBodyId = connectedNodeIndex !== undefined
-            ? nodeIndexToBodyId.get(connectedNodeIndex)
-            : null;
+        // Resolve the connected body by climbing ancestors: connectedNode points at an anchor
+        // child ("jointSpaceB") whose body lives on an ancestor, not on the node itself.
+        let connectedBodyId = null;
+        let connectedIdx = connectedNodeIndex;
+        while (connectedIdx !== undefined) {
+            if (nodeIndexToBodyId.has(connectedIdx)) {
+                connectedBodyId = nodeIndexToBodyId.get(connectedIdx);
+                break;
+            }
+            connectedIdx = parentOf.get(connectedIdx);
+        }
 
         if (parentBodyId && connectedBodyId) {
             const enableCollision = node.physicsExt.joint.enableCollision === true;

--- a/examples/webgpu/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgpu/havok/gltf_physics_JointTypes/index.js
@@ -1000,7 +1000,12 @@ function setupJoint(jointNodeIndex, parentBodyId, connectedBodyId, jointDef, ena
     if (typeof HK.HP_Constraint_Create !== 'function') return;
 
     const created = HK.HP_Constraint_Create();
-    if (!created || created[0] !== HK.Result.RESULT_OK) return;
+    if (!created) return;
+    // HK.Result.RESULT_OK is an enum object; compare numerically (a strict !== always fails and
+    // would wrongly abort every joint, leaving all bodies unconstrained).
+    const rc = enumToNumber(created[0]);
+    const ok = enumToNumber(HK.Result.RESULT_OK);
+    if (!Number.isNaN(rc) && !Number.isNaN(ok) && rc !== ok) return;
     const constraintId = created[1];
 
     HK.HP_Constraint_SetParentBody(constraintId, parentBodyId);
@@ -1442,9 +1447,17 @@ function initPhysics() {
             parentIdx = parentOf.get(parentIdx);
         }
 
-        const connectedBodyId = connectedNodeIndex !== undefined
-            ? nodeIndexToBodyId.get(connectedNodeIndex)
-            : null;
+        // Resolve the connected body by climbing ancestors: connectedNode points at an anchor
+        // child ("jointSpaceB") whose body lives on an ancestor, not on the node itself.
+        let connectedBodyId = null;
+        let connectedIdx = connectedNodeIndex;
+        while (connectedIdx !== undefined) {
+            if (nodeIndexToBodyId.has(connectedIdx)) {
+                connectedBodyId = nodeIndexToBodyId.get(connectedIdx);
+                break;
+            }
+            connectedIdx = parentOf.get(connectedIdx);
+        }
 
         if (parentBodyId && connectedBodyId) {
             const enableCollision = node.physicsExt.joint.enableCollision === true;

--- a/examples/webgpu/havok/gltf_physics_JointTypes/index.js
+++ b/examples/webgpu/havok/gltf_physics_JointTypes/index.js
@@ -915,6 +915,25 @@ function getHKMotorType(type) {
     return 0;
 }
 
+// HK.ConstraintAxis is an enum whose members are objects ({value:N}), not plain numbers. The
+// constraint setters require those enum members for the axis argument; passing the raw 0..5 index
+// silently fails to lock the axis (the joint then has no effect). Resolve to the enum member.
+function getHKAxis(isAngular, index) {
+    const A = HK.ConstraintAxis;
+    if (A) {
+        const v = isAngular
+            ? [A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z][index]
+            : [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z][index];
+        if (v !== undefined && v !== null) return v;
+    }
+    return (isAngular ? ANGULAR_AXIS_BASE : LINEAR_AXIS_BASE) + index;
+}
+function allHKAxes() {
+    const A = HK.ConstraintAxis;
+    if (A) return [A.LINEAR_X, A.LINEAR_Y, A.LINEAR_Z, A.ANGULAR_X, A.ANGULAR_Y, A.ANGULAR_Z];
+    return [0, 1, 2, 3, 4, 5];
+}
+
 function configureConstraintAxes(constraintId, jointDef) {
     if (!jointDef || typeof HK.HP_Constraint_SetAxisMode !== 'function') return;
 
@@ -922,14 +941,14 @@ function configureConstraintAxes(constraintId, jointDef) {
     const LIMITED = getHKAxisMode('LIMITED');
     const LOCKED = getHKAxisMode('LOCKED');
 
-    for (let axis = 0; axis < 6; axis++) {
+    for (const axis of allHKAxes()) {
         HK.HP_Constraint_SetAxisMode(constraintId, axis, FREE);
     }
 
     for (const limit of (jointDef.limits || [])) {
         const axisIndices = limit.linearAxes
-            ? limit.linearAxes.map(a => LINEAR_AXIS_BASE + a)
-            : limit.angularAxes.map(a => ANGULAR_AXIS_BASE + a);
+            ? limit.linearAxes.map(a => getHKAxis(false, a))
+            : limit.angularAxes.map(a => getHKAxis(true, a));
 
         const min = limit.min ?? 0;
         const max = limit.max ?? 0;
@@ -956,9 +975,7 @@ function configureConstraintAxes(constraintId, jointDef) {
     }
 
     for (const drive of (jointDef.drives || [])) {
-        const axis = drive.type === 'angular'
-            ? ANGULAR_AXIS_BASE + drive.axis
-            : LINEAR_AXIS_BASE + drive.axis;
+        const axis = getHKAxis(drive.type === 'angular', drive.axis);
 
         const hasSpring = drive.stiffness !== undefined && drive.stiffness > 0;
         const hasPosTarget = drive.positionTarget !== undefined && drive.positionTarget !== 0;


### PR DESCRIPTION
## Summary

The Havok **JointTypes** glTF Physics samples for three.js, WebGL 1.0, WebGL 2.0, and WebGPU spawned every body unconstrained — all of them fell through the scene because the joints had no effect. Three separate bugs were responsible (each blocking the next from being observable):

1. **`connectedNode` resolution** — a joint's `connectedNode` references an anchor child node (`jointSpaceB`) that has no body of its own; the body lives on an ancestor. The code looked the body up directly (`nodeIndexToBodyId.get(connectedNode)`), always got `undefined`, and skipped the joint. Now resolved by climbing ancestors, mirroring how the parent body is found.

2. **Constraint-result check** — `setupJoint` aborted on `created[0] !== HK.Result.RESULT_OK`. `HK.Result.RESULT_OK` is an enum object, so the strict comparison is always true and every constraint was discarded. Now compared numerically via `enumToNumber`, consistent with the samples' own `checkResult`.

3. **Axis argument type (the main cause)** — `HK.ConstraintAxis` is an enum whose members are objects (`{value:N}`), not plain numbers, and `HP_Constraint_SetAxisMode` / limit / motor setters require those enum members for the axis argument. The samples passed the raw `0..5` index, so every `SetAxisMode` silently failed and all axes stayed `FREE`, leaving the constraints with no locked degrees of freedom (bodies free-fell despite the constraints being created and enabled). Now the axis is resolved to the runtime `HK.ConstraintAxis` member (`getHKAxis` / `allHKAxes`), matching the working Rhodonite sample.

With all three fixed, the joints hold and the bodies hang / swing / rotate per joint type instead of falling.

## Files

- `examples/threejs/havok/gltf_physics_JointTypes/index.js`
- `examples/webgl1/havok/gltf_physics_JointTypes/index.js`
- `examples/webgl2/havok/gltf_physics_JointTypes/index.js`
- `examples/webgpu/havok/gltf_physics_JointTypes/index.js`

## Testing

Verified in-browser by the author: bodies no longer fall; the joints hold. The remaining `THREE.Clock` deprecation message is an unrelated three.js warning, left as-is for consistency with the other three.js samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
