### PR TITLE
Add W-key wireframe toggle to Rhodonite + Havok football sample

### DIFF
--- a/examples/rhodonite/havok/football/index.html
+++ b/examples/rhodonite/havok/football/index.html
@@ -14,6 +14,7 @@
 }
 </script>
 <canvas id="world"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/rhodonite/havok/football/index.js
+++ b/examples/rhodonite/havok/football/index.js
@@ -40,6 +40,31 @@ let HK, worldId, engine;
 const entities = [];
 const bodyIds = [];
 
+let showWireframe = true;
+const debugEntities = [];      // all collider wireframes (W toggles visibility)
+const ballDebugEntities = [];  // per-ball wireframes, parallel to bodyIds
+const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+
+// PbrUber + RN_USE_WIREFRAME with calcBaryCentricCoord() so the wireframe shader can draw the
+// collider edges (mirrors the other Rhodonite + Havok samples).
+function makeDebugMaterial(color) {
+  const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: false, isSkinning: false, isMorphing: false });
+  try { mat.addShaderDefine('RN_USE_WIREFRAME'); } catch (e) {}
+  try { mat.setParameter('wireframe', Rn.Vector3.fromCopy3(1, 0, 1)); } catch (e) {}
+  try { mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4(color)); } catch (e) {}
+  return mat;
+}
+
+function createDebugBox(size, pos, color) {
+  const entity = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(color) });
+  entity.getTransform().localScale = Rn.Vector3.fromCopyArray([size[0], size[1], size[2]]);
+  entity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
+  try { entity.getMesh().calcBaryCentricCoord(); } catch (e) {}
+  debugEntities.push(entity);
+  return entity;
+}
+
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
   if (!value || typeof value !== 'object') return NaN;
@@ -104,6 +129,7 @@ const load = async function() {
   groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, 0, 0]);
   groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([20, 0.4, 20]);
   entities.push(groundEntity);
+  createDebugBox([20, 0.4, 20], [0, 0, 0], DEBUG_COLOR_STATIC);
 
   // Shared ball physics shape
   const radius = BALL_SIZE / 2;
@@ -129,6 +155,21 @@ const load = async function() {
     sphereMeshByKey[key] = helper.getMesh().mesh;
   }
 
+  // Shared sphere collider wireframe (one mesh reused by every ball, instanced like the visual
+  // meshes, so the debug pass doesn't issue 256 separate draws). The wireframe shader needs
+  // un-indexed geometry + barycentric coords (what MeshComponent.calcBaryCentricCoord does).
+  const ballWireHelper = Rn.MeshHelper.createSphere(engine, {
+    radius,
+    widthSegments: 12,
+    heightSegments: 8,
+    material: makeDebugMaterial(DEBUG_COLOR_DYNAMIC),
+  });
+  const ballWireMesh = ballWireHelper.getMesh().mesh;
+  try {
+    for (const prim of ballWireMesh.primitives) prim.convertToUnindexedGeometry();
+    ballWireMesh._calcBaryCentricCoord();
+  } catch (e) { console.warn('[Football] baryCentric failed:', e); }
+
   for (let x = 0; x < 16; x++) {
     for (let y = 0; y < 16; y++) {
       const colorKey = dataSet[y * 16 + x];
@@ -150,6 +191,11 @@ const load = async function() {
       const entity = Rn.createMeshEntity(engine);
       entity.getMesh().setMesh(sphereMeshByKey[colorKey]);
       entities.push(entity);
+
+      const debugEntity = Rn.createMeshEntity(engine);
+      debugEntity.getMesh().setMesh(ballWireMesh);
+      debugEntities.push(debugEntity);
+      ballDebugEntities.push(debugEntity);
     }
   }
 
@@ -177,8 +223,18 @@ const load = async function() {
   renderPass.clearColor = Rn.Vector4.fromCopyArray4([0.1, 0.1, 0.15, 1]);
   renderPass.addEntities(entities);
 
+  // Collider wireframes are drawn in a second pass on top of the model (no depth test)
+  // so the whole collider shape is visible, not just its silhouette.
+  const debugRenderPass = new Rn.RenderPass(engine);
+  debugRenderPass.cameraComponent = cameraComponent;
+  debugRenderPass.toClearColorBuffer = false;
+  try { debugRenderPass.isDepthTest = false; } catch (e) {}
+  debugRenderPass.addEntities(debugEntities);
+
   const expression = new Rn.Expression();
-  expression.addRenderPasses([renderPass]);
+  expression.addRenderPasses([renderPass, debugRenderPass]);
+
+  setWireframeVisible(showWireframe);
 
   const physicsEntityOffset = 1;
 
@@ -192,6 +248,10 @@ const load = async function() {
       const entity = entities[physicsEntityOffset + i];
       entity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
       entity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
+
+      const debugEntity = ballDebugEntities[i];
+      debugEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
+      debugEntity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
 
       if (pos[1] < -10) {
         const nx = -5 + Math.random() * 10;
@@ -217,5 +277,23 @@ const load = async function() {
 
   draw();
 };
+
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  for (const entity of debugEntities) {
+    try { entity.getSceneGraph().isVisible = visible; } catch (e) {}
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) return;
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
 
 document.body.onload = load;

--- a/examples/rhodonite/havok/football/style.css
+++ b/examples/rhodonite/havok/football/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
Extends the W-key collider-wireframe toggle (added to the `minimum` sample in #292) to the Rhodonite + Havok **football** sample.

- Render collider wireframes in a second, depth-test-disabled render pass drawn on top of the model, so the whole collider shape is visible rather than just its silhouette.
- Ground collider (static box) drawn in green; ball colliders (dynamic spheres) drawn in orange.
- Toggle visibility with the **W** key; an on-screen hint shows the current `ON` / `OFF` state.
- Ball colliders share a single un-indexed sphere mesh with barycentric coords, so the debug pass stays instanced instead of issuing 256 separate draws.

## Files changed
- `examples/rhodonite/havok/football/index.html` — wireframe hint element
- `examples/rhodonite/havok/football/index.js` — debug materials, wireframe meshes, second render pass, W-key toggle
- `examples/rhodonite/havok/football/style.css` — hint label styling

## Test plan
- [x] Open the football sample; colliders render as wireframes over the balls and ground by default.
- [x] Press `W` to toggle wireframes off/on; hint text updates accordingly.
- [x] Balls that fall below the floor respawn as before (no regression in physics loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)