### PR TITLE
Make beach balls matte too (less metallic)

### DIFF
--- a/examples/filament/havok/balls/index.js
+++ b/examples/filament/havok/balls/index.js
@@ -20,11 +20,10 @@
 const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermill_ibl.ktx';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 
-// All non-metal; rubber/felt surfaces are rough (matte) so they don't read as shiny/metallic. The
-// beach ball is the one glossier (vinyl) kind.
+// All non-metal; rubber/felt/vinyl surfaces are rough (matte) so they don't read as shiny/metallic.
 const dataSet = [
   { imageFile: '../../../../assets/textures/Basketball.jpg', scale: 1.0, restitution: 0.6,  roughness: 0.95 },
-  { imageFile: '../../../../assets/textures/BeachBall.jpg',  scale: 0.9, restitution: 0.7,  roughness: 0.5 },
+  { imageFile: '../../../../assets/textures/BeachBall.jpg',  scale: 0.9, restitution: 0.7,  roughness: 0.85 },
   { imageFile: '../../../../assets/textures/Football.jpg',   scale: 1.0, restitution: 0.55, roughness: 0.8 },
   { imageFile: '../../../../assets/textures/Softball.jpg',   scale: 0.3, restitution: 0.4,  roughness: 0.9 },
   { imageFile: '../../../../assets/textures/TennisBall.jpg', scale: 0.3, restitution: 0.75, roughness: 1.0 },


### PR DESCRIPTION
## Summary

Follow-up to the Falling Balls PBR work. The basketballs now read as rubber, but the **beach balls** still looked shiny / metallic.

Their roughness (0.5) was low enough to pick up the strong IBL reflection as a chrome-like hotspot. Raised it to **0.85** (matte vinyl), in line with the other balls (basketball 0.95, softball 0.9, football 0.8, tennis 1.0).

Only the beach-ball `roughnessFactor` changes; everything else (textures, physics, lighting) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)