### PR TITLE
Hide origin helper entities left by MeshHelper in football sample

### DIFF
--- a/examples/rhodonite/havok/football/index.js
+++ b/examples/rhodonite/havok/football/index.js
@@ -152,6 +152,7 @@ const load = async function() {
       heightSegments: 16,
       material: mat,
     });
+    try { helper.getSceneGraph().isVisible = false; } catch (e) {} // hide the origin helper entity
     sphereMeshByKey[key] = helper.getMesh().mesh;
   }
 
@@ -164,6 +165,7 @@ const load = async function() {
     heightSegments: 8,
     material: makeDebugMaterial(DEBUG_COLOR_DYNAMIC),
   });
+  try { ballWireHelper.getSceneGraph().isVisible = false; } catch (e) {} // hide the origin helper entity
   const ballWireMesh = ballWireHelper.getMesh().mesh;
   try {
     for (const prim of ballWireMesh.primitives) prim.convertToUnindexedGeometry();


### PR DESCRIPTION
## Summary
Fixes a stray base shape rendered at the world origin in the Rhodonite + Havok **football** sample (same root cause found and fixed in the domino sample, PR #294).

`Rn.MeshHelper.createSphere` / `createCube` create a drawable entity parked at the origin, and Rhodonite renders that entity even when it is never added to a `RenderPass`. The sample builds these helpers only to reuse their mesh (`helper.getMesh().mesh`) for the per-color balls and the shared collider wireframe, so the leftover helper entities sat as base spheres at `(0,0,0)`. They went unnoticed here because the origin is buried inside the 256-ball pile, but they are still extra geometry. (In the domino sample the same bug showed up clearly as a lone football floating in the middle of the field.)

## Fix
Hide each mesh-only helper with `getSceneGraph().isVisible = false` right after extracting its mesh:
- the per-color ball spheres (`sphereMeshByKey`)
- the shared collider wireframe sphere (`ballWireHelper`)

## Files changed
- `examples/rhodonite/havok/football/index.js` (+2)

## Test plan
- [ ] Open the football sample; no stray sphere sits at the origin (toggle wireframe with `W` to inspect the center of the pile).
- [ ] Balls and collider wireframes render and move as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)