### PR TITLE
Make the W-key toggle show real wireframe colliders in falling glTF sample

### DIFF
--- a/examples/rhodonite/havok/gltf/index.js
+++ b/examples/rhodonite/havok/gltf/index.js
@@ -16,6 +16,29 @@ let expression;
 let started = false;
 let showWireframe = true;
 
+const debugEntities = [];      // collider wireframes (W toggles visibility)
+const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+
+// PbrUber + RN_USE_WIREFRAME with calcBaryCentricCoord() so the wireframe shader can draw the
+// collider edges (mirrors the other Rhodonite + Havok samples).
+function makeDebugMaterial(color) {
+  const mat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: false, isSkinning: false, isMorphing: false });
+  try { mat.addShaderDefine('RN_USE_WIREFRAME'); } catch (e) {}
+  try { mat.setParameter('wireframe', Rn.Vector3.fromCopy3(1, 0, 1)); } catch (e) {}
+  try { mat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4(color)); } catch (e) {}
+  return mat;
+}
+
+function createDebugBox(size, pos, color) {
+  const entity = Rn.MeshHelper.createCube(engine, { material: makeDebugMaterial(color) });
+  entity.getTransform().localScale = Rn.Vector3.fromCopyArray([size[0], size[1], size[2]]);
+  entity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
+  try { entity.getMesh().calcBaryCentricCoord(); } catch (e) {}
+  debugEntities.push(entity);
+  return entity;
+}
+
 function enumToNumber(value) {
   if (typeof value === 'number' || typeof value === 'bigint') return Number(value);
   if (!value || typeof value !== 'object') return NaN;
@@ -106,11 +129,9 @@ const load = async function() {
   groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, -5, 0]);
   groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([300, 8, 300]);
 
-  // Wireframe box (visual bounding box indicator)
-  const wireMat = Rn.MaterialHelper.createClassicUberMaterial(engine);
-  wireMat.setParameter('diffuseColorFactor', Rn.Vector4.fromCopyArray4([0, 1, 0, 1]));
-  wireEntity = Rn.MeshHelper.createCube(engine, { material: wireMat });
-  wireEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([cubeSizeX * 2, cubeSizeY * 2, cubeSizeZ * 2]);
+  // Collider wireframes: ground box (static, green) + duck box (dynamic, orange, follows the body).
+  createDebugBox([800, 8, 800], [0, -5, 0], DEBUG_COLOR_STATIC);
+  wireEntity = createDebugBox([cubeSizeX * 2, cubeSizeY * 2, cubeSizeZ * 2], [0, 20, 0], DEBUG_COLOR_DYNAMIC);
 
   // Camera
   const cameraEntity = Rn.createCameraControllerEntity(engine);
@@ -134,7 +155,7 @@ const load = async function() {
   renderPass.cameraComponent = cameraComponent;
   renderPass.toClearColorBuffer = true;
   renderPass.clearColor = Rn.Vector4.fromCopyArray4([0, 0, 0, 1]);
-  renderPass.addEntities([groundEntity, wireEntity]);
+  renderPass.addEntities([groundEntity]);
 
   expression = new Rn.Expression();
   expression.addRenderPasses([renderPass]);
@@ -158,6 +179,17 @@ const load = async function() {
   });
 
   expression.addRenderPasses([duckRenderPassObj]);
+
+  // Collider wireframes drawn last, on top of everything, with no depth test
+  // so the whole collider shape is visible, not just its silhouette.
+  const debugRenderPass = new Rn.RenderPass(engine);
+  debugRenderPass.cameraComponent = cameraComponent;
+  debugRenderPass.toClearColorBuffer = false;
+  try { debugRenderPass.isDepthTest = false; } catch (e) {}
+  debugRenderPass.addEntities(debugEntities);
+  expression.addRenderPasses([debugRenderPass]);
+
+  setWireframeVisible(showWireframe);
 
   document.addEventListener('click', () => {
     if (duckBodyId !== undefined) {
@@ -193,8 +225,8 @@ const load = async function() {
 
 function setWireframeVisible(visible) {
   showWireframe = visible;
-  if (wireEntity) {
-    wireEntity.getSceneGraph().isVisible = visible;
+  for (const entity of debugEntities) {
+    try { entity.getSceneGraph().isVisible = visible; } catch (e) {}
   }
   const hint = document.getElementById('hint');
   if (hint) {


### PR DESCRIPTION
## Summary
Brings the Rhodonite + Havok **falling glTF (Duck)** sample in line with the other samples' W-key collider-wireframe toggle (#292/#293/#294/#296/#297).

The sample already had the W-key toggle wiring (`setWireframeVisible`, keydown handler, on-screen hint), but:
- the toggled "wire box" was a **solid** green `ClassicUber` cube (no `RN_USE_WIREFRAME`), so it covered the duck rather than outlining its collider;
- the static ground collider was not shown at all.

## Fix
- Use the shared wireframe debug pattern: `PbrUber` + `RN_USE_WIREFRAME` + barycentric coords, rendered in a second depth-test-disabled render pass drawn last (on top of the duck and ground).
- Duck box collider drawn in orange (follows the body position/rotation); static ground collider drawn in green.
- The `W` key now toggles all collider wireframes via a shared `debugEntities` list.

## Files changed
- `examples/rhodonite/havok/gltf/index.js` (HTML/CSS already had the `#hint` element)

## Notes
- The ground wireframe uses the actual physics collider size `[800, 8, 800]`, which is larger than the visual ground plane (`[300, 8, 300]`) — that is the true collider extent. Happy to clamp it to the visual size if a tighter look is preferred.

## Test plan
- [ ] Open the falling glTF sample; the duck's box collider and the ground collider render as wireframes (not a solid box hiding the duck).
- [ ] Press `W` to toggle wireframes off/on; hint text updates accordingly.
- [ ] The duck wireframe box follows the duck as it falls/spins; click still bounces the duck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)