### PR TITLE
Render Falling Shogi with lit PBR materials (gltfio)

### DIFF
--- a/examples/filament/havok/shogi/index.html
+++ b/examples/filament/havok/shogi/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
   <link rel="stylesheet" type="text/css" href="style.css">
-  <!-- dev build matches texture.filamat (a compiled material package is tied to a Filament version) -->
-  <script src="https://cx20.github.io/gltf-test/libs/filament/dev/filament.js"></script>
+  <!-- gltfio's PBR ubershader needs no external .filamat, so the standard versioned build is used. -->
+  <script src="https://cx20.github.io/gltf-test/libs/filament/v1.70.1/filament.js"></script>
   <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
   <script src="https://unpkg.com/gl-matrix@2.8.1/dist/gl-matrix.js"></script>
 </head>

--- a/examples/filament/havok/shogi/index.js
+++ b/examples/filament/havok/shogi/index.js
@@ -1,14 +1,22 @@
-// Filament + Havok — Falling Shogi sample.
+// Filament + Havok — Falling Shogi sample (PBR).
 //
-// Many shogi pieces (a faceted pentagon-prism shape, textured with a shogi piece image) tumble
-// into a walled box, simulated by Havok and rendered by Filament. The piece geometry + the
-// textured material (texture.filamat) are built by hand; the four walls are collider-only and
-// shown as wireframes. Each piece collides as a box. Press W to toggle the collider wireframes.
+// Many shogi pieces (a faceted pentagon-prism shape, textured with a shogi piece image) tumble into
+// a walled box, simulated by Havok and rendered by Filament with lit, physically-based materials.
 //
-// A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
-// (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
+// There is no lit .filamat we can load, so the scene is emitted as an in-code glTF (GLB): the piece
+// mesh (the shogi image as baseColorTexture, with flat per-face normals) plus a grass ground slab,
+// loaded through Filament's gltfio. The papermill IBL and a directional sun light the scene, so the
+// pieces are shaded instead of looking flat. Each piece node is matched to a Havok box body and
+// synced every frame.
+//
+// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
+// camera (Filament can't easily draw lines); the four walls are shown only as wireframes. Press W to
+// toggle them.
+//
+// Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
+// (vec3 / quat / mat4).
 
-const FILAMAT_TEX_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
+const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermill_ibl.ktx';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 const SHOGI_URL = '../../../../assets/textures/shogi_001/shogi.png';
 
@@ -17,11 +25,13 @@ const PIECE_W = 1.6;
 const PIECE_H = 1.6;
 const PIECE_D = 0.45;
 const COLLIDER_SIZE = [PIECE_W, PIECE_H, PIECE_D * 1.4];
+const PIECE_ROUGHNESS = 0.65; // lacquered-wood look
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const RESET_Y_THRESHOLD = -10;
 const GROUND = { size: [40, 4, 40], pos: [0, -2, 0] };
+const GROUND_TILES = 16;
 const WALLS = [
   { size: [10, 10, 1], pos: [0, 5, -5] },
   { size: [10, 10, 1], pos: [0, 5, 5] },
@@ -36,6 +46,7 @@ let HK = null;
 let worldId = null;
 
 let engine = null;
+let asset = null;
 const pieces = [];      // { entity, bodyId, curPos, curRot }
 const staticBoxes = []; // ground + walls, for the debug overlay
 
@@ -60,7 +71,37 @@ function checkResult(result, label) {
 }
 
 // ---- Geometry ----
-// Faceted shogi-piece prism (positions + uv0; texture.filamat is unlit so normals are dropped).
+// Flat per-face normals: each vertex belongs only to coplanar triangles (faces don't share
+// vertices), so accumulating triangle normals and normalising yields the face normal.
+function computeFlatNormals(positions, indices) {
+  const normals = new Float32Array(positions.length);
+  for (let i = 0; i < indices.length; i += 3) {
+    const a = indices[i] * 3, b = indices[i + 1] * 3, c = indices[i + 2] * 3;
+    const ux = positions[b] - positions[a], uy = positions[b + 1] - positions[a + 1], uz = positions[b + 2] - positions[a + 2];
+    const vx = positions[c] - positions[a], vy = positions[c + 1] - positions[a + 1], vz = positions[c + 2] - positions[a + 2];
+    const nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+    for (const idx of [a, b, c]) { normals[idx] += nx; normals[idx + 1] += ny; normals[idx + 2] += nz; }
+  }
+  for (let i = 0; i < normals.length; i += 3) {
+    const l = Math.hypot(normals[i], normals[i + 1], normals[i + 2]) || 1;
+    normals[i] /= l; normals[i + 1] /= l; normals[i + 2] /= l;
+  }
+  return normals;
+}
+
+function minMax3(positions) {
+  const min = [Infinity, Infinity, Infinity], max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < positions.length; i += 3) {
+    for (let k = 0; k < 3; k++) {
+      min[k] = Math.min(min[k], positions[i + k]);
+      max[k] = Math.max(max[k], positions[i + k]);
+    }
+  }
+  return { min, max };
+}
+
+// Faceted shogi-piece prism (positions + uv0 + flat normals). UVs follow the glTF top-left
+// convention the atlas was authored for, so gltfio maps the kanji onto the faces with no flip.
 function createShogiGeometry(w, h, d) {
   const positions = new Float32Array([
     -0.5 * w, -0.5 * h, 0.7 * d, 0.5 * w, -0.5 * h, 0.7 * d, 0.35 * w, 0.5 * h, 0.4 * d, -0.35 * w, 0.5 * h, 0.4 * d,
@@ -74,7 +115,7 @@ function createShogiGeometry(w, h, d) {
     0.35 * w, 0.5 * h, 0.4 * d, 0.35 * w, 0.5 * h, -0.4 * d, 0.0 * w, 0.6 * h, -0.35 * d, 0.0 * w, 0.6 * h, 0.35 * d,
     -0.35 * w, 0.5 * h, 0.4 * d, -0.35 * w, 0.5 * h, -0.4 * d, 0.0 * w, 0.6 * h, -0.35 * d, 0.0 * w, 0.6 * h, 0.35 * d,
   ]);
-  const texcoords = new Float32Array([
+  const uvs = new Float32Array([
     0.5, 0.5, 0.75, 0.5, 0.75 - 0.25 / 8, 1.0, 0.5 + 0.25 / 8, 1.0,
     0.5, 0.5, 0.25, 0.5, 0.25 + 0.25 / 8, 1.0, 0.5 - 0.25 / 8, 1.0,
     0.75, 0.5, 0.5, 0.5, 0.5, 0.0, 0.75, 0.0,
@@ -86,10 +127,7 @@ function createShogiGeometry(w, h, d) {
     0.75, 0.0, 1.0, 0.0, 1.0, 0.5, 0.75, 0.5,
     0.75, 0.0, 1.0, 0.0, 1.0, 0.5, 0.75, 0.5,
   ]);
-  // The atlas UVs were authored for a top-left texture origin; Filament samples with the opposite
-  // V direction, so flip V to keep the kanji on the piece faces (not the sides).
-  for (let i = 1; i < texcoords.length; i += 2) texcoords[i] = 1 - texcoords[i];
-  const indices = new Uint16Array([
+  const indices = new Uint32Array([
     0, 1, 2, 0, 2, 3,
     4, 6, 5, 4, 7, 6,
     8, 9, 10, 8, 10, 11,
@@ -101,40 +139,142 @@ function createShogiGeometry(w, h, d) {
     30, 31, 33, 31, 32, 33,
     34, 36, 35, 34, 37, 36,
   ]);
-  return { positions, texcoords, indices };
+  const { min, max } = minMax3(positions);
+  return { positions, normals: computeFlatNormals(positions, indices), uvs, indices, min, max };
 }
 
-function makePlaneGeometry(size, tiles) {
-  const h = size / 2;
+function buildQuadGeometry(halfX, halfZ, y, tiles) {
+  const positions = new Float32Array([-halfX, y, -halfZ, halfX, y, -halfZ, halfX, y, halfZ, -halfX, y, halfZ]);
   return {
-    positions: new Float32Array([-h, 0, -h, h, 0, -h, h, 0, h, -h, 0, h]),
+    positions,
+    normals: new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0]),
     uvs: new Float32Array([0, 0, tiles, 0, tiles, tiles, 0, tiles]),
-    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+    indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    min: [-halfX, y, -halfZ],
+    max: [halfX, y, halfZ],
   };
 }
 
-function buildVB(eng, positions, uvs, vertexCount) {
-  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
-  const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
-    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
-    .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
-    .build(eng);
-  vb.setBufferAt(eng, 0, positions);
-  vb.setBufferAt(eng, 1, uvs);
-  return vb;
+// ---- In-code GLB assembly ----
+// Generic builder: meshGeos (each carrying a `material` index), materials, nodes (each referencing a
+// mesh by index), and embedded images (each { bytes, mimeType }). Materials' baseColorTexture index
+// refers into the images array. Produces a single self-contained GLB (JSON + embedded BIN).
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function buildGlb(meshGeos, materials, nodes, images) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
+  }
+
+  const meshes = meshGeos.map((g) => {
+    const posBV = addBufferView(g.positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
+    const nrmBV = addBufferView(g.normals, 34962);
+    const nrmAcc = accessors.length;
+    accessors.push({ bufferView: nrmBV, componentType: 5126, count: g.normals.length / 3, type: 'VEC3' });
+    const uvBV = addBufferView(g.uvs, 34962);
+    const uvAcc = accessors.length;
+    accessors.push({ bufferView: uvBV, componentType: 5126, count: g.uvs.length / 2, type: 'VEC2' });
+    const idxBV = addBufferView(g.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
+    return { primitives: [{ attributes: { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc }, indices: idxAcc, material: g.material }] };
+  });
+
+  const textureBlocks = {};
+  if (images && images.length) {
+    const imgs = [], texs = [];
+    images.forEach((im, i) => {
+      const bv = addBufferView(im.bytes, undefined);
+      imgs.push({ bufferView: bv, mimeType: im.mimeType });
+      texs.push({ sampler: 0, source: i });
+    });
+    textureBlocks.images = imgs;
+    textureBlocks.samplers = [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }];
+    textureBlocks.textures = texs;
+  }
+
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-shogi' },
+    scene: 0,
+    scenes: [{ nodes: nodes.map((_, i) => i) }],
+    nodes, meshes, materials, accessors, bufferViews,
+    ...textureBlocks,
+    buffers: [{ byteLength: binOffset }],
+  };
+
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) {
+    const t = new Uint8Array(jsonBytes.length + jsonPad);
+    t.set(jsonBytes); t.fill(0x20, jsonBytes.length);
+    jsonBytes = t;
+  }
+
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0;
+  for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4; // 'glTF'
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4; // 'JSON'
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4; // 'BIN\0'
+  glb.set(binBuf, p);
+  return glb;
 }
 
-function buildIB(eng, indices) {
-  const ib = Filament.IndexBuffer.Builder()
-    .indexCount(indices.length)
-    .bufferType(Filament.IndexBuffer$IndexType.USHORT)
-    .build(eng);
-  ib.setBuffer(eng, indices);
-  return ib;
+// Piece mesh/material (0, shogi texture) + grass ground slab (1). Piece nodes are named "piece<i>"
+// so they can be matched to Havok bodies; physics drives their orientation, so node rotation is left
+// at identity.
+function buildSceneGlb(pieceSpecs, shogiImage, grassImage) {
+  const pieceGeo = createShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
+  pieceGeo.material = 0;
+  const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES);
+  groundGeo.material = 1;
+
+  const materials = [
+    {
+      name: 'piece',
+      pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: PIECE_ROUGHNESS },
+      doubleSided: true,
+    },
+    {
+      name: 'ground',
+      pbrMetallicRoughness: { baseColorTexture: { index: 1 }, metallicFactor: 0.0, roughnessFactor: 0.9 },
+      doubleSided: true,
+    },
+  ];
+
+  const nodes = pieceSpecs.map((s, i) => ({ name: 'piece' + i, mesh: 0, translation: s.position }));
+  nodes.push({ name: 'ground', mesh: 1 });
+
+  return buildGlb([pieceGeo, groundGeo], materials, nodes, [shogiImage, grassImage]);
 }
 
+// ---- Scene setup ----
 function createStaticBox(size, pos) {
   const s = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
   const b = HK.HP_Body_Create();
@@ -156,8 +296,7 @@ function randomDrop() {
   return [(Math.random() - 0.5) * 8, 12 + Math.random() * 26, (Math.random() - 0.5) * 8];
 }
 
-// ---- Body creation (builds the matching Filament renderable) ----
-function addPiece(scene, vb, ib, matInstance, shapeId, pos, rot) {
+function addPieceBody(shapeId, entity, pos, rot) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -167,18 +306,6 @@ function addPiece(scene, vb, ib, matInstance, shapeId, pos, rot) {
   HK.HP_Body_SetPosition(bodyId, pos);
   HK.HP_Body_SetOrientation(bodyId, rot);
   HK.HP_World_AddBody(worldId, bodyId, false);
-
-  const entity = Filament.EntityManager.get().create();
-  Filament.RenderableManager.Builder(1)
-    .boundingBox({ center: [0, 0, 0], halfExtent: [PIECE_W / 2, PIECE_H * 0.6, PIECE_D * 0.7] })
-    .material(0, matInstance)
-    .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
-    .build(engine, entity);
-  scene.addEntity(entity);
-  const rm = engine.getRenderableManager();
-  const inst = rm.getInstance(entity);
-  if (inst) { rm.setCulling(inst, false); inst.delete(); }
-
   pieces.push({ entity, bodyId, curPos: pos.slice(), curRot: rot.slice() });
 }
 
@@ -198,6 +325,7 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(p.bodyId)[1];
     p.curPos[0] = pos[0]; p.curPos[1] = pos[1]; p.curPos[2] = pos[2];
     p.curRot[0] = r[0]; p.curRot[1] = r[1]; p.curRot[2] = r[2]; p.curRot[3] = r[3];
+    if (!p.entity) continue;
     const m = mat4.fromRotationTranslation(
       mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(pos[0], pos[1], pos[2]));
     const inst = tcm.getInstance(p.entity);
@@ -304,9 +432,16 @@ window.addEventListener('keydown', (event) => {
   }
 });
 
+async function fetchBytes(url) {
+  return new Uint8Array(await (await fetch(url)).arrayBuffer());
+}
+
 // ---- Filament app ----
-Filament.init([FILAMAT_TEX_URL, GRASS_URL, SHOGI_URL], () => {
+Filament.init([IBL_URL], () => {
+  window.gltfio = Filament.gltfio;
   window.Fov = Filament.Camera$Fov;
+  window.LightType = Filament.LightManager$Type;
+  window.ToneMapping = Filament.ColorGrading$ToneMapping;
   main().catch(e => console.error(e));
 });
 
@@ -315,65 +450,79 @@ async function main() {
   engine = Filament.Engine.create(canvas);
   const scene = engine.createScene();
 
-  const texMat = engine.createMaterial(FILAMAT_TEX_URL);
-  const linear = new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.CLAMP_TO_EDGE);
+  // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
+  const ibl = engine.createIblFromKtx1(IBL_URL);
+  ibl.setIntensity(50000);
+  scene.setIndirectLight(ibl);
 
-  // Shogi piece material + geometry (one shared mesh + one material instance for all pieces).
-  const pieceInst = texMat.createInstance();
-  pieceInst.setTextureParameter('texture', engine.createTextureFromPng(SHOGI_URL, { nomips: true }), linear);
-  const pieceGeo = createShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
-  const pieceVB = buildVB(engine, pieceGeo.positions, pieceGeo.texcoords, pieceGeo.positions.length / 3);
-  const pieceIB = buildIB(engine, pieceGeo.indices);
-
-  // Grass ground
-  const grassSampler = new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.REPEAT);
-  const groundInst = texMat.createInstance();
-  groundInst.setTextureParameter('texture', engine.createTextureFromJpeg(GRASS_URL, { nomips: true }), grassSampler);
-  const planeGeo = makePlaneGeometry(GROUND.size[0], 16);
-  const groundVB = buildVB(engine, planeGeo.positions, planeGeo.uvs, 4);
-  const groundIB = buildIB(engine, planeGeo.indices);
+  const sun = Filament.EntityManager.get().create();
+  Filament.LightManager.Builder(LightType.SUN)
+    .color([0.98, 0.92, 0.89])
+    .intensity(50000.0)
+    .direction([0.5, -1.0, -0.6])
+    .castShadows(true)
+    .build(engine, sun);
+  scene.addEntity(sun);
 
   const swapChain = engine.createSwapChain();
   const renderer = engine.createRenderer();
   const camera = engine.createCamera(Filament.EntityManager.get().create());
+  camera.setExposure(16.0, 1.0 / 125.0, 100.0);
   const view = engine.createView();
   view.setCamera(camera);
   view.setScene(scene);
+  // Explicit LINEAR color grading; the default path trips a "uniform buffer too small" GL error
+  // at feature level 1.
+  const colorGrading = Filament.ColorGrading.Builder().toneMapping(ToneMapping.LINEAR).build(engine);
+  view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
 
   initDebugCanvas(canvas);
 
+  // Physics world + static ground / walls (walls are wireframe-only).
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
   checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
-
-  // Ground collider + grass renderable; four wall colliders (wireframe-only).
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
 
-  const groundEntity = Filament.EntityManager.get().create();
-  Filament.RenderableManager.Builder(1)
-    .boundingBox({ center: [0, 0, 0], halfExtent: [GROUND.size[0] / 2, 0.1, GROUND.size[2] / 2] })
-    .material(0, groundInst)
-    .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, groundVB, groundIB)
-    .build(engine, groundEntity);
-  scene.addEntity(groundEntity);
-  {
-    const tcm = engine.getTransformManager();
-    const inst = tcm.getInstance(groundEntity);
-    tcm.setTransform(inst, mat4.fromTranslation(mat4.create(), vec3.fromValues(0, GROUND.pos[1] + GROUND.size[1] / 2, 0)));
-    inst.delete();
-    const rm = engine.getRenderableManager();
-    const ri = rm.getInstance(groundEntity);
-    if (ri) { rm.setCulling(ri, false); ri.delete(); }
-  }
+  // Assign a spawn point to each piece, then build & load the GLB (pieces + ground).
+  const pieceSpecs = [];
+  for (let i = 0; i < PIECE_COUNT; i++) pieceSpecs.push({ position: randomDrop() });
 
+  const shogiImage = { bytes: await fetchBytes(SHOGI_URL), mimeType: 'image/png' };
+  const grassImage = { bytes: await fetchBytes(GRASS_URL), mimeType: 'image/jpeg' };
+
+  const glb = buildSceneGlb(pieceSpecs, shogiImage, grassImage);
+  const assetLoader = engine.createAssetLoader();
+  asset = assetLoader.createAsset(glb);
+  await new Promise((resolve) => {
+    asset.loadResources(() => {
+      assetLoader.delete();
+      const rm = engine.getRenderableManager();
+      for (const e of asset.getEntities()) {
+        const inst = rm.getInstance(e);
+        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+
+  // One shared box collider; match each piece node to its Filament entity and create its body.
   const pieceShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, COLLIDER_SIZE)[1];
-  for (let i = 0; i < PIECE_COUNT; i++) {
-    addPiece(scene, pieceVB, pieceIB, pieceInst, pieceShape, randomDrop(), randomQuat());
+  for (let i = 0; i < pieceSpecs.length; i++) {
+    const named = asset.getEntitiesByName('piece' + i);
+    const entity = named.length > 0 ? named[0] : null;
+    if (entity) {
+      const rm = engine.getRenderableManager();
+      const inst = rm.getInstance(entity);
+      if (inst) { rm.setCulling(inst, false); inst.delete(); }
+    }
+    addPieceBody(pieceShape, entity, pieceSpecs[i].position, randomQuat());
   }
+  console.log('[Filament+Havok] pieces ready:', pieces.length);
 
   const center = [0, 2, 0];
   const orbitDist = 30;
@@ -398,13 +547,21 @@ async function main() {
   let angle = 0.5;
   function render() {
     requestAnimationFrame(render);
+
+    if (asset) {
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
+    }
+
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
+
     angle += 0.004;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
+
     renderer.render(swapChain, view);
     drawDebug(eye, center, up, aspect);
   }

--- a/examples/filament/havok/shogi/index.js
+++ b/examples/filament/havok/shogi/index.js
@@ -6,8 +6,8 @@
 // There is no lit .filamat we can load, so the scene is emitted as an in-code glTF (GLB): the piece
 // mesh (the shogi image as baseColorTexture, with flat per-face normals) plus a grass ground slab,
 // loaded through Filament's gltfio. The papermill IBL and a directional sun light the scene, so the
-// pieces are shaded instead of looking flat. Each piece node is matched to a Havok box body and
-// synced every frame.
+// pieces are shaded instead of looking flat. Each piece collides as a convex hull of its own mesh
+// (HP_Shape_CreateConvexHull) and its node is synced every frame.
 //
 // Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
 // camera (Filament can't easily draw lines); the four walls are shown only as wireframes. Press W to
@@ -24,7 +24,7 @@ const PIECE_COUNT = 220;
 const PIECE_W = 1.6;
 const PIECE_H = 1.6;
 const PIECE_D = 0.45;
-const COLLIDER_SIZE = [PIECE_W, PIECE_H, PIECE_D * 1.4];
+const COLLIDER_SIZE = [PIECE_W, PIECE_H, PIECE_D * 1.4]; // box fallback only
 const PIECE_ROUGHNESS = 0.65; // lacquered-wood look
 
 const FIXED_TIMESTEP = 1 / 60;
@@ -51,7 +51,7 @@ const pieces = [];      // { entity, bodyId, curPos, curRot }
 const staticBoxes = []; // ground + walls, for the debug overlay
 
 let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null;
+let unitCubeLines = null, pieceLines = null;
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -249,8 +249,7 @@ function buildGlb(meshGeos, materials, nodes, images) {
 // Piece mesh/material (0, shogi texture) + grass ground slab (1). Piece nodes are named "piece<i>"
 // so they can be matched to Havok bodies; physics drives their orientation, so node rotation is left
 // at identity.
-function buildSceneGlb(pieceSpecs, shogiImage, grassImage) {
-  const pieceGeo = createShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
+function buildSceneGlb(pieceSpecs, pieceGeo, shogiImage, grassImage) {
   pieceGeo.material = 0;
   const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES);
   groundGeo.material = 1;
@@ -284,6 +283,30 @@ function createStaticBox(size, pos) {
   HK.HP_Body_SetOrientation(b[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, b[1], false);
   staticBoxes.push({ size, pos });
+}
+
+// Convex-hull collider from the piece's own mesh vertices (a shogi piece is convex). Dynamic bodies
+// need a convex shape in Havok, so a hull — not a triangle mesh — is used. Falls back to a box.
+function createPieceShape(positions) {
+  if (typeof HK.HP_Shape_CreateConvexHull === 'function') {
+    const nPoints = positions.length / 3;
+    let shapeId = null;
+    if (typeof HK._malloc === 'function' && HK.HEAPU8) {
+      const ptr = HK._malloc(positions.byteLength);
+      new Float32Array(HK.HEAPU8.buffer, ptr, positions.length).set(positions);
+      const res = HK.HP_Shape_CreateConvexHull(ptr, nPoints);
+      HK._free(ptr);
+      if (enumToNumber(res[0]) === enumToNumber(HK.Result.RESULT_OK) && res[1]) shapeId = res[1];
+    }
+    if (!shapeId) {
+      const res = HK.HP_Shape_CreateConvexHull(positions, nPoints);
+      if (enumToNumber(res[0]) === enumToNumber(HK.Result.RESULT_OK) && res[1]) shapeId = res[1];
+    }
+    if (shapeId) return shapeId;
+  }
+  const res = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, COLLIDER_SIZE);
+  checkResult(res[0], 'HP_Shape_CreateBox piece fallback');
+  return res[1];
 }
 
 function randomQuat() {
@@ -345,6 +368,18 @@ function makeBoxLineVerts(sx, sy, sz) {
   return new Float32Array(v);
 }
 
+// Triangle-edge line list from the piece geometry — a faithful outline of the convex-hull collider.
+function makePieceLineVerts(geo) {
+  const pos = geo.positions, idx = geo.indices, v = [];
+  for (let i = 0; i < idx.length; i += 3) {
+    const a = idx[i] * 3, b = idx[i + 1] * 3, c = idx[i + 2] * 3;
+    v.push(pos[a], pos[a + 1], pos[a + 2], pos[b], pos[b + 1], pos[b + 2]);
+    v.push(pos[b], pos[b + 1], pos[b + 2], pos[c], pos[c + 1], pos[c + 2]);
+    v.push(pos[c], pos[c + 1], pos[c + 2], pos[a], pos[a + 1], pos[a + 2]);
+  }
+  return new Float32Array(v);
+}
+
 function initDebugCanvas(mainCanvas) {
   debugCanvas = document.createElement('canvas');
   debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
@@ -389,8 +424,6 @@ function drawDebug(eye, center, up, aspect) {
   gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
   gl.enableVertexAttribArray(aPos);
   gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const count = unitCubeLines.length / 3;
 
   const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
   function drawScaled(p, r, scale) {
@@ -404,16 +437,23 @@ function drawDebug(eye, center, up, aspect) {
 
   // Ground + walls (static, green)
   gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
+  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
+  const cubeCount = unitCubeLines.length / 3;
   for (const sb of staticBoxes) {
     drawScaled(sb.pos, IDENTITY_QUATERNION, sb.size);
-    gl.drawArrays(gl.LINES, 0, count);
+    gl.drawArrays(gl.LINES, 0, cubeCount);
   }
 
-  // Pieces (orange box colliders)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  for (const p of pieces) {
-    drawScaled(p.curPos, p.curRot, COLLIDER_SIZE);
-    gl.drawArrays(gl.LINES, 0, count);
+  // Pieces (orange convex-hull / mesh outline at the body transform)
+  if (pieceLines) {
+    gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
+    gl.bufferData(gl.ARRAY_BUFFER, pieceLines, gl.DYNAMIC_DRAW);
+    const pieceCount = pieceLines.length / 3;
+    const one = [1, 1, 1];
+    for (const p of pieces) {
+      drawScaled(p.curPos, p.curRot, one);
+      gl.drawArrays(gl.LINES, 0, pieceCount);
+    }
   }
   gl.disableVertexAttribArray(aPos);
 }
@@ -492,10 +532,13 @@ async function main() {
   const pieceSpecs = [];
   for (let i = 0; i < PIECE_COUNT; i++) pieceSpecs.push({ position: randomDrop() });
 
+  const pieceGeo = createShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
+  pieceLines = makePieceLineVerts(pieceGeo);
+
   const shogiImage = { bytes: await fetchBytes(SHOGI_URL), mimeType: 'image/png' };
   const grassImage = { bytes: await fetchBytes(GRASS_URL), mimeType: 'image/jpeg' };
 
-  const glb = buildSceneGlb(pieceSpecs, shogiImage, grassImage);
+  const glb = buildSceneGlb(pieceSpecs, pieceGeo, shogiImage, grassImage);
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(glb);
   await new Promise((resolve) => {
@@ -510,8 +553,8 @@ async function main() {
     }, () => {}, '');
   });
 
-  // One shared box collider; match each piece node to its Filament entity and create its body.
-  const pieceShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, COLLIDER_SIZE)[1];
+  // One shared convex-hull collider; match each piece node to its Filament entity and create its body.
+  const pieceShape = createPieceShape(pieceGeo.positions);
   for (let i = 0; i < pieceSpecs.length; i++) {
     const named = asset.getEntitiesByName('piece' + i);
     const entity = named.length > 0 ? named[0] : null;


### PR DESCRIPTION
## Summary

Converts the **Filament + Havok** Falling Shogi sample to use **gltfio** with lit PBR materials, like the Falling Coins / Balls samples — so the pieces are shaded instead of looking flat (they used the unlit `texture.filamat`).

## How

The scene is emitted as an in-code glTF (GLB):

- the faceted pentagon-prism piece mesh with the shogi image as `baseColorTexture`, `metallicFactor = 0`, roughness 0.65 (lacquered-wood look), and **flat per-face normals computed from the geometry** (the source had no normals),
- a grass ground slab,
- loaded via gltfio, lit by the **papermill IBL** + a directional **sun with shadows**. No skybox, so the background stays the original dark colour.

Each piece node is matched to its Havok box body by name and synced every frame.

UVs now follow the glTF top-left convention the atlas was authored for, so the **manual V-flip** the old unlit path needed is dropped — gltfio maps the kanji onto the faces directly (same as the ball textures, which render upright with no flip).

## Unchanged

Physics is identical: shared box collider, random spawn orientation, ground + four wall colliders (wireframe-only), spawn/reset. W-key collider overlay unchanged. `index.html` switches from the dev build to `v1.70.1`.

## Verification note

`index.js` syntax-checked; the GLB byte layout (8 accessors, 10 bufferViews, 2 embedded textures, normals==positions count, UV==position count, baseColorTexture wiring) was validated offline. **In-browser rendering needs your visual check** — especially that the kanji land on the piece faces the right way up (if not, the fix is a V-flip), and that the shading/exposure looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)