### PR TITLE
Render Falling Balls with lit PBR materials (gltfio)

### DIFF
--- a/examples/filament/havok/balls/index.html
+++ b/examples/filament/havok/balls/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
   <link rel="stylesheet" type="text/css" href="style.css">
-  <!-- dev build matches texture.filamat (a compiled material package is tied to a Filament version) -->
-  <script src="https://cx20.github.io/gltf-test/libs/filament/dev/filament.js"></script>
+  <!-- gltfio's PBR ubershader needs no external .filamat, so the standard versioned build is used. -->
+  <script src="https://cx20.github.io/gltf-test/libs/filament/v1.70.1/filament.js"></script>
   <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
   <script src="https://unpkg.com/gl-matrix@2.8.1/dist/gl-matrix.js"></script>
 </head>

--- a/examples/filament/havok/balls/index.js
+++ b/examples/filament/havok/balls/index.js
@@ -1,30 +1,41 @@
-// Filament + Havok — Falling Balls sample.
+// Filament + Havok — Falling Balls sample (PBR).
 //
-// Many balls of five kinds (basketball, beach ball, football, softball, tennis ball) — each with
-// its own texture, size and restitution (bounciness) — drop into a walled box, simulated by Havok
-// and rendered by Filament. Geometry (a shared sphere) + the textured material (texture.filamat)
-// are built by hand; the four walls are sensors-only colliders shown as wireframes. Press W to
-// toggle the collider wireframes.
+// Many balls of five kinds (basketball, beach ball, football, softball, tennis ball) — each with its
+// own texture, size and restitution (bounciness) — drop into a walled box, simulated by Havok and
+// rendered by Filament with lit, physically-based materials.
 //
-// A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
-// (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
+// There is no lit .filamat we can load, so the balls are emitted as an in-code glTF (GLB): one
+// textured metallic-roughness sphere mesh per kind (the ball texture as baseColorTexture, plus
+// per-kind roughness) referenced by N nodes, loaded through Filament's gltfio. The papermill IBL
+// and a directional sun light the scene, so the balls are shaded instead of looking flat. Each ball
+// node is matched to a Havok sphere body and synced every frame.
+//
+// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
+// camera (Filament can't easily draw lines); the four walls are shown only as wireframes. Press W to
+// toggle them.
+//
+// Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
+// (vec3 / quat / mat4).
 
-const FILAMAT_TEX_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
+const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermill_ibl.ktx';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 
 const dataSet = [
-  { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6 },
-  { imageFile: '../../../../assets/textures/BeachBall.jpg', scale: 0.9, restitution: 0.7 },
-  { imageFile: '../../../../assets/textures/Football.jpg', scale: 1.0, restitution: 0.55 },
-  { imageFile: '../../../../assets/textures/Softball.jpg', scale: 0.3, restitution: 0.4 },
-  { imageFile: '../../../../assets/textures/TennisBall.jpg', scale: 0.3, restitution: 0.75 },
+  { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6,  roughness: 0.7 },
+  { imageFile: '../../../../assets/textures/BeachBall.jpg',  scale: 0.9, restitution: 0.7,  roughness: 0.35 },
+  { imageFile: '../../../../assets/textures/Football.jpg',   scale: 1.0, restitution: 0.55, roughness: 0.5 },
+  { imageFile: '../../../../assets/textures/Softball.jpg',   scale: 0.3, restitution: 0.4,  roughness: 0.7 },
+  { imageFile: '../../../../assets/textures/TennisBall.jpg', scale: 0.3, restitution: 0.75, roughness: 0.8 },
 ];
 const BALL_COUNT = 200;
+const SPHERE_SEGMENTS = 24;
+const SPHERE_RINGS = 16;
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -10;
 const GROUND = { size: [20, 2, 20], pos: [0, -2, 0] };
