### PR TITLE
Add W-key wireframe toggle to Rhodonite + Havok stacked boxes sample

### DIFF
--- a/examples/rhodonite/havok/box/index.html
+++ b/examples/rhodonite/havok/box/index.html
@@ -14,6 +14,7 @@
 }
 </script>
 <canvas id="world"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/rhodonite/havok/box/index.js
+++ b/examples/rhodonite/havok/box/index.js
@@ -40,6 +40,31 @@ let HK, worldId, engine;
 const entities = [];
 const bodyIds = [];
 
+let showWireframe = true;
+const debugEntities = [];        // all collider wireframes (W toggles visibility)
+const boxDebugEntities = [];     // per-box wireframes, parallel to bodyIds
+const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+
+// PbrUber + RN_USE_WIREFRAME with calcBaryCentricCoord() so the wireframe shader can draw the
+// collider edges (mirrors the other Rhodonite + Havok samples).
+function makeDebugMaterial(color) {
+  const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: false, isSkinning: false, isMorphing: false });
+  try { mat.addShaderDefine('RN_USE_WIREFRAME'); } catch (e) {}
+  try { mat.setParameter('wireframe', Rn.Vector3.fromCopy3(1, 0, 1)); } catch (e) {}
+  try { mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4(color)); } catch (e) {}
+  return mat;
+}
+
+function createDebugBox(size, pos, color) {
+  const entity = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(color) });
+  entity.getTransform().localScale = Rn.Vector3.fromCopyArray([size[0], size[1], size[2]]);
+  entity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
+  try { entity.getMesh().calcBaryCentricCoord(); } catch (e) {}
+  debugEntities.push(entity);
+  return entity;
+}
+
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
   if (!value || typeof value !== 'object') return NaN;
@@ -103,6 +128,7 @@ const load = async function() {
   groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, 0, 0]);
   groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([30, 0.4, 30]);
   entities.push(groundEntity);
+  createDebugBox([30, 0.4, 30], [0, 0, 0], DEBUG_COLOR_STATIC);
 
   // Shared box physics shape
   const bsRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE]);
@@ -118,8 +144,20 @@ const load = async function() {
     const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
     mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([color[0], color[1], color[2], 1]));
     const helper = Rn.MeshHelper.createCube(engine, { material: mat });
+    try { helper.getSceneGraph().isVisible = false; } catch (e) {} // hide the origin helper entity
     cubeMeshByKey[key] = helper.getMesh().mesh;
   }
+
+  // Shared box collider wireframe (one unit-cube mesh scaled per box, instanced like the visual
+  // meshes so the debug pass doesn't issue one draw per collider). The wireframe shader needs
+  // un-indexed geometry + barycentric coords.
+  const boxWireHelper = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(DEBUG_COLOR_DYNAMIC) });
+  try { boxWireHelper.getSceneGraph().isVisible = false; } catch (e) {} // hide the origin helper entity
+  const boxWireMesh = boxWireHelper.getMesh().mesh;
+  try {
+    for (const prim of boxWireMesh.primitives) prim.convertToUnindexedGeometry();
+    boxWireMesh._calcBaryCentricCoord();
+  } catch (e) { console.warn('[Box] baryCentric failed:', e); }
 
   for (let x = 0; x < 16; x++) {
     for (let y = 0; y < 16; y++) {
@@ -143,6 +181,12 @@ const load = async function() {
       entity.getMesh().setMesh(cubeMeshByKey[colorKey]);
       entity.getTransform().localScale = Rn.Vector3.fromCopyArray([BOX_SIZE, BOX_SIZE, BOX_SIZE]);
       entities.push(entity);
+
+      const debugEntity = Rn.createMeshEntity(engine);
+      debugEntity.getMesh().setMesh(boxWireMesh);
+      debugEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([BOX_SIZE, BOX_SIZE, BOX_SIZE]);
+      debugEntities.push(debugEntity);
+      boxDebugEntities.push(debugEntity);
     }
   }
 
@@ -170,8 +214,18 @@ const load = async function() {
   renderPass.clearColor = Rn.Vector4.fromCopyArray4([0.1, 0.1, 0.15, 1]);
   renderPass.addEntities(entities);
 
+  // Collider wireframes are drawn in a second pass on top of the model (no depth test)
+  // so the whole collider shape is visible, not just its silhouette.
+  const debugRenderPass = new Rn.RenderPass(engine);
+  debugRenderPass.cameraComponent = cameraComponent;
+  debugRenderPass.toClearColorBuffer = false;
+  try { debugRenderPass.isDepthTest = false; } catch (e) {}
+  debugRenderPass.addEntities(debugEntities);
+
   const expression = new Rn.Expression();
-  expression.addRenderPasses([renderPass]);
+  expression.addRenderPasses([renderPass, debugRenderPass]);
+
+  setWireframeVisible(showWireframe);
 
   const physicsEntityOffset = 1;
 
@@ -185,6 +239,10 @@ const load = async function() {
       const entity = entities[physicsEntityOffset + i];
       entity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
       entity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
+
+      const debugEntity = boxDebugEntities[i];
+      debugEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
+      debugEntity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
 
       if (pos[1] < -10) {
         const nx = -5 + Math.random() * 10;
@@ -209,5 +267,23 @@ const load = async function() {
 
   draw();
 };
+
+function setWireframeVisible(visible) {
+  showWireframe = visible;
+  for (const entity of debugEntities) {
+    try { entity.getSceneGraph().isVisible = visible; } catch (e) {}
+  }
+  const hint = document.getElementById('hint');
+  if (hint) {
+    hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  }
+}
+
+window.addEventListener('keydown', (event) => {
+  if (event.repeat) return;
+  if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+    setWireframeVisible(!showWireframe);
+  }
+});
 
 document.body.onload = load;

--- a/examples/rhodonite/havok/box/style.css
+++ b/examples/rhodonite/havok/box/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
Extends the W-key collider-wireframe toggle (added to `minimum` #292, `football` #293, `domino` #294) to the Rhodonite + Havok **stacked boxes** sample.

- Render collider wireframes in a second, depth-test-disabled render pass drawn on top of the model, so the whole collider shape is visible rather than just its silhouette.
- Ground collider (static box) drawn in green; the 256 dynamic box colliders drawn in orange.
- Toggle visibility with the **W** key; an on-screen hint shows the current `ON` / `OFF` state.
- Box colliders share a single un-indexed cube mesh with barycentric coords (scaled per entity), so the debug pass stays instanced instead of issuing one draw per collider.
- Also hides the `MeshHelper` helper entities left parked at the origin after their mesh is reused (same latent bug fixed in #294 / #295).

## Files changed
- `examples/rhodonite/havok/box/index.html` — wireframe hint element
- `examples/rhodonite/havok/box/index.js` — debug materials, shared wireframe mesh, second render pass, W-key toggle, origin-helper hide
- `examples/rhodonite/havok/box/style.css` — hint label styling

## Test plan
- [ ] Open the stacked boxes sample; colliders render as wireframes over the boxes and ground by default.
- [ ] Press `W` to toggle wireframes off/on; hint text updates accordingly.
- [ ] Wireframes stay aligned with each box as it falls/tumbles and respawns (no regression in the physics loop).
- [ ] No stray base cube sits at the origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)