### PR TITLE
Add W-key wireframe toggle to Rhodonite + Havok minimum sample

### DIFF
--- a/examples/rhodonite/havok/minimum/index.html
+++ b/examples/rhodonite/havok/minimum/index.html
@@ -14,6 +14,7 @@
 }
 </script>
 <canvas id="world"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/rhodonite/havok/minimum/index.js
+++ b/examples/rhodonite/havok/minimum/index.js
@@ -8,6 +8,31 @@ let engine;
 let entityGround, entityCube;
 let groundBodyId, cubeBodyId;
 
+let showWireframe = true;
+const debugEntities = [];     // collider wireframes (W toggles visibility)
+let cubeDebugEntity = null;   // dynamic cube wireframe (follows the body)
+const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+
+// PbrUber + RN_USE_WIREFRAME, with calcBaryCentricCoord() on the mesh so the wireframe shader
+// can draw the collider edges (mirrors the other Rhodonite + Havok samples).
+function makeDebugMaterial(color) {
+  const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: false, isSkinning: false, isMorphing: false });
+  try { mat.addShaderDefine('RN_USE_WIREFRAME'); } catch (e) {}
+  try { mat.setParameter('wireframe', Rn.Vector3.fromCopy3(1, 0, 1)); } catch (e) {}
+  try { mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4(color)); } catch (e) {}
+  return mat;
+}
+
+function createDebugBox(size, pos, color) {
+  const entity = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(color) });
+  entity.getTransform().localScale = Rn.Vector3.fromCopyArray([size[0], size[1], size[2]]);
+  entity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
+  try { entity.getMesh().calcBaryCentricCoord(); } catch (e) {}
+  debugEntities.push(entity);
+  return entity;
+}
+
 function initPhysics() {
   const worldRes = HK.HP_World_Create();
   worldId = worldRes[1];
@@ -81,6 +106,10 @@ const load = async function() {
 
   initPhysics();
 
+  // Collider wireframes (green = static ground, orange = dynamic cube)
+  createDebugBox([4, 0.1, 4], [0, 0, 0], DEBUG_COLOR_STATIC);
+  cubeDebugEntity = createDebugBox([1, 1, 1], [0, 2, 0], DEBUG_COLOR_DYNAMIC);
+
   // Camera
   const cameraEntity = Rn.createCameraControllerEntity(engine);
   cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0, 3, 6]);
@@ -98,9 +127,19 @@ const load = async function() {
   renderPass.clearColor = Rn.Vector4.fromCopyArray4([0, 0, 0, 1]);
   renderPass.addEntities([entityGround, entityCube]);
 
+  // Collider wireframes are drawn in a second pass on top of the model (no depth test)
+  // so the whole collider shape is visible, not just its silhouette.
+  const debugRenderPass = new Rn.RenderPass(engine);
+  debugRenderPass.cameraComponent = cameraComponent;
+  debugRenderPass.toClearColorBuffer = false;
+  try { debugRenderPass.isDepthTest = false; } catch (e) {}
+  debugRenderPass.addEntities(debugEntities);
+
   // Expression
   const expression = new Rn.Expression();
-  expression.addRenderPasses([renderPass]);
+  expression.addRenderPasses([renderPass, debugRenderPass]);
+
+  setWireframeVisible(showWireframe);
 
   const draw = function() {
     HK.HP_World_Step(worldId, FIXED_TIMESTEP);
@@ -111,11 +150,34 @@ const load = async function() {
     entityCube.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
     entityCube.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
 
+    if (cubeDebugEntity) {
+      cubeDebugEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
+      cubeDebugEntity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
+    }
+
     engine.process([expression]);
     requestAnimationFrame(draw);
   };
 
   draw();
 };
+
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  for (const entity of debugEntities) {
+    try { entity.getSceneGraph().isVisible = visible; } catch (e) {}
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) return;
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
 
 document.body.onload = load;

--- a/examples/rhodonite/havok/minimum/style.css
+++ b/examples/rhodonite/havok/minimum/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the W-key physics-shape wireframe on/off toggle to the Rhodonite + Havok **minimum** sample, bringing it in line with the other Rhodonite + Havok samples.

## Changes

- **Box collider wireframes**: the static ground (`[4, 0.1, 4]`) renders green and the falling dynamic cube (`[1, 1, 1]`) renders orange.
- **Wireframe rendering**: `RN_USE_WIREFRAME` PbrUber material with barycentric coords (`calcBaryCentricCoord`).
- **Render order**: collider wireframes are drawn in a second render pass on top of the model (`toClearColorBuffer=false`, `isDepthTest=false`).
- **Toggle**: the W key flips visibility via `setWireframeVisible`; the cube wireframe follows its physics body each frame; a hint div shows the current state (default ON).

## Files

- `examples/rhodonite/havok/minimum/index.js`
- `examples/rhodonite/havok/minimum/index.html` — added the `#hint` div
- `examples/rhodonite/havok/minimum/style.css` — added `#hint` styles

## Testing

Verified in-browser by the author: the ground and falling cube show their box collider wireframes and the W key toggles them on/off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