+const GROUND_TILES = 8;
 const WALLS = [
   { size: [5, 5, 0.5], pos: [0, 1.5, -2.5] },
   { size: [5, 5, 0.5], pos: [0, 1.5, 2.5] },
@@ -39,6 +50,7 @@ let HK = null;
 let worldId = null;
 
 let engine = null;
+let asset = null;
 const balls = [];       // { entity, bodyId, radius, curPos, curRot }
 const staticBoxes = []; // ground + walls, for the debug overlay
 
@@ -63,56 +75,174 @@ function checkResult(result, label) {
 }
 
 // ---- Geometry ----
-function makeSphereGeometry(segments, rings) {
-  const pos = [], uv = [], idx = [];
+// UV-sphere of the given radius. Normals = unit position (needed for lighting); UVs match the
+// original sample so the equirectangular ball textures map the same way.
+function buildSphereGeometry(radius, segments, rings) {
+  const positions = [], normals = [], uvs = [], indices = [];
   for (let y = 0; y <= rings; y++) {
     const v = y / rings, theta = v * Math.PI, st = Math.sin(theta), ct = Math.cos(theta);
     for (let x = 0; x <= segments; x++) {
       const u = x / segments, phi = u * 2 * Math.PI;
-      pos.push(st * Math.cos(phi), ct, st * Math.sin(phi));
-      uv.push(u, v);
+      const nx = st * Math.cos(phi), ny = ct, nz = st * Math.sin(phi);
+      positions.push(nx * radius, ny * radius, nz * radius);
+      normals.push(nx, ny, nz);
+      uvs.push(u, v);
     }
   }
   for (let y = 0; y < rings; y++) {
     for (let x = 0; x < segments; x++) {
       const a = y * (segments + 1) + x, b = a + segments + 1;
-      idx.push(a, b, a + 1, a + 1, b, b + 1);
+      indices.push(a, b, a + 1, a + 1, b, b + 1);
     }
   }
-  return { positions: new Float32Array(pos), uvs: new Float32Array(uv), indices: new Uint16Array(idx) };
-}
-
-function makePlaneGeometry(size, tiles) {
-  const h = size / 2;
   return {
-    positions: new Float32Array([-h, 0, -h, h, 0, -h, h, 0, h, -h, 0, h]),
-    uvs: new Float32Array([0, 0, tiles, 0, tiles, tiles, 0, tiles]),
-    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+    positions: new Float32Array(positions),
+    normals: new Float32Array(normals),
+    uvs: new Float32Array(uvs),
+    indices: new Uint32Array(indices),
+    min: [-radius, -radius, -radius],
+    max: [radius, radius, radius],
   };
 }
 
-function buildVB(eng, positions, uvs, vertexCount) {
-  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
-  const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
-    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
-    .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
-    .build(eng);
-  vb.setBufferAt(eng, 0, positions);
-  vb.setBufferAt(eng, 1, uvs);
-  return vb;
+function buildQuadGeometry(halfX, halfZ, y, tiles) {
+  return {
+    positions: new Float32Array([-halfX, y, -halfZ, halfX, y, -halfZ, halfX, y, halfZ, -halfX, y, halfZ]),
+    normals: new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0]),
+    uvs: new Float32Array([0, 0, tiles, 0, tiles, tiles, 0, tiles]),
+    indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    min: [-halfX, y, -halfZ],
+    max: [halfX, y, halfZ],
+  };
 }
 
-function buildIB(eng, indices) {
-  const ib = Filament.IndexBuffer.Builder()
-    .indexCount(indices.length)
-    .bufferType(Filament.IndexBuffer$IndexType.USHORT)
-    .build(eng);
-  ib.setBuffer(eng, indices);
-  return ib;
+// ---- In-code GLB assembly ----
+// Generic builder: meshGeos (each carrying a `material` index), materials, nodes (each referencing a
+// mesh by index), and embedded images (each { bytes, mimeType }). Materials' baseColorTexture index
+// refers into the images array. Produces a single self-contained GLB (JSON + embedded BIN).
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function buildGlb(meshGeos, materials, nodes, images) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
+  }
+
+  const meshes = meshGeos.map((g) => {
+    const posBV = addBufferView(g.positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
+    const nrmBV = addBufferView(g.normals, 34962);
+    const nrmAcc = accessors.length;
+    accessors.push({ bufferView: nrmBV, componentType: 5126, count: g.normals.length / 3, type: 'VEC3' });
+    const uvBV = addBufferView(g.uvs, 34962);
+    const uvAcc = accessors.length;
+    accessors.push({ bufferView: uvBV, componentType: 5126, count: g.uvs.length / 2, type: 'VEC2' });
+    const idxBV = addBufferView(g.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
+    return { primitives: [{ attributes: { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc }, indices: idxAcc, material: g.material }] };
+  });
+
+  // Embedded textures (JPEG/PNG bytes in bufferViews) shared by one REPEAT sampler.
+  const textureBlocks = {};
+  if (images && images.length) {
+    const imgs = [], texs = [];
+    images.forEach((im, i) => {
+      const bv = addBufferView(im.bytes, undefined);
+      imgs.push({ bufferView: bv, mimeType: im.mimeType });
+      texs.push({ sampler: 0, source: i });
+    });
+    textureBlocks.images = imgs;
+    textureBlocks.samplers = [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }];
+    textureBlocks.textures = texs;
+  }
+
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-balls' },
+    scene: 0,
+    scenes: [{ nodes: nodes.map((_, i) => i) }],
+    nodes, meshes, materials, accessors, bufferViews,
+    ...textureBlocks,
+    buffers: [{ byteLength: binOffset }],
+  };
+
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) {
+    const t = new Uint8Array(jsonBytes.length + jsonPad);
+    t.set(jsonBytes); t.fill(0x20, jsonBytes.length);
+    jsonBytes = t;
+  }
+
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0;
+  for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4; // 'glTF'
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4; // 'JSON'
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4; // 'BIN\0'
+  glb.set(binBuf, p);
+  return glb;
 }
 
+// One textured sphere mesh/material per ball kind (mesh/material 0..N-1) + a grass ground slab
+// (mesh/material N). Ball nodes are named "ball<i>" so they can be matched to Havok bodies.
+function buildSceneGlb(ballSpecs, ballImages, grassImage) {
+  const meshGeos = dataSet.map((d, ti) => {
+    const g = buildSphereGeometry(d.scale * 0.5, SPHERE_SEGMENTS, SPHERE_RINGS);
+    g.material = ti;
+    return g;
+  });
+  const groundIndex = dataSet.length;
+  const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES);
+  groundGeo.material = groundIndex;
+  meshGeos.push(groundGeo);
+
+  const materials = dataSet.map((d, ti) => ({
+    name: 'ball' + ti,
+    pbrMetallicRoughness: {
+      baseColorTexture: { index: ti },
+      metallicFactor: 0.0,
+      roughnessFactor: d.roughness,
+    },
+  }));
+  materials.push({
+    name: 'ground',
+    pbrMetallicRoughness: { baseColorTexture: { index: groundIndex }, metallicFactor: 0.0, roughnessFactor: 0.9 },
+    doubleSided: true,
+  });
+
+  const nodes = ballSpecs.map((b, i) => ({ name: 'ball' + i, mesh: b.typeIndex, translation: b.position }));
+  nodes.push({ name: 'ground', mesh: groundIndex });
+
+  const images = ballImages.concat([grassImage]);
+  return buildGlb(meshGeos, materials, nodes, images);
+}
+
+// ---- Scene setup ----
 function createStaticBox(size, pos) {
   const s = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
   const b = HK.HP_Body_Create();
@@ -124,8 +254,16 @@ function createStaticBox(size, pos) {
   staticBoxes.push({ size, pos });
 }
 
-// ---- Body creation (builds the matching Filament renderable) ----
-function addBall(scene, vb, ib, matInstance, shapeId, radius, pos) {
+function createBallShape(typeIndex) {
+  const d = dataSet[typeIndex];
+  const s = HK.HP_Shape_CreateSphere([0, 0, 0], d.scale * 0.5);
+  if (typeof HK.HP_Shape_SetMaterial === 'function') {
+    HK.HP_Shape_SetMaterial(s[1], [0.5, 0.5, d.restitution, HK.MaterialCombine.MAXIMUM, HK.MaterialCombine.MAXIMUM]);
+  }
+  return s[1];
+}
+
+function addBallBody(shapeId, typeIndex, entity, pos) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -135,19 +273,7 @@ function addBall(scene, vb, ib, matInstance, shapeId, radius, pos) {
   HK.HP_Body_SetPosition(bodyId, pos);
   HK.HP_Body_SetOrientation(bodyId, IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, bodyId, false);
-
-  const entity = Filament.EntityManager.get().create();
-  Filament.RenderableManager.Builder(1)
-    .boundingBox({ center: [0, 0, 0], halfExtent: [radius, radius, radius] })
-    .material(0, matInstance)
-    .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
-    .build(engine, entity);
-  scene.addEntity(entity);
-  const rm = engine.getRenderableManager();
-  const inst = rm.getInstance(entity);
-  if (inst) { rm.setCulling(inst, false); inst.delete(); }
-
-  balls.push({ entity, bodyId, radius, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
+  balls.push({ entity, bodyId, radius: dataSet[typeIndex].scale * 0.5, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
 }
 
 function randomDrop(yBase, ySpread) {
@@ -169,9 +295,9 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(b.bodyId)[1];
     b.curPos[0] = p[0]; b.curPos[1] = p[1]; b.curPos[2] = p[2];
     b.curRot[0] = r[0]; b.curRot[1] = r[1]; b.curRot[2] = r[2]; b.curRot[3] = r[3];
-    const m = mat4.fromRotationTranslationScale(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]), vec3.fromValues(b.radius, b.radius, b.radius));
+    if (!b.entity) continue;
+    const m = mat4.fromRotationTranslation(
+      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
     const inst = tcm.getInstance(b.entity);
     tcm.setTransform(inst, m);
     inst.delete();
@@ -295,9 +421,16 @@ window.addEventListener('keydown', (event) => {
   }
 });
 
+async function fetchBytes(url) {
+  return new Uint8Array(await (await fetch(url)).arrayBuffer());
+}
+
 // ---- Filament app ----
-Filament.init([FILAMAT_TEX_URL, GRASS_URL, ...dataSet.map(d => d.imageFile)], () => {
+Filament.init([IBL_URL], () => {
+  window.gltfio = Filament.gltfio;
   window.Fov = Filament.Camera$Fov;
+  window.LightType = Filament.LightManager$Type;
+  window.ToneMapping = Filament.ColorGrading$ToneMapping;
   main().catch(e => console.error(e));
 });
 
@@ -306,73 +439,83 @@ async function main() {
   engine = Filament.Engine.create(canvas);
   const scene = engine.createScene();
 
-  const texMat = engine.createMaterial(FILAMAT_TEX_URL);
-  const linear = new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.REPEAT);
+  // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
+  const ibl = engine.createIblFromKtx1(IBL_URL);
+  ibl.setIntensity(50000);
+  scene.setIndirectLight(ibl);
 
-  // Grass ground
-  const groundInst = texMat.createInstance();
-  groundInst.setTextureParameter('texture', engine.createTextureFromJpeg(GRASS_URL, { nomips: true }), linear);
-  const planeGeo = makePlaneGeometry(GROUND.size[0], 8);
-  const groundVB = buildVB(engine, planeGeo.positions, planeGeo.uvs, 4);
-  const groundIB = buildIB(engine, planeGeo.indices);
-
-  const sphereGeo = makeSphereGeometry(20, 14);
-  const sphereVB = buildVB(engine, sphereGeo.positions, sphereGeo.uvs, sphereGeo.positions.length / 3);
-  const sphereIB = buildIB(engine, sphereGeo.indices);
+  const sun = Filament.EntityManager.get().create();
+  Filament.LightManager.Builder(LightType.SUN)
+    .color([0.98, 0.92, 0.89])
+    .intensity(50000.0)
+    .direction([0.5, -1.0, -0.6])
+    .castShadows(true)
+    .build(engine, sun);
+  scene.addEntity(sun);
 
   const swapChain = engine.createSwapChain();
   const renderer = engine.createRenderer();
   const camera = engine.createCamera(Filament.EntityManager.get().create());
+  camera.setExposure(16.0, 1.0 / 125.0, 100.0);
   const view = engine.createView();
   view.setCamera(camera);
   view.setScene(scene);
+  // Explicit LINEAR color grading; the default path trips a "uniform buffer too small" GL error
+  // at feature level 1.
+  const colorGrading = Filament.ColorGrading.Builder().toneMapping(ToneMapping.LINEAR).build(engine);
+  view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
 
   initDebugCanvas(canvas);
 
+  // Physics world + static ground / walls (walls are wireframe-only).
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
   checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
-
-  // Ground collider + grass renderable; four wall colliders (shown only as wireframes).
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
 
-  const groundEntity = Filament.EntityManager.get().create();
-  Filament.RenderableManager.Builder(1)
-    .boundingBox({ center: [0, 0, 0], halfExtent: [GROUND.size[0] / 2, 0.1, GROUND.size[2] / 2] })
-    .material(0, groundInst)
-    .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, groundVB, groundIB)
-    .build(engine, groundEntity);
-  scene.addEntity(groundEntity);
-  {
-    const tcm = engine.getTransformManager();
-    const inst = tcm.getInstance(groundEntity);
-    tcm.setTransform(inst, mat4.fromTranslation(mat4.create(), vec3.fromValues(0, GROUND.pos[1] + GROUND.size[1] / 2, 0)));
-    inst.delete();
-    const rm = engine.getRenderableManager();
-    const ri = rm.getInstance(groundEntity);
-    if (ri) { rm.setCulling(ri, false); ri.delete(); }
+  // Assign a kind + spawn point to each ball, then build & load the GLB (balls + ground).
+  const ballSpecs = [];
+  for (let i = 0; i < BALL_COUNT; i++) {
+    ballSpecs.push({ typeIndex: Math.floor(Math.random() * dataSet.length), position: randomDrop(6, 13) });
   }
+  const ballShapes = dataSet.map((_, ti) => createBallShape(ti));
 
-  // Per-type material (texture) + physics shape (radius + restitution).
-  const typeData = dataSet.map((d) => {
-    const radius = d.scale * 0.5;
-    const inst = texMat.createInstance();
-    inst.setTextureParameter('texture', engine.createTextureFromJpeg(d.imageFile, { nomips: true }), linear);
-    const s = HK.HP_Shape_CreateSphere([0, 0, 0], radius);
-    if (typeof HK.HP_Shape_SetMaterial === 'function') {
-      HK.HP_Shape_SetMaterial(s[1], [0.5, 0.5, d.restitution, HK.MaterialCombine.MAXIMUM, HK.MaterialCombine.MAXIMUM]);
-    }
-    return { matInst: inst, shapeId: s[1], radius };
+  const ballImages = [];
+  for (const d of dataSet) ballImages.push({ bytes: await fetchBytes(d.imageFile), mimeType: 'image/jpeg' });
+  const grassImage = { bytes: await fetchBytes(GRASS_URL), mimeType: 'image/jpeg' };
+
+  const glb = buildSceneGlb(ballSpecs, ballImages, grassImage);
+  const assetLoader = engine.createAssetLoader();
+  asset = assetLoader.createAsset(glb);
+  await new Promise((resolve) => {
+    asset.loadResources(() => {
+      assetLoader.delete();
+      const rm = engine.getRenderableManager();
+      for (const e of asset.getEntities()) {
+        const inst = rm.getInstance(e);
+        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
   });
 
-  for (let i = 0; i < BALL_COUNT; i++) {
-    const t = typeData[Math.floor(Math.random() * typeData.length)];
-    addBall(scene, sphereVB, sphereIB, t.matInst, t.shapeId, t.radius, randomDrop(6, 13));
+  // Match each ball node to its Filament entity and create its Havok body.
+  for (let i = 0; i < ballSpecs.length; i++) {
+    const spec = ballSpecs[i];
+    const named = asset.getEntitiesByName('ball' + i);
+    const entity = named.length > 0 ? named[0] : null;
+    if (entity) {
+      const rm = engine.getRenderableManager();
+      const inst = rm.getInstance(entity);
+      if (inst) { rm.setCulling(inst, false); inst.delete(); }
+    }
+    addBallBody(ballShapes[spec.typeIndex], spec.typeIndex, entity, spec.position);
   }
+  console.log('[Filament+Havok] balls ready:', balls.length);
 
   const center = [0, 0, 0];
   const orbitDist = 18;
@@ -397,13 +540,21 @@ async function main() {
   let angle = 0.5;
   function render() {
     requestAnimationFrame(render);
+
+    if (asset) {
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
+    }
+
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
+
     angle += 0.004;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
+
     renderer.render(swapChain, view);
     drawDebug(eye, center, up, aspect);
   }

--- a/examples/filament/havok/balls/index.js
+++ b/examples/filament/havok/balls/index.js
@@ -20,12 +20,14 @@
 const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermill_ibl.ktx';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 
+// All non-metal; rubber/felt surfaces are rough (matte) so they don't read as shiny/metallic. The
+// beach ball is the one glossier (vinyl) kind.
 const dataSet = [
-  { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6,  roughness: 0.7 },
-  { imageFile: '../../../../assets/textures/BeachBall.jpg',  scale: 0.9, restitution: 0.7,  roughness: 0.35 },
-  { imageFile: '../../../../assets/textures/Football.jpg',   scale: 1.0, restitution: 0.55, roughness: 0.5 },
-  { imageFile: '../../../../assets/textures/Softball.jpg',   scale: 0.3, restitution: 0.4,  roughness: 0.7 },
-  { imageFile: '../../../../assets/textures/TennisBall.jpg', scale: 0.3, restitution: 0.75, roughness: 0.8 },
+  { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6,  roughness: 0.95 },
+  { imageFile: '../../../../assets/textures/BeachBall.jpg',  scale: 0.9, restitution: 0.7,  roughness: 0.5 },
+  { imageFile: '../../../../assets/textures/Football.jpg',   scale: 1.0, restitution: 0.55, roughness: 0.8 },
+  { imageFile: '../../../../assets/textures/Softball.jpg',   scale: 0.3, restitution: 0.4,  roughness: 0.9 },
+  { imageFile: '../../../../assets/textures/TennisBall.jpg', scale: 0.3, restitution: 0.75, roughness: 1.0 },
 ];
 const BALL_COUNT = 200;
 const SPHERE_SEGMENTS = 24;


### PR DESCRIPTION
## Summary

Fixes the **Filament + Havok** Falling Balls sample looking flat / unshaded.

The balls were rendered with the **unlit** `texture.filamat`, so they had no shading. They are now rendered through Filament's **gltfio** with **lit metallic-roughness PBR**, so they're properly shaded.

## How

There is no lit `.filamat` we can load, so (as with the Falling Coins sample) the scene is emitted as an in-code glTF (GLB):

- one textured sphere mesh per ball kind — the ball JPEG embedded as `baseColorTexture`, `metallicFactor = 0`, per-kind `roughnessFactor` (matte rubber vs. glossy beach ball, etc.), plus NORMAL for shading,
- a grass ground slab in the same GLB,
- loaded via gltfio (ubershader PBR), lit by the **papermill IBL** + a directional **sun with shadows**. No skybox, so the background stays the original dark clear colour.

Each ball node is matched to its Havok sphere body by name and synced every frame.

## Unchanged

Physics is identical to before: sphere shapes, per-kind restitution (`HP_Shape_SetMaterial`), ground + four wall colliders (walls wireframe-only), spawn positions and Y-reset, gravity. The W-key collider-wireframe overlay is unchanged. `index.html` switches from the dev build to `v1.70.1` (gltfio needs no external `.filamat`).

## Verification note

`index.js` syntax-checked; the GLB byte layout (24 accessors, 30 bufferViews, 6 embedded textures, per-material baseColorTexture wiring, POSITION min/max) was validated offline. **In-browser rendering still needs your visual check** — confirm the balls are now shaded, textures map correctly (not upside-down), and lighting/exposure looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)