### PR TITLE
Filament + Havok: single-canvas wireframes for balls / coins / shogi (Group A)

### DIFF
--- a/examples/filament/havok/balls/index.js
+++ b/examples/filament/havok/balls/index.js
@@ -10,9 +10,9 @@
 // and a directional sun light the scene, so the balls are shaded instead of looking flat. Each ball
 // node is matched to a Havok sphere body and synced every frame.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines); the four walls are shown only as wireframes. Press W to
-// toggle them.
+// Collider wireframes are baked into the same GLB as LINES primitives with KHR_materials_unlit
+// (orange = balls, green = ground + walls), so they render in the same Filament pass — no second
+// canvas. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -31,6 +31,7 @@ const dataSet = [
 const BALL_COUNT = 200;
 const SPHERE_SEGMENTS = 24;
 const SPHERE_RINGS = 16;
+const WIREFRAME_OUTSET = 1.005; // slight outset so lines don't z-fight with textured surfaces
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
@@ -44,19 +45,18 @@ const WALLS = [
   { size: [0.5, 5, 5], pos: [2.5, 1.5, 0] },
 ];
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0]; // orange = ball colliders
+const COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];  // green  = ground + walls
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
+let scene = null;
 let asset = null;
-const balls = [];       // { entity, bodyId, radius, curPos, curRot }
-const staticBoxes = []; // ground + walls, for the debug overlay
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null, unitSphereLines = null;
+let showWireframe = true;
+const balls = [];                    // { entity, wireframeEntity, bodyId, radius }
+const staticWireframeEntities = [];  // ground + walls
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -75,7 +75,7 @@ function checkResult(result, label) {
   console.warn('[Havok] ' + label + ' returned:', result);
 }
 
-// ---- Geometry ----
+// ---- Geometry (triangle meshes) ----
 // UV-sphere of the given radius. Normals = unit position (needed for lighting); UVs match the
 // original sample so the equirectangular ball textures map the same way.
 function buildSphereGeometry(radius, segments, rings) {
@@ -117,13 +117,57 @@ function buildQuadGeometry(halfX, halfZ, y, tiles) {
   };
 }
 
+// ---- Geometry (LINES wireframes) ----
+// 12 edges of an axis-aligned box, as line-segment index pairs over the 8 corners.
+const LINE_BOX_INDICES = new Uint32Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBox(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  const positions = new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+  return {
+    positions,
+    indices: LINE_BOX_INDICES,
+    min: [cx - hx, cy - hy, cz - hz],
+    max: [cx + hx, cy + hy, cz + hz],
+  };
+}
+
+// Three great circles (XY / XZ / YZ planes), each `segments` line segments.
+function buildLineSphere(radius, segments = 16) {
+  const positions = [];
+  for (let plane = 0; plane < 3; plane++) {
+    for (let i = 0; i < segments; i++) {
+      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
+      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius;
+      const c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
+      if (plane === 0)      positions.push(c0, s0, 0, c1, s1, 0);
+      else if (plane === 1) positions.push(c0, 0, s0, c1, 0, s1);
+      else                  positions.push(0, c0, s0, 0, c1, s1);
+    }
+  }
+  const positionArr = new Float32Array(positions);
+  const indices = new Uint32Array(positionArr.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return {
+    positions: positionArr,
+    indices,
+    min: [-radius, -radius, -radius],
+    max: [radius, radius, radius],
+  };
+}
+
 // ---- In-code GLB assembly ----
-// Generic builder: meshGeos (each carrying a `material` index), materials, nodes (each referencing a
-// mesh by index), and embedded images (each { bytes, mimeType }). Materials' baseColorTexture index
-// refers into the images array. Produces a single self-contained GLB (JSON + embedded BIN).
 function alignTo4(n) { return (n + 3) & ~3; }
 
-function buildGlb(meshGeos, materials, nodes, images) {
+// Builds the full scene GLB: textured ball meshes + ground + LINES wireframes, all sharing one
+// embedded sampler. Triangle meshes carry POSITION + NORMAL + TEXCOORD_0; LINES meshes carry only
+// POSITION (the wireframes are unlit, no UVs needed).
+function buildSceneGlb(ballSpecs, ballImages, grassImage) {
   const accessors = [];
   const bufferViews = [];
   const binChunks = [];
@@ -142,7 +186,7 @@ function buildGlb(meshGeos, materials, nodes, images) {
     return index;
   }
 
-  const meshes = meshGeos.map((g) => {
+  function addTriMesh(g) {
     const posBV = addBufferView(g.positions, 34962);
     const posAcc = accessors.length;
     accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
@@ -155,29 +199,89 @@ function buildGlb(meshGeos, materials, nodes, images) {
     const idxBV = addBufferView(g.indices, 34963);
     const idxAcc = accessors.length;
     accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
-    return { primitives: [{ attributes: { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc }, indices: idxAcc, material: g.material }] };
+    return { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc, indices: idxAcc };
+  }
+  function addLineMesh(g) {
+    const posBV = addBufferView(g.positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
+    const idxBV = addBufferView(g.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
+    return { POSITION: posAcc, indices: idxAcc };
+  }
+
+  const meshes = [];
+  const materials = [];
+
+  // ---- PBR ball meshes (one per type) ----
+  const ballMeshIndexByType = dataSet.map((d, ti) => {
+    const accs = addTriMesh(buildSphereGeometry(d.scale * 0.5, SPHERE_SEGMENTS, SPHERE_RINGS));
+    materials.push({
+      name: 'ball' + ti,
+      pbrMetallicRoughness: { baseColorTexture: { index: ti }, metallicFactor: 0.0, roughnessFactor: d.roughness },
+    });
+    meshes.push({ primitives: [{ attributes: { POSITION: accs.POSITION, NORMAL: accs.NORMAL, TEXCOORD_0: accs.TEXCOORD_0 }, indices: accs.indices, material: materials.length - 1 }] });
+    return meshes.length - 1;
   });
 
-  // Embedded textures (JPEG/PNG bytes in bufferViews) shared by one REPEAT sampler.
-  const textureBlocks = {};
-  if (images && images.length) {
-    const imgs = [], texs = [];
-    images.forEach((im, i) => {
-      const bv = addBufferView(im.bytes, undefined);
-      imgs.push({ bufferView: bv, mimeType: im.mimeType });
-      texs.push({ sampler: 0, source: i });
-    });
-    textureBlocks.images = imgs;
-    textureBlocks.samplers = [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }];
-    textureBlocks.textures = texs;
-  }
+  // ---- Ground PBR ----
+  const groundAccs = addTriMesh(buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES));
+  materials.push({
+    name: 'ground',
+    pbrMetallicRoughness: { baseColorTexture: { index: dataSet.length }, metallicFactor: 0.0, roughnessFactor: 0.9 },
+    doubleSided: true,
+  });
+  meshes.push({ primitives: [{ attributes: { POSITION: groundAccs.POSITION, NORMAL: groundAccs.NORMAL, TEXCOORD_0: groundAccs.TEXCOORD_0 }, indices: groundAccs.indices, material: materials.length - 1 }] });
+  const groundMeshIndex = meshes.length - 1;
+
+  // ---- Unlit wireframe materials (shared by all wireframe meshes) ----
+  const ballWireMatIndex = materials.length;
+  materials.push({ name: 'ballWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_DYNAMIC } });
+  const staticWireMatIndex = materials.length;
+  materials.push({ name: 'staticWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_STATIC } });
+
+  // ---- LINES ball wireframe meshes (one per type, radius baked) ----
+  const ballWireMeshIndexByType = dataSet.map((d) => {
+    const accs = addLineMesh(buildLineSphere(d.scale * 0.5 * WIREFRAME_OUTSET));
+    meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: accs.POSITION }, indices: accs.indices, material: ballWireMatIndex }] });
+    return meshes.length - 1;
+  });
+
+  // ---- LINES static wireframes (ground + walls, size + position baked) ----
+  const staticDefs = [{ size: GROUND.size, pos: GROUND.pos }, ...WALLS];
+  const staticWireMeshIndices = staticDefs.map((d) => {
+    const hx = d.size[0] / 2 * WIREFRAME_OUTSET, hy = d.size[1] / 2 * WIREFRAME_OUTSET, hz = d.size[2] / 2 * WIREFRAME_OUTSET;
+    const accs = addLineMesh(buildLineBox(hx, hy, hz, d.pos[0], d.pos[1], d.pos[2]));
+    meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: accs.POSITION }, indices: accs.indices, material: staticWireMatIndex }] });
+    return meshes.length - 1;
+  });
+
+  // ---- Nodes ----
+  const nodes = [];
+  ballSpecs.forEach((b, i) => nodes.push({ name: 'ball' + i, mesh: ballMeshIndexByType[b.typeIndex], translation: b.position }));
+  nodes.push({ name: 'ground', mesh: groundMeshIndex });
+  ballSpecs.forEach((b, i) => nodes.push({ name: 'ballWireframe' + i, mesh: ballWireMeshIndexByType[b.typeIndex], translation: b.position }));
+  staticWireMeshIndices.forEach((mi, i) => nodes.push({ name: 'staticWireframe' + i, mesh: mi }));
+
+  // ---- Embedded images (ball JPEGs + grass) ----
+  const images = ballImages.concat([grassImage]);
+  const imgs = [], texs = [];
+  images.forEach((im, i) => {
+    const bv = addBufferView(im.bytes, undefined);
+    imgs.push({ bufferView: bv, mimeType: im.mimeType });
+    texs.push({ sampler: 0, source: i });
+  });
 
   const gltf = {
     asset: { version: '2.0', generator: 'filament-havok-balls' },
+    extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
     scenes: [{ nodes: nodes.map((_, i) => i) }],
     nodes, meshes, materials, accessors, bufferViews,
-    ...textureBlocks,
+    images: imgs,
+    samplers: [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }],
+    textures: texs,
     buffers: [{ byteLength: binOffset }],
   };
 
@@ -209,40 +313,6 @@ function buildGlb(meshGeos, materials, nodes, images) {
   return glb;
 }
 
-// One textured sphere mesh/material per ball kind (mesh/material 0..N-1) + a grass ground slab
-// (mesh/material N). Ball nodes are named "ball<i>" so they can be matched to Havok bodies.
-function buildSceneGlb(ballSpecs, ballImages, grassImage) {
-  const meshGeos = dataSet.map((d, ti) => {
-    const g = buildSphereGeometry(d.scale * 0.5, SPHERE_SEGMENTS, SPHERE_RINGS);
-    g.material = ti;
-    return g;
-  });
-  const groundIndex = dataSet.length;
-  const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES);
-  groundGeo.material = groundIndex;
-  meshGeos.push(groundGeo);
-
-  const materials = dataSet.map((d, ti) => ({
-    name: 'ball' + ti,
-    pbrMetallicRoughness: {
-      baseColorTexture: { index: ti },
-      metallicFactor: 0.0,
-      roughnessFactor: d.roughness,
-    },
-  }));
-  materials.push({
-    name: 'ground',
-    pbrMetallicRoughness: { baseColorTexture: { index: groundIndex }, metallicFactor: 0.0, roughnessFactor: 0.9 },
-    doubleSided: true,
-  });
-
-  const nodes = ballSpecs.map((b, i) => ({ name: 'ball' + i, mesh: b.typeIndex, translation: b.position }));
-  nodes.push({ name: 'ground', mesh: groundIndex });
-
-  const images = ballImages.concat([grassImage]);
-  return buildGlb(meshGeos, materials, nodes, images);
-}
-
 // ---- Scene setup ----
 function createStaticBox(size, pos) {
   const s = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
@@ -252,7 +322,6 @@ function createStaticBox(size, pos) {
   HK.HP_Body_SetPosition(b[1], pos);
   HK.HP_Body_SetOrientation(b[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, b[1], false);
-  staticBoxes.push({ size, pos });
 }
 
 function createBallShape(typeIndex) {
@@ -264,7 +333,7 @@ function createBallShape(typeIndex) {
   return s[1];
 }
 
-function addBallBody(shapeId, typeIndex, entity, pos) {
+function addBallBody(shapeId, typeIndex, entity, wireframeEntity, pos) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -274,12 +343,17 @@ function addBallBody(shapeId, typeIndex, entity, pos) {
   HK.HP_Body_SetPosition(bodyId, pos);
   HK.HP_Body_SetOrientation(bodyId, IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, bodyId, false);
-  balls.push({ entity, bodyId, radius: dataSet[typeIndex].scale * 0.5, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
+  balls.push({ entity, wireframeEntity, bodyId, radius: dataSet[typeIndex].scale * 0.5 });
 }
 
 function randomDrop(yBase, ySpread) {
   return [-5 + Math.random() * 10, yBase + Math.random() * ySpread, -5 + Math.random() * 10];
 }
+
+// Scratch buffers reused by stepAndSync so the per-frame transform updates don't allocate. The
+// gl-matrix globals aren't ready at module-load time under every loader (and not at all in our
+// Node validator), so they're filled in from main() once gl-matrix is available.
+let tmpMat = null, tmpQuat = null, tmpVec = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -294,125 +368,36 @@ function stepAndSync() {
       p = HK.HP_Body_GetPosition(b.bodyId)[1];
     }
     const r = HK.HP_Body_GetOrientation(b.bodyId)[1];
-    b.curPos[0] = p[0]; b.curPos[1] = p[1]; b.curPos[2] = p[2];
-    b.curRot[0] = r[0]; b.curRot[1] = r[1]; b.curRot[2] = r[2]; b.curRot[3] = r[3];
-    if (!b.entity) continue;
-    const m = mat4.fromRotationTranslation(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    const inst = tcm.getInstance(b.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, p[0], p[1], p[2]);
+    mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+    if (b.entity) {
+      const inst = tcm.getInstance(b.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (b.wireframeEntity) {
+      const inst = tcm.getInstance(b.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
 
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function makeSphereLineVerts(radius, segments = 12) {
-  const v = [];
-  for (let c = 0; c < 3; c++) {
-    for (let i = 0; i < segments; i++) {
-      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
-      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius, c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
-      if (c === 0) v.push(c0, s0, 0, c1, s1, 0);
-      else if (c === 1) v.push(c0, 0, s0, c1, 0, s1);
-      else v.push(0, c0, s0, 0, c1, s1);
-    }
-  }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-  unitSphereLines = makeSphereLineVerts(1);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function drawScaled(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground + walls (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const cubeCount = unitCubeLines.length / 3;
-  for (const sb of staticBoxes) {
-    drawScaled(sb.pos, IDENTITY_QUATERNION, sb.size);
-    gl.drawArrays(gl.LINES, 0, cubeCount);
-  }
-
-  // Balls (orange spheres)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitSphereLines, gl.DYNAMIC_DRAW);
-  const sphCount = unitSphereLines.length / 3;
-  const s = [0, 0, 0];
-  for (const b of balls) {
-    s[0] = s[1] = s[2] = b.radius;
-    drawScaled(b.curPos, b.curRot, s);
-    gl.drawArrays(gl.LINES, 0, sphCount);
-  }
-  gl.disableVertexAttribArray(aPos);
-}
-
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const b of balls) {
+    if (!b.wireframeEntity) continue;
+    if (visible) scene.addEntity(b.wireframeEntity); else scene.remove(b.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -436,9 +421,13 @@ Filament.init([IBL_URL], () => {
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
   const ibl = engine.createIblFromKtx1(IBL_URL);
@@ -467,8 +456,6 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
   // Physics world + static ground / walls (walls are wireframe-only).
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
@@ -478,7 +465,7 @@ async function main() {
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
 
-  // Assign a kind + spawn point to each ball, then build & load the GLB (balls + ground).
+  // Assign a kind + spawn point to each ball, then build & load the GLB (balls + ground + wires).
   const ballSpecs = [];
   for (let i = 0; i < BALL_COUNT; i++) {
     ballSpecs.push({ typeIndex: Math.floor(Math.random() * dataSet.length), position: randomDrop(6, 13) });
@@ -495,28 +482,36 @@ async function main() {
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      // Pop every renderable into the scene now so the W toggle can manage wireframes by name.
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
-      for (const e of asset.getEntities()) {
-        const inst = rm.getInstance(e);
-        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      for (const ent of asset.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) {
+          rm.setCastShadows(inst, true);
+          rm.setReceiveShadows(inst, true);
+          rm.setCulling(inst, false);
+          inst.delete();
+        }
       }
       resolve();
     }, () => {}, '');
   });
 
-  // Match each ball node to its Filament entity and create its Havok body.
+  // Match each ball node to its Filament entity + wireframe entity, then create its Havok body.
   for (let i = 0; i < ballSpecs.length; i++) {
     const spec = ballSpecs[i];
-    const named = asset.getEntitiesByName('ball' + i);
-    const entity = named.length > 0 ? named[0] : null;
-    if (entity) {
-      const rm = engine.getRenderableManager();
-      const inst = rm.getInstance(entity);
-      if (inst) { rm.setCulling(inst, false); inst.delete(); }
-    }
-    addBallBody(ballShapes[spec.typeIndex], spec.typeIndex, entity, spec.position);
+    const entity = asset.getEntitiesByName('ball' + i)[0] || null;
+    const wireframeEntity = asset.getEntitiesByName('ballWireframe' + i)[0] || null;
+    addBallBody(ballShapes[spec.typeIndex], spec.typeIndex, entity, wireframeEntity, spec.position);
   }
-  console.log('[Filament+Havok] balls ready:', balls.length);
+  // Static wireframes don't move, but we still want them in the toggle set.
+  for (let i = 0; i < 1 + WALLS.length; i++) {
+    const ent = asset.getEntitiesByName('staticWireframe' + i)[0];
+    if (ent) staticWireframeEntities.push(ent);
+  }
+  console.log('[Filament+Havok] balls ready:', balls.length, 'static wires:', staticWireframeEntities.length);
 
   const center = [0, 0, 0];
   const orbitDist = 18;
@@ -527,7 +522,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -538,26 +532,23 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time (matches the raw WebGL2 sample) — pure function of
+  // `now`, no accumulator drift when requestAnimationFrame's frame interval jitters.
+  const ORBIT_SPEED = 0.24; // rad/s
+  const ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
 
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
 
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/coins/index.js
+++ b/examples/filament/havok/coins/index.js
@@ -10,8 +10,9 @@
 // matching node is synced every frame; coins that settle or fall off the edge recycle to the top to
 // keep the stream flowing.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines). Press W to toggle them.
+// Collider wireframes are baked into the same GLB as LINES primitives with KHR_materials_unlit
+// (orange = coins, green = ground), so they render in the same Filament pass — no second canvas.
+// Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -34,30 +35,28 @@ const SPAWN_Y_MIN = 24;         // recycled coins re-enter at the top of this ba
 const SPAWN_Y_MAX = 32;
 const COLUMN_Y_MIN = 2;         // initial fill spans the whole column for an instant waterfall
 const COLUMN_Y_MAX = 32;
+const WIREFRAME_OUTSET = 1.005; // slight outset so lines don't z-fight with textured surfaces
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
-const RESET_Y_THRESHOLD = -8;   // fell off the ground edge -> recycle to the top
-// A coin that has come to rest near the ground is lifted back to the top so the stream never stops.
+const RESET_Y_THRESHOLD = -8;
 const SETTLE_Y = 4.0;
-const SETTLE_MOVE_SQ = 0.0025;  // squared per-frame movement below which a coin counts as "still"
+const SETTLE_MOVE_SQ = 0.0025;
 const SETTLE_FRAMES = 18;
 const GROUND = { size: [24, 2, 24], pos: [0, -1, 0] };  // top surface at y = 0
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
+let scene = null;
 let asset = null;
-const coins = [];       // { entity, bodyId, typeIndex, curPos, curRot, restFrames }
-const staticBoxes = []; // ground, for the debug overlay
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null;
-const coinLinesByType = [];  // sphere outline verts, per coin type
+let showWireframe = true;
+const coins = [];                    // { entity, wireframeEntity, bodyId, typeIndex, curPos, restFrames }
+const staticWireframeEntities = [];  // ground only
 
 // ---- Colour helper ----
 function srgbToLinear(c) {
@@ -88,12 +87,9 @@ function checkResult(result, label) {
   console.warn('[Havok] ' + label + ' returned:', result);
 }
 
-// ---- Geometry ----
-// Y-aligned cylinder of the given radius and half-height. Caps get their own flat-shaded vertices.
+// ---- Geometry (triangle meshes) ----
 function buildCylinderGeometry(radius, halfHeight, segments) {
   const positions = [], normals = [], uvs = [], indices = [];
-
-  // Side: seam-duplicated ring of top/bottom pairs so the rim UV runs cleanly 0..1.
   for (let i = 0; i <= segments; i++) {
     const a = (i / segments) * Math.PI * 2;
     const cx = Math.cos(a), sz = Math.sin(a), u = i / segments;
@@ -104,8 +100,6 @@ function buildCylinderGeometry(radius, halfHeight, segments) {
     const t0 = i * 2, b0 = i * 2 + 1, t1 = (i + 1) * 2, b1 = (i + 1) * 2 + 1;
     indices.push(t0, b0, b1, t0, b1, t1);
   }
-
-  // Top cap (fan around a centre vertex; planar radial UV maps the relief onto the face).
   const topCenter = positions.length / 3;
   positions.push(0, halfHeight, 0); normals.push(0, 1, 0); uvs.push(0.5, 0.5);
   const topRing = positions.length / 3;
@@ -115,8 +109,6 @@ function buildCylinderGeometry(radius, halfHeight, segments) {
     uvs.push(0.5 + 0.5 * Math.cos(a), 0.5 + 0.5 * Math.sin(a));
   }
   for (let i = 0; i < segments; i++) indices.push(topCenter, topRing + i, topRing + ((i + 1) % segments));
-
-  // Bottom cap (reversed winding).
   const botCenter = positions.length / 3;
   positions.push(0, -halfHeight, 0); normals.push(0, -1, 0); uvs.push(0.5, 0.5);
   const botRing = positions.length / 3;
@@ -126,7 +118,6 @@ function buildCylinderGeometry(radius, halfHeight, segments) {
     uvs.push(0.5 + 0.5 * Math.cos(a), 0.5 + 0.5 * Math.sin(a));
   }
   for (let i = 0; i < segments; i++) indices.push(botCenter, botRing + ((i + 1) % segments), botRing + i);
-
   return {
     positions: new Float32Array(positions),
     normals: new Float32Array(normals),
@@ -148,12 +139,48 @@ function buildQuadGeometry(halfX, halfZ, y) {
   };
 }
 
+// ---- Geometry (LINES wireframes) ----
+const LINE_BOX_INDICES = new Uint32Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBox(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  const positions = new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+  return {
+    positions, indices: LINE_BOX_INDICES,
+    min: [cx - hx, cy - hy, cz - hz], max: [cx + hx, cy + hy, cz + hz],
+  };
+}
+
+function buildLineSphere(radius, segments = 16) {
+  const positions = [];
+  for (let plane = 0; plane < 3; plane++) {
+    for (let i = 0; i < segments; i++) {
+      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
+      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius;
+      const c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
+      if (plane === 0)      positions.push(c0, s0, 0, c1, s1, 0);
+      else if (plane === 1) positions.push(c0, 0, s0, c1, 0, s1);
+      else                  positions.push(0, c0, s0, 0, c1, s1);
+    }
+  }
+  const positionArr = new Float32Array(positions);
+  const indices = new Uint32Array(positionArr.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return {
+    positions: positionArr, indices,
+    min: [-radius, -radius, -radius], max: [radius, radius, radius],
+  };
+}
+
 // ---- In-code GLB assembly ----
-// Generic builder: meshGeos (each carrying a `material` index), materials, and nodes (each
-// referencing a mesh by index). Produces a single self-contained GLB (JSON + embedded BIN).
 function alignTo4(n) { return (n + 3) & ~3; }
 
-function buildGlb(meshGeos, materials, nodes, imageBytes) {
+function buildSceneGlb(coinSpecs, normalImageBytes) {
   const accessors = [];
   const bufferViews = [];
   const binChunks = [];
@@ -172,7 +199,7 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
     return index;
   }
 
-  const meshes = meshGeos.map((g) => {
+  function addTriMesh(g) {
     const posBV = addBufferView(g.positions, 34962);
     const posAcc = accessors.length;
     accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
@@ -185,13 +212,76 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
     const idxBV = addBufferView(g.indices, 34963);
     const idxAcc = accessors.length;
     accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
-    return { primitives: [{ attributes: { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc }, indices: idxAcc, material: g.material }] };
+    return { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc, indices: idxAcc };
+  }
+  function addLineMesh(g) {
+    const posBV = addBufferView(g.positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
+    const idxBV = addBufferView(g.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
+    return { POSITION: posAcc, indices: idxAcc };
+  }
+
+  const meshes = [];
+  const materials = [];
+
+  // ---- PBR coin meshes ----
+  const coinMeshIndexByType = COIN_TYPES.map((t, ti) => {
+    const accs = addTriMesh(buildCylinderGeometry(t.diameter * 0.5, t.height * 0.5, COIN_SEGMENTS));
+    const lin = hexToLinear(t.colorHex);
+    const mat = {
+      name: t.name,
+      pbrMetallicRoughness: { baseColorFactor: [lin[0], lin[1], lin[2], 1.0], metallicFactor: t.metalness, roughnessFactor: t.roughness },
+      doubleSided: true,
+    };
+    if (normalImageBytes) mat.normalTexture = { index: 0, scale: 0.6 };
+    materials.push(mat);
+    meshes.push({ primitives: [{ attributes: { POSITION: accs.POSITION, NORMAL: accs.NORMAL, TEXCOORD_0: accs.TEXCOORD_0 }, indices: accs.indices, material: materials.length - 1 }] });
+    return meshes.length - 1;
   });
 
-  // Embedded shared normal map (PNG bytes in a bufferView), if supplied.
+  // ---- Ground PBR ----
+  const groundAccs = addTriMesh(buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2));
+  materials.push({
+    name: 'ground',
+    pbrMetallicRoughness: { baseColorFactor: [0.18, 0.19, 0.21, 1.0], metallicFactor: 0.0, roughnessFactor: 0.9 },
+    doubleSided: true,
+  });
+  meshes.push({ primitives: [{ attributes: { POSITION: groundAccs.POSITION, NORMAL: groundAccs.NORMAL, TEXCOORD_0: groundAccs.TEXCOORD_0 }, indices: groundAccs.indices, material: materials.length - 1 }] });
+  const groundMeshIndex = meshes.length - 1;
+
+  // ---- Unlit wireframe materials ----
+  const coinWireMatIndex = materials.length;
+  materials.push({ name: 'coinWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_DYNAMIC } });
+  const staticWireMatIndex = materials.length;
+  materials.push({ name: 'staticWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_STATIC } });
+
+  // ---- LINES coin wireframe meshes (one per type, radius baked) ----
+  const coinWireMeshIndexByType = COIN_TYPES.map((t) => {
+    const accs = addLineMesh(buildLineSphere(t.diameter * 0.5 * WIREFRAME_OUTSET));
+    meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: accs.POSITION }, indices: accs.indices, material: coinWireMatIndex }] });
+    return meshes.length - 1;
+  });
+
+  // ---- LINES static wireframe (ground) ----
+  const gHX = GROUND.size[0] / 2 * WIREFRAME_OUTSET, gHY = GROUND.size[1] / 2 * WIREFRAME_OUTSET, gHZ = GROUND.size[2] / 2 * WIREFRAME_OUTSET;
+  const groundWireAccs = addLineMesh(buildLineBox(gHX, gHY, gHZ, GROUND.pos[0], GROUND.pos[1], GROUND.pos[2]));
+  meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: groundWireAccs.POSITION }, indices: groundWireAccs.indices, material: staticWireMatIndex }] });
+  const groundWireMeshIndex = meshes.length - 1;
+
+  // ---- Nodes ----
+  const nodes = [];
+  coinSpecs.forEach((c, i) => nodes.push({ name: 'coin' + i, mesh: coinMeshIndexByType[c.typeIndex], translation: c.position }));
+  nodes.push({ name: 'ground', mesh: groundMeshIndex });
+  coinSpecs.forEach((c, i) => nodes.push({ name: 'coinWireframe' + i, mesh: coinWireMeshIndexByType[c.typeIndex], translation: c.position }));
+  nodes.push({ name: 'staticWireframe0', mesh: groundWireMeshIndex });
+
+  // ---- Embedded normal map (optional) ----
   const textureBlocks = {};
-  if (imageBytes) {
-    const imgBV = addBufferView(imageBytes, undefined);
+  if (normalImageBytes) {
+    const imgBV = addBufferView(normalImageBytes, undefined);
     textureBlocks.images = [{ bufferView: imgBV, mimeType: 'image/png' }];
     textureBlocks.samplers = [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }];
     textureBlocks.textures = [{ sampler: 0, source: 0 }];
@@ -199,6 +289,7 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
 
   const gltf = {
     asset: { version: '2.0', generator: 'filament-havok-coins' },
+    extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
     scenes: [{ nodes: nodes.map((_, i) => i) }],
     nodes, meshes, materials, accessors, bufferViews,
@@ -206,7 +297,6 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
     buffers: [{ byteLength: binOffset }],
   };
 
-  // JSON chunk (4-byte padded with spaces).
   let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
   const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
   if (jsonPad) {
@@ -215,7 +305,6 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
     jsonBytes = t;
   }
 
-  // BIN chunk (4-byte padded with zeros).
   const binBuf = new Uint8Array(alignTo4(binOffset));
   let o = 0;
   for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
@@ -224,56 +313,16 @@ function buildGlb(meshGeos, materials, nodes, imageBytes) {
   const glb = new Uint8Array(totalLen);
   const dv = new DataView(glb.buffer);
   let p = 0;
-  dv.setUint32(p, 0x46546C67, true); p += 4; // 'glTF'
+  dv.setUint32(p, 0x46546C67, true); p += 4;
   dv.setUint32(p, 2, true); p += 4;
   dv.setUint32(p, totalLen, true); p += 4;
   dv.setUint32(p, jsonBytes.length, true); p += 4;
-  dv.setUint32(p, 0x4E4F534A, true); p += 4; // 'JSON'
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
   glb.set(jsonBytes, p); p += jsonBytes.length;
   dv.setUint32(p, binBuf.length, true); p += 4;
-  dv.setUint32(p, 0x004E4942, true); p += 4; // 'BIN\0'
+  dv.setUint32(p, 0x004E4942, true); p += 4;
   glb.set(binBuf, p);
   return glb;
-}
-
-// Coins (mesh/material 0..2) + a flat ground slab (mesh/material 3). Coin nodes are named
-// "coin<i>" so they can be matched to Havok bodies after load.
-function buildSceneGlb(coinSpecs, normalImageBytes) {
-  const meshGeos = COIN_TYPES.map((t, ti) => {
-    const g = buildCylinderGeometry(t.diameter * 0.5, t.height * 0.5, COIN_SEGMENTS);
-    g.material = ti;
-    return g;
-  });
-  const groundMatIndex = COIN_TYPES.length;
-  const groundMeshIndex = COIN_TYPES.length;
-  const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2);
-  groundGeo.material = groundMatIndex;
-  meshGeos.push(groundGeo);
-
-  const materials = COIN_TYPES.map((t) => {
-    const lin = hexToLinear(t.colorHex);
-    const mat = {
-      name: t.name,
-      pbrMetallicRoughness: {
-        baseColorFactor: [lin[0], lin[1], lin[2], 1.0],
-        metallicFactor: t.metalness,
-        roughnessFactor: t.roughness,
-      },
-      doubleSided: true,
-    };
-    if (normalImageBytes) mat.normalTexture = { index: 0, scale: 0.6 };
-    return mat;
-  });
-  materials.push({
-    name: 'ground',
-    pbrMetallicRoughness: { baseColorFactor: [0.18, 0.19, 0.21, 1.0], metallicFactor: 0.0, roughnessFactor: 0.9 },
-    doubleSided: true,
-  });
-
-  const nodes = coinSpecs.map((c, i) => ({ name: 'coin' + i, mesh: c.typeIndex, translation: c.position }));
-  nodes.push({ name: 'ground', mesh: groundMeshIndex });
-
-  return buildGlb(meshGeos, materials, nodes, normalImageBytes);
 }
 
 // ---- Scene setup ----
@@ -281,19 +330,16 @@ function randomXZ() {
   return [-DROP_HALF + Math.random() * (2 * DROP_HALF), -DROP_HALF + Math.random() * (2 * DROP_HALF)];
 }
 
-// Spawn point at the top of the falling column (used when recycling).
 function randomDropTop() {
   const [x, z] = randomXZ();
   return [x, SPAWN_Y_MIN + Math.random() * (SPAWN_Y_MAX - SPAWN_Y_MIN), z];
 }
 
-// Initial fill spread over the whole column so the waterfall is full from the first frame.
 function randomDropColumn() {
   const [x, z] = randomXZ();
   return [x, COLUMN_Y_MIN + Math.random() * (COLUMN_Y_MAX - COLUMN_Y_MIN), z];
 }
 
-// Uniform random orientation so coins land at varied angles.
 function randomQuat() {
   const u1 = Math.random(), u2 = Math.random(), u3 = Math.random();
   const s1 = Math.sqrt(1 - u1), s2 = Math.sqrt(u1);
@@ -313,11 +359,8 @@ function createStaticBox(size, pos) {
   HK.HP_Body_SetPosition(b[1], pos);
   HK.HP_Body_SetOrientation(b[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, b[1], false);
-  staticBoxes.push({ size, pos });
 }
 
-// Coins collide as spheres (radius = coin radius), like the three.js sample, so they roll and
-// cascade rather than stacking flat.
 function createCoinShape(typeIndex) {
   const r = COIN_TYPES[typeIndex].diameter * 0.5;
   const res = HK.HP_Shape_CreateSphere([0, 0, 0], r);
@@ -325,7 +368,7 @@ function createCoinShape(typeIndex) {
   return res[1];
 }
 
-function addCoinBody(shapeId, typeIndex, entity, pos, rot) {
+function addCoinBody(shapeId, typeIndex, entity, wireframeEntity, pos, rot) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -335,7 +378,7 @@ function addCoinBody(shapeId, typeIndex, entity, pos, rot) {
   HK.HP_Body_SetPosition(bodyId, pos);
   HK.HP_Body_SetOrientation(bodyId, rot);
   HK.HP_World_AddBody(worldId, bodyId, false);
-  coins.push({ entity, bodyId, typeIndex, curPos: pos.slice(), curRot: rot.slice(), restFrames: 0 });
+  coins.push({ entity, wireframeEntity, bodyId, typeIndex, curPos: pos.slice(), restFrames: 0 });
 }
 
 function recycleCoin(c) {
@@ -345,6 +388,9 @@ function recycleCoin(c) {
   HK.HP_Body_SetAngularVelocity(c.bodyId, [0, 0, 0]);
   c.restFrames = 0;
 }
+
+// Scratch buffers reused by stepAndSync; initialised in main() once gl-matrix is available.
+let tmpMat = null, tmpQuat = null, tmpVec = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -361,128 +407,36 @@ function stepAndSync() {
     }
     const r = HK.HP_Body_GetOrientation(c.bodyId)[1];
     c.curPos[0] = pos[0]; c.curPos[1] = pos[1]; c.curPos[2] = pos[2];
-    c.curRot[0] = r[0]; c.curRot[1] = r[1]; c.curRot[2] = r[2]; c.curRot[3] = r[3];
-    if (!c.entity) continue;
-    const m = mat4.fromRotationTranslation(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(pos[0], pos[1], pos[2]));
-    const inst = tcm.getInstance(c.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, pos[0], pos[1], pos[2]);
+    mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+    if (c.entity) {
+      const inst = tcm.getInstance(c.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (c.wireframeEntity) {
+      const inst = tcm.getInstance(c.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
 
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function makeSphereLineVerts(radius, segments = 16) {
-  const v = [];
-  for (let c = 0; c < 3; c++) {
-    for (let i = 0; i < segments; i++) {
-      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
-      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius, c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
-      if (c === 0) v.push(c0, s0, 0, c1, s1, 0);
-      else if (c === 1) v.push(c0, 0, s0, c1, 0, s1);
-      else v.push(0, c0, s0, 0, c1, s1);
-    }
-  }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-  for (const t of COIN_TYPES) coinLinesByType.push(makeSphereLineVerts(t.diameter * 0.5));
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function setMVP(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground (static, green).
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const cubeCount = unitCubeLines.length / 3;
-  for (const sb of staticBoxes) {
-    setMVP(sb.pos, IDENTITY_QUATERNION, sb.size);
-    gl.drawArrays(gl.LINES, 0, cubeCount);
-  }
-
-  // Coins (orange sphere outlines at the body position), grouped by type.
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  const one = [1, 1, 1];
-  for (let ti = 0; ti < COIN_TYPES.length; ti++) {
-    const lines = coinLinesByType[ti];
-    if (!lines) continue;
-    gl.bufferData(gl.ARRAY_BUFFER, lines, gl.DYNAMIC_DRAW);
-    const count = lines.length / 3;
-    for (const c of coins) {
-      if (c.typeIndex !== ti) continue;
-      setMVP(c.curPos, IDENTITY_QUATERNION, one);
-      gl.drawArrays(gl.LINES, 0, count);
-    }
-  }
-  gl.disableVertexAttribArray(aPos);
-}
-
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const c of coins) {
+    if (!c.wireframeEntity) continue;
+    if (visible) scene.addEntity(c.wireframeEntity); else scene.remove(c.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -502,9 +456,13 @@ Filament.init([IBL_URL, SKY_URL], () => {
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
@@ -529,13 +487,9 @@ async function main() {
   const view = engine.createView();
   view.setCamera(camera);
   view.setScene(scene);
-  // Explicit LINEAR color grading; the default path trips a "uniform buffer too small" GL error
-  // at feature level 1.
   const colorGrading = Filament.ColorGrading.Builder().toneMapping(ToneMapping.LINEAR).build(engine);
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
-
-  initDebugCanvas(canvas);
 
   // Physics world + static ground.
   HK = await HavokPhysics();
@@ -545,7 +499,7 @@ async function main() {
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
   createStaticBox(GROUND.size, GROUND.pos);
 
-  // Assign a coin type + spawn point to each coin, then build & load the GLB (coins + ground).
+  // Assign a coin type + spawn point to each coin, then build & load the GLB (coins + wires + ground).
   const coinSpecs = [];
   for (let i = 0; i < COIN_COUNT; i++) {
     coinSpecs.push({ typeIndex: Math.floor(Math.random() * COIN_TYPES.length), position: randomDropColumn() });
@@ -559,27 +513,31 @@ async function main() {
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      // Pop every renderable into the scene now so the W toggle can manage wireframes by name.
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
-      for (const e of asset.getEntities()) {
-        const inst = rm.getInstance(e);
-        if (inst) { rm.setCastShadows(inst, true); inst.delete(); }
+      for (const ent of asset.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) {
+          rm.setCastShadows(inst, true);
+          rm.setCulling(inst, false);
+          inst.delete();
+        }
       }
       resolve();
     }, () => {}, '');
   });
 
-  // Match each coin node to its Filament entity and create its Havok body.
+  // Match each coin node to its Filament entity + wireframe entity, then create its Havok body.
   for (let i = 0; i < coinSpecs.length; i++) {
     const spec = coinSpecs[i];
-    const named = asset.getEntitiesByName('coin' + i);
-    const entity = named.length > 0 ? named[0] : null;
-    if (entity) {
-      const rm = engine.getRenderableManager();
-      const inst = rm.getInstance(entity);
-      if (inst) { rm.setCulling(inst, false); inst.delete(); }
-    }
-    addCoinBody(coinShapes[spec.typeIndex], spec.typeIndex, entity, spec.position, randomQuat());
+    const entity = asset.getEntitiesByName('coin' + i)[0] || null;
+    const wireframeEntity = asset.getEntitiesByName('coinWireframe' + i)[0] || null;
+    addCoinBody(coinShapes[spec.typeIndex], spec.typeIndex, entity, wireframeEntity, spec.position, randomQuat());
   }
+  const groundWire = asset.getEntitiesByName('staticWireframe0')[0];
+  if (groundWire) staticWireframeEntities.push(groundWire);
   console.log('[Filament+Havok] coins ready:', coins.length);
 
   const center = [0, 6, 0];
@@ -591,7 +549,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -602,26 +559,22 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time — pure function of `now`, no accumulator drift.
+  const ORBIT_SPEED = 0.24; // rad/s
+  const ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
 
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
 
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/minimum/index.html
+++ b/examples/filament/havok/minimum/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
   <link rel="stylesheet" type="text/css" href="style.css">
-  <!-- dev build matches texture.filamat (a compiled material package is tied to a Filament version) -->
-  <script src="https://cx20.github.io/gltf-test/libs/filament/dev/filament.js"></script>
+  <!-- gltfio's PBR ubershader needs no external .filamat, so the standard versioned build is used. -->
+  <script src="https://cx20.github.io/gltf-test/libs/filament/v1.70.1/filament.js"></script>
   <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
   <script src="https://unpkg.com/gl-matrix@2.8.1/dist/gl-matrix.js"></script>
 </head>

--- a/examples/filament/havok/minimum/index.js
+++ b/examples/filament/havok/minimum/index.js
@@ -8,9 +8,10 @@
 // cube is shaded instead of looking flat. The cube node is matched to its Havok box body and synced
 // every frame.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines); the ground collider's wireframe is the green box.
-// Press W to toggle them.
+// Collider wireframes are baked into the same GLB as LINES primitives with KHR_materials_unlit, so
+// they render in the same Filament pass (no second canvas) — that single-canvas setup matches the
+// raw WebGL2 sample and avoids the compositor stutter the previous overlay approach had. Press W to
+// toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -23,9 +24,6 @@ const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const GROUND = { size: [4, 0.1, 4], pos: [0, 0, 0] };
 const CUBE_SIZE = [1, 1, 1];
 const CUBE_ROUGHNESS = 0.7;
-
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0]; // orange = cube
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];  // green  = ground
 
 // Unit cube geometry (24 verts so each face has its own UVs + flat normal).
 const CUBE_POSITIONS = new Float32Array([
@@ -63,19 +61,12 @@ let groundBodyId = null;
 let cubeBodyId = null;
 
 let engine = null;
+let scene = null;
 let asset = null;
 let cubeEntity = null;
-
-let debugCanvas = null;
-let debugGl = null;
-let debugProg = null;
-let debugVbo = null;
+let cubeWireframeEntity = null;
+let groundWireframeEntity = null;
 let showWireframe = true;
-// Cached debug shader locations + scratch matrices reused every frame (drops the per-frame
-// Float32Array / mat4.create() allocations that were churning the GC).
-let debugAPos = -1, debugUMVP = null, debugUColor = null;
-const dbgScratch = {};
-const UNIT_CUBE_LINE_COUNT = 24; // 12 edges × 2 vertices
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -150,7 +141,7 @@ function buildSceneGlb(textureBytes) {
     return index;
   }
 
-  function addMeshAccessors(positions, normals, uvs, indices, min, max) {
+  function addTriMeshAccessors(positions, normals, uvs, indices, min, max) {
     const posBV = addBufferView(positions, 34962);
     const posAcc = accessors.length;
     accessors.push({ bufferView: posBV, componentType: 5126, count: positions.length / 3, type: 'VEC3', min, max });
@@ -166,8 +157,32 @@ function buildSceneGlb(textureBytes) {
     return { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc, indices: idxAcc };
   }
 
+  // For LINES primitives we only need POSITION + indices (no normals / UVs).
+  function addLineMeshAccessors(positions, indices, min, max) {
+    const posBV = addBufferView(positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: positions.length / 3, type: 'VEC3', min, max });
+    const idxBV = addBufferView(indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: indices.length, type: 'SCALAR' });
+    return { POSITION: posAcc, indices: idxAcc };
+  }
+
+  // The 12 edges of an axis-aligned box, as line-segment index pairs.
+  const LINE_BOX_INDICES = new Uint32Array([
+    0, 1, 1, 2, 2, 3, 3, 0,    // bottom square
+    4, 5, 5, 6, 6, 7, 7, 4,    // top square
+    0, 4, 1, 5, 2, 6, 3, 7,    // verticals
+  ]);
+  function lineBoxPositions(hx, hy, hz) {
+    return new Float32Array([
+      -hx, -hy, -hz,  hx, -hy, -hz,  hx, hy, -hz,  -hx, hy, -hz,
+      -hx, -hy,  hz,  hx, -hy,  hz,  hx, hy,  hz,  -hx, hy,  hz,
+    ]);
+  }
+
   // Cube mesh.
-  const cube = addMeshAccessors(CUBE_POSITIONS, CUBE_NORMALS, CUBE_UVS, CUBE_INDICES, [-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]);
+  const cube = addTriMeshAccessors(CUBE_POSITIONS, CUBE_NORMALS, CUBE_UVS, CUBE_INDICES, [-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]);
 
   // Ground quad at the collider's top surface, with a single frog stretched across it.
   const halfX = GROUND.size[0] / 2, halfZ = GROUND.size[2] / 2;
@@ -176,22 +191,48 @@ function buildSceneGlb(textureBytes) {
   const groundNormals = new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0]);
   const groundUVs = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
   const groundIndices = new Uint32Array([0, 1, 2, 0, 2, 3]);
-  const ground = addMeshAccessors(groundPositions, groundNormals, groundUVs, groundIndices, [-halfX, gy, -halfZ], [halfX, gy, halfZ]);
+  const ground = addTriMeshAccessors(groundPositions, groundNormals, groundUVs, groundIndices, [-halfX, gy, -halfZ], [halfX, gy, halfZ]);
 
-  // Single embedded image shared by both materials.
+  // Wireframe boxes. Slightly outset (~0.5%) so the lines sit just outside the textured geometry
+  // and don't z-fight with the cube / ground triangle surfaces.
+  const cubeWireHX = CUBE_SIZE[0] / 2 * 1.005, cubeWireHY = CUBE_SIZE[1] / 2 * 1.005, cubeWireHZ = CUBE_SIZE[2] / 2 * 1.005;
+  const cubeWire = addLineMeshAccessors(
+    lineBoxPositions(cubeWireHX, cubeWireHY, cubeWireHZ),
+    LINE_BOX_INDICES,
+    [-cubeWireHX, -cubeWireHY, -cubeWireHZ], [cubeWireHX, cubeWireHY, cubeWireHZ],
+  );
+  const gHX = GROUND.size[0] / 2 * 1.005, gHY = GROUND.size[1] / 2 * 1.005, gHZ = GROUND.size[2] / 2 * 1.005;
+  // The ground wireframe bakes the ground's world Y centre in (collider sits at GROUND.pos).
+  const gMidY = GROUND.pos[1];
+  const groundWirePositions = new Float32Array([
+    -gHX, gMidY - gHY, -gHZ,  gHX, gMidY - gHY, -gHZ,  gHX, gMidY + gHY, -gHZ,  -gHX, gMidY + gHY, -gHZ,
+    -gHX, gMidY - gHY,  gHZ,  gHX, gMidY - gHY,  gHZ,  gHX, gMidY + gHY,  gHZ,  -gHX, gMidY + gHY,  gHZ,
+  ]);
+  const groundWire = addLineMeshAccessors(
+    groundWirePositions, LINE_BOX_INDICES,
+    [-gHX, gMidY - gHY, -gHZ], [gHX, gMidY + gHY, gHZ],
+  );
+
+  // Single embedded image shared by both PBR materials.
   const imgBV = addBufferView(textureBytes, undefined);
 
   const gltf = {
     asset: { version: '2.0', generator: 'filament-havok-minimum' },
+    extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
-    scenes: [{ nodes: [0, 1] }],
+    scenes: [{ nodes: [0, 1, 2, 3] }],
     nodes: [
       { name: 'cube', mesh: 0 },
       { name: 'ground', mesh: 1 },
+      { name: 'cubeWireframe', mesh: 2 },
+      { name: 'groundWireframe', mesh: 3 },
     ],
     meshes: [
       { primitives: [{ attributes: { POSITION: cube.POSITION, NORMAL: cube.NORMAL, TEXCOORD_0: cube.TEXCOORD_0 }, indices: cube.indices, material: 0 }] },
       { primitives: [{ attributes: { POSITION: ground.POSITION, NORMAL: ground.NORMAL, TEXCOORD_0: ground.TEXCOORD_0 }, indices: ground.indices, material: 1 }] },
+      // mode 1 = LINES (glTF spec). gltfio maps that to Filament's PrimitiveType.LINES.
+      { primitives: [{ mode: 1, attributes: { POSITION: cubeWire.POSITION }, indices: cubeWire.indices, material: 2 }] },
+      { primitives: [{ mode: 1, attributes: { POSITION: groundWire.POSITION }, indices: groundWire.indices, material: 3 }] },
     ],
     materials: [
       // doubleSided so back-face culling can't hide faces whose winding happens to be reversed
@@ -199,6 +240,9 @@ function buildSceneGlb(textureBytes) {
       // visible without having to rewind every index).
       { name: 'cube',   pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: CUBE_ROUGHNESS }, doubleSided: true },
       { name: 'ground', pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: 0.9 },            doubleSided: true },
+      // Unlit so the wireframes show as solid coloured lines regardless of lighting.
+      { name: 'cubeWireframe',   extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: [1.0, 0.5, 0.2, 1.0] } },
+      { name: 'groundWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: [0.2, 1.0, 0.4, 1.0] } },
     ],
     images: [{ bufferView: imgBV, mimeType: 'image/jpeg' }],
     samplers: [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }],
@@ -235,98 +279,19 @@ function buildSceneGlb(textureBytes) {
   return glb;
 }
 
-// ---- Debug wireframe overlay (separate transparent WebGL2 canvas) ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  // Cache shader locations + scratch matrices once; upload the unit cube lines once. Per-frame
-  // drawDebug then only does matrix math + one drawArrays per body — no allocations, no rebuffering.
-  debugAPos = gl.getAttribLocation(debugProg, 'aPos');
-  debugUMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  debugUColor = gl.getUniformLocation(debugProg, 'uColor');
-  dbgScratch.view = mat4.create();
-  dbgScratch.proj = mat4.create();
-  dbgScratch.vp = mat4.create();
-  dbgScratch.model = mat4.create();
-  dbgScratch.mvp = mat4.create();
-  dbgScratch.q = quat.create();
-  dbgScratch.p = vec3.create();
-  dbgScratch.s = vec3.create();
-  debugVbo = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.bufferData(gl.ARRAY_BUFFER, makeBoxLineVerts(1, 1, 1), gl.STATIC_DRAW);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const S = dbgScratch;
-  mat4.lookAt(S.view, eye, center, up);
-  mat4.perspective(S.proj, 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  mat4.multiply(S.vp, S.proj, S.view);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(debugAPos);
-  gl.vertexAttribPointer(debugAPos, 3, gl.FLOAT, false, 0, 0);
-
-  function drawBox(size, color, p, r) {
-    quat.set(S.q, r[0], r[1], r[2], r[3]);
-    vec3.set(S.p, p[0], p[1], p[2]);
-    vec3.set(S.s, size[0], size[1], size[2]);
-    mat4.fromRotationTranslationScale(S.model, S.q, S.p, S.s);
-    mat4.multiply(S.mvp, S.vp, S.model);
-    gl.uniformMatrix4fv(debugUMVP, false, S.mvp);
-    gl.uniform4fv(debugUColor, color);
-    gl.drawArrays(gl.LINES, 0, UNIT_CUBE_LINE_COUNT);
-  }
-
-  drawBox(GROUND.size, DEBUG_COLOR_STATIC, GROUND.pos, IDENTITY_QUATERNION);
-  if (cubeBodyId !== null) {
-    const pr = HK.HP_Body_GetPosition(cubeBodyId);
-    const qr = HK.HP_Body_GetOrientation(cubeBodyId);
-    drawBox(CUBE_SIZE, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
-  }
-  gl.disableVertexAttribArray(debugAPos);
-}
-
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene || !cubeWireframeEntity || !groundWireframeEntity) return;
+  if (visible) {
+    scene.addEntity(cubeWireframeEntity);
+    scene.addEntity(groundWireframeEntity);
+  } else {
+    scene.remove(cubeWireframeEntity);
+    scene.remove(groundWireframeEntity);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -352,7 +317,7 @@ Filament.init([IBL_URL], () => {
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
   const ibl = engine.createIblFromKtx1(IBL_URL);
@@ -381,12 +346,10 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.13, 0.15, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
   HK = await HavokPhysics();
   initPhysics();
 
-  // Build & load the scene GLB (cube + ground both reference the same embedded frog texture).
+  // Build & load the scene GLB (cube + ground + LINE wireframes, all in one asset / one canvas).
   const textureBytes = await fetchBytes(TEXTURE_URL);
   const glb = buildSceneGlb(textureBytes);
   const assetLoader = engine.createAssetLoader();
@@ -394,23 +357,28 @@ async function main() {
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      // Pop every renderable into the scene right now so the wireframe toggle can manage them by
+      // name immediately (no further popRenderable in the render loop).
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
-      for (const e of asset.getEntities()) {
-        const inst = rm.getInstance(e);
-        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      for (const ent of asset.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) {
+          rm.setCastShadows(inst, true);
+          rm.setReceiveShadows(inst, true);
+          rm.setCulling(inst, false);
+          inst.delete();
+        }
       }
       resolve();
     }, () => {}, '');
   });
-  const named = asset.getEntitiesByName('cube');
-  cubeEntity = named.length > 0 ? named[0] : null;
-  if (cubeEntity) {
-    const rm = engine.getRenderableManager();
-    const inst = rm.getInstance(cubeEntity);
-    if (inst) { rm.setCulling(inst, false); inst.delete(); }
-  } else {
-    console.warn('[Filament+Havok] cube entity not found');
-  }
+  cubeEntity = asset.getEntitiesByName('cube')[0] || null;
+  cubeWireframeEntity = asset.getEntitiesByName('cubeWireframe')[0] || null;
+  groundWireframeEntity = asset.getEntitiesByName('groundWireframe')[0] || null;
+  if (!cubeEntity) console.warn('[Filament+Havok] cube entity not found');
+  if (!cubeWireframeEntity || !groundWireframeEntity) console.warn('[Filament+Havok] wireframe entities not found');
 
   const center = [0, 0.5, 0];
   const orbitDist = 6;
@@ -421,7 +389,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -433,42 +400,44 @@ async function main() {
   setWireframeVisible(showWireframe);
 
   const tcm = engine.getTransformManager();
-  // Camera orbit speed in radians per second (was 0.005 / fixed frame, equivalent to 0.3 rad/s
-  // at 60fps); driving it by wall time instead of frame count keeps the rotation smooth even when
-  // requestAnimationFrame's frame interval jitters between, say, 16ms and 32ms.
-  const ORBIT_SPEED = 0.3;
-  let angle = 0.5;
-  let prevTime = 0;
+  // Camera orbit driven directly by wall time (matches the raw WebGL2 sample). No accumulator, no
+  // drift — frame interval jitter doesn't compound into a stutter, because the angle is a pure
+  // function of `now`.
+  const ORBIT_SPEED = 0.3; // rad/s
+  const ORBIT_PHASE = 0.5; // initial angle (was the seed `angle = 0.5`)
+  // Reusable scratch so the render loop doesn't allocate every frame.
+  const tmpMat = mat4.create(), tmpQuat = quat.create(), tmpVec = vec3.create();
   function render(now) {
     requestAnimationFrame(render);
-    const dt = prevTime ? Math.min((now - prevTime) / 1000, 0.1) : 1 / 60;
-    prevTime = now;
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
 
     if (HK && worldId) {
       checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
-      if (cubeEntity) {
+      if (cubeEntity || cubeWireframeEntity) {
         const pr = HK.HP_Body_GetPosition(cubeBodyId);
         const qr = HK.HP_Body_GetOrientation(cubeBodyId);
         const p = pr[1], q = qr[1];
-        const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(q[0], q[1], q[2], q[3]), vec3.fromValues(p[0], p[1], p[2]));
-        const inst = tcm.getInstance(cubeEntity);
-        tcm.setTransform(inst, m);
-        inst.delete();
+        quat.set(tmpQuat, q[0], q[1], q[2], q[3]);
+        vec3.set(tmpVec, p[0], p[1], p[2]);
+        mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+        if (cubeEntity) {
+          const inst = tcm.getInstance(cubeEntity);
+          tcm.setTransform(inst, tmpMat);
+          inst.delete();
+        }
+        if (cubeWireframeEntity) {
+          const inst = tcm.getInstance(cubeWireframeEntity);
+          tcm.setTransform(inst, tmpMat);
+          inst.delete();
+        }
       }
     }
 
-    angle += ORBIT_SPEED * dt;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
 
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/minimum/index.js
+++ b/examples/filament/havok/minimum/index.js
@@ -1,34 +1,47 @@
-// Filament + Havok — Minimum sample.
+// Filament + Havok — Minimum sample (PBR).
 //
-// A textured cube falls onto a ground and settles, simulated by Havok and rendered by Filament.
-// Unlike the glTF samples, the cube geometry and its textured (unlit) material are built by hand
-// in Filament, using the compiled `texture.filamat` material package + a JPEG texture (mirrors
-// cx20's webgl-test Filament textured-cube example). Press W to toggle the collider wireframes.
+// A textured cube falls onto a ground and settles, simulated by Havok and rendered by Filament with
+// a lit, physically-based material. There is no lit .filamat we can load, so the scene is emitted
+// as an in-code glTF (GLB): a single cube mesh (the JPEG as baseColorTexture, with hand-authored
+// flat per-face normals so the lighting reads correctly) loaded through Filament's gltfio. The
+// papermill IBL and a directional sun light the scene, so the cube is shaded instead of looking
+// flat. The cube node is matched to its Havok box body and synced every frame.
 //
-// Because a compiled .filamat is tied to a Filament version, this sample uses the matching `dev`
-// Filament build (see index.html), not the pinned v1.70.1 used by the other samples.
+// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
+// camera (Filament can't easily draw lines); the ground is shown only as a wireframe. Press W to
+// toggle them.
 //
-// Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix.
+// Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
+// (vec3 / quat / mat4).
 
-const FILAMAT_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
+const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermill_ibl.ktx';
 const TEXTURE_URL = '../../../../assets/textures/frog.jpg';
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const GROUND = { size: [4, 0.1, 4], pos: [0, 0, 0] };
 const CUBE_SIZE = [1, 1, 1];
+const CUBE_ROUGHNESS = 0.7;
 
 const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0]; // orange = cube
 const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];  // green  = ground
 
-// Unit cube geometry (24 verts so each face has its own UVs), from cx20's webgl-test texture cube.
+// Unit cube geometry (24 verts so each face has its own UVs + flat normal).
 const CUBE_POSITIONS = new Float32Array([
-  -0.5, -0.5, 0.5, 0.5, -0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, 0.5,        // Front
-  -0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, -0.5,    // Back
-  0.5, 0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5,        // Top
-  -0.5, -0.5, 0.5, 0.5, -0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5, -0.5,    // Bottom
-  0.5, -0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, -0.5, -0.5,        // Right
-  -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5, -0.5, -0.5, -0.5, -0.5,    // Left
+  -0.5, -0.5, 0.5, 0.5, -0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, 0.5,        // Front  (+Z)
+  -0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, 0.5, -0.5,    // Back   (-Z)
+  0.5, 0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5,        // Top    (+Y)
+  -0.5, -0.5, 0.5, 0.5, -0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5, -0.5,    // Bottom (-Y)
+  0.5, -0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, -0.5, -0.5,        // Right  (+X)
+  -0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5, -0.5, -0.5, -0.5, -0.5,    // Left   (-X)
+]);
+const CUBE_NORMALS = new Float32Array([
+  0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1,        // Front
+  0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1,    // Back
+  0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0,        // Top
+  0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0,    // Bottom
+  1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0,        // Right
+  -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0,    // Left
 ]);
 const CUBE_UVS = new Float32Array([
   0, 0, 1, 0, 1, 1, 0, 1,   // Front
@@ -38,7 +51,7 @@ const CUBE_UVS = new Float32Array([
   1, 0, 1, 1, 0, 1, 0, 0,   // Right
   0, 0, 1, 0, 1, 1, 0, 1,   // Left
 ]);
-const CUBE_INDICES = new Uint16Array([
+const CUBE_INDICES = new Uint32Array([
   0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, 8, 9, 10, 8, 10, 11,
   12, 13, 14, 12, 14, 15, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23,
 ]);
@@ -49,6 +62,7 @@ let groundBodyId = null;
 let cubeBodyId = null;
 
 let engine = null;
+let asset = null;
 let cubeEntity = null;
 
 let debugCanvas = null;
@@ -106,6 +120,83 @@ function initPhysics() {
   const sn = Math.sin(angle / 2), cs2 = Math.cos(angle / 2), inv = 1 / Math.sqrt(2);
   HK.HP_Body_SetOrientation(cubeBodyId, [inv * sn, 0, inv * sn, cs2]);
   HK.HP_World_AddBody(worldId, cubeBodyId, false);
+}
+
+// ---- In-code GLB assembly (one textured cube node) ----
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function buildCubeGlb(textureBytes) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
+  }
+
+  const posBV = addBufferView(CUBE_POSITIONS, 34962);
+  accessors.push({ bufferView: posBV, componentType: 5126, count: 24, type: 'VEC3', min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] });
+  const nrmBV = addBufferView(CUBE_NORMALS, 34962);
+  accessors.push({ bufferView: nrmBV, componentType: 5126, count: 24, type: 'VEC3' });
+  const uvBV = addBufferView(CUBE_UVS, 34962);
+  accessors.push({ bufferView: uvBV, componentType: 5126, count: 24, type: 'VEC2' });
+  const idxBV = addBufferView(CUBE_INDICES, 34963);
+  accessors.push({ bufferView: idxBV, componentType: 5125, count: 36, type: 'SCALAR' });
+  const imgBV = addBufferView(textureBytes, undefined);
+
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-minimum' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ name: 'cube', mesh: 0 }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1, TEXCOORD_0: 2 }, indices: 3, material: 0 }] }],
+    materials: [{
+      name: 'cube',
+      pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: CUBE_ROUGHNESS },
+    }],
+    images: [{ bufferView: imgBV, mimeType: 'image/jpeg' }],
+    samplers: [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }],
+    textures: [{ sampler: 0, source: 0 }],
+    accessors, bufferViews,
+    buffers: [{ byteLength: binOffset }],
+  };
+
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) {
+    const t = new Uint8Array(jsonBytes.length + jsonPad);
+    t.set(jsonBytes); t.fill(0x20, jsonBytes.length);
+    jsonBytes = t;
+  }
+
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0;
+  for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4; // 'glTF'
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4; // 'JSON'
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4; // 'BIN\0'
+  glb.set(binBuf, p);
+  return glb;
 }
 
 // ---- Debug wireframe overlay (separate transparent WebGL2 canvas) ----
@@ -194,68 +285,81 @@ window.addEventListener('keydown', (event) => {
   }
 });
 
+async function fetchBytes(url) {
+  return new Uint8Array(await (await fetch(url)).arrayBuffer());
+}
+
 // ---- Filament app ----
-Filament.init([TEXTURE_URL, FILAMAT_URL], () => {
+Filament.init([IBL_URL], () => {
+  window.gltfio = Filament.gltfio;
   window.Fov = Filament.Camera$Fov;
+  window.LightType = Filament.LightManager$Type;
+  window.ToneMapping = Filament.ColorGrading$ToneMapping;
   main().catch(e => console.error(e));
 });
-
-function buildCube(eng) {
-  const VertexAttribute = Filament.VertexAttribute;
-  const AttributeType = Filament.VertexBuffer$AttributeType;
-  const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(24)
-    .bufferCount(2)
-    .attribute(VertexAttribute.POSITION, 0, AttributeType.FLOAT3, 0, 0)
-    .attribute(VertexAttribute.UV0, 1, AttributeType.FLOAT2, 0, 0)
-    .build(eng);
-  vb.setBufferAt(eng, 0, CUBE_POSITIONS);
-  vb.setBufferAt(eng, 1, CUBE_UVS);
-  const ib = Filament.IndexBuffer.Builder()
-    .indexCount(36)
-    .bufferType(Filament.IndexBuffer$IndexType.USHORT)
-    .build(eng);
-  ib.setBuffer(eng, CUBE_INDICES);
-
-  const material = eng.createMaterial(FILAMAT_URL);
-  const matInstance = material.getDefaultInstance();
-  const sampler = new Filament.TextureSampler(
-    Filament.MinFilter.LINEAR_MIPMAP_LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.REPEAT);
-  const texture = eng.createTextureFromJpeg(TEXTURE_URL, { nomips: true });
-  matInstance.setTextureParameter('texture', texture, sampler);
-
-  const entity = Filament.EntityManager.get().create();
-  Filament.RenderableManager.Builder(1)
-    .boundingBox({ center: [0, 0, 0], halfExtent: [0.5, 0.5, 0.5] })
-    .material(0, matInstance)
-    .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
-    .build(eng, entity);
-  return entity;
-}
 
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
   const scene = engine.createScene();
 
-  cubeEntity = buildCube(engine);
-  scene.addEntity(cubeEntity);
-  const rm = engine.getRenderableManager();
-  const rmInst = rm.getInstance(cubeEntity);
-  if (rmInst) { rm.setCulling(rmInst, false); rmInst.delete(); } // bbox is at origin; cube moves via transform
+  // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
+  const ibl = engine.createIblFromKtx1(IBL_URL);
+  ibl.setIntensity(50000);
+  scene.setIndirectLight(ibl);
+
+  const sun = Filament.EntityManager.get().create();
+  Filament.LightManager.Builder(LightType.SUN)
+    .color([0.98, 0.92, 0.89])
+    .intensity(50000.0)
+    .direction([0.5, -1.0, -0.6])
+    .castShadows(true)
+    .build(engine, sun);
+  scene.addEntity(sun);
 
   const swapChain = engine.createSwapChain();
   const renderer = engine.createRenderer();
   const camera = engine.createCamera(Filament.EntityManager.get().create());
+  camera.setExposure(16.0, 1.0 / 125.0, 100.0);
   const view = engine.createView();
   view.setCamera(camera);
   view.setScene(scene);
+  // Explicit LINEAR color grading; the default path trips a "uniform buffer too small" GL error
+  // at feature level 1.
+  const colorGrading = Filament.ColorGrading.Builder().toneMapping(ToneMapping.LINEAR).build(engine);
+  view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.13, 0.15, 1.0], clear: true });
 
   initDebugCanvas(canvas);
 
   HK = await HavokPhysics();
   initPhysics();
+
+  // Build & load the cube GLB (the texture is embedded so gltfio resolves no external URIs).
+  const textureBytes = await fetchBytes(TEXTURE_URL);
+  const glb = buildCubeGlb(textureBytes);
+  const assetLoader = engine.createAssetLoader();
+  asset = assetLoader.createAsset(glb);
+  await new Promise((resolve) => {
+    asset.loadResources(() => {
+      assetLoader.delete();
+      const rm = engine.getRenderableManager();
+      for (const e of asset.getEntities()) {
+        const inst = rm.getInstance(e);
+        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+  const named = asset.getEntitiesByName('cube');
+  cubeEntity = named.length > 0 ? named[0] : null;
+  if (cubeEntity) {
+    const rm = engine.getRenderableManager();
+    const inst = rm.getInstance(cubeEntity);
+    if (inst) { rm.setCulling(inst, false); inst.delete(); }
+  } else {
+    console.warn('[Filament+Havok] cube entity not found');
+  }
 
   const center = [0, 0.5, 0];
   const orbitDist = 6;
@@ -282,15 +386,22 @@ async function main() {
   function render() {
     requestAnimationFrame(render);
 
+    if (asset) {
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
+    }
+
     if (HK && worldId) {
       checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
-      const pr = HK.HP_Body_GetPosition(cubeBodyId);
-      const qr = HK.HP_Body_GetOrientation(cubeBodyId);
-      const p = pr[1], q = qr[1];
-      const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(q[0], q[1], q[2], q[3]), vec3.fromValues(p[0], p[1], p[2]));
-      const inst = tcm.getInstance(cubeEntity);
-      tcm.setTransform(inst, m);
-      inst.delete();
+      if (cubeEntity) {
+        const pr = HK.HP_Body_GetPosition(cubeBodyId);
+        const qr = HK.HP_Body_GetOrientation(cubeBodyId);
+        const p = pr[1], q = qr[1];
+        const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(q[0], q[1], q[2], q[3]), vec3.fromValues(p[0], p[1], p[2]));
+        const inst = tcm.getInstance(cubeEntity);
+        tcm.setTransform(inst, m);
+        inst.delete();
+      }
     }
 
     angle += 0.005;

--- a/examples/filament/havok/minimum/index.js
+++ b/examples/filament/havok/minimum/index.js
@@ -433,9 +433,16 @@ async function main() {
   setWireframeVisible(showWireframe);
 
   const tcm = engine.getTransformManager();
+  // Camera orbit speed in radians per second (was 0.005 / fixed frame, equivalent to 0.3 rad/s
+  // at 60fps); driving it by wall time instead of frame count keeps the rotation smooth even when
+  // requestAnimationFrame's frame interval jitters between, say, 16ms and 32ms.
+  const ORBIT_SPEED = 0.3;
   let angle = 0.5;
-  function render() {
+  let prevTime = 0;
+  function render(now) {
     requestAnimationFrame(render);
+    const dt = prevTime ? Math.min((now - prevTime) / 1000, 0.1) : 1 / 60;
+    prevTime = now;
 
     if (asset) {
       let e = asset.popRenderable();
@@ -455,7 +462,7 @@ async function main() {
       }
     }
 
-    angle += 0.005;
+    angle += ORBIT_SPEED * dt;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);

--- a/examples/filament/havok/minimum/index.js
+++ b/examples/filament/havok/minimum/index.js
@@ -71,6 +71,11 @@ let debugGl = null;
 let debugProg = null;
 let debugVbo = null;
 let showWireframe = true;
+// Cached debug shader locations + scratch matrices reused every frame (drops the per-frame
+// Float32Array / mat4.create() allocations that were churning the GC).
+let debugAPos = -1, debugUMVP = null, debugUColor = null;
+const dbgScratch = {};
+const UNIT_CUBE_LINE_COUNT = 24; // 12 edges × 2 vertices
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -262,7 +267,22 @@ function initDebugCanvas(mainCanvas) {
     console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
     debugProg = null; return;
   }
+  // Cache shader locations + scratch matrices once; upload the unit cube lines once. Per-frame
+  // drawDebug then only does matrix math + one drawArrays per body — no allocations, no rebuffering.
+  debugAPos = gl.getAttribLocation(debugProg, 'aPos');
+  debugUMVP = gl.getUniformLocation(debugProg, 'uMVP');
+  debugUColor = gl.getUniformLocation(debugProg, 'uColor');
+  dbgScratch.view = mat4.create();
+  dbgScratch.proj = mat4.create();
+  dbgScratch.vp = mat4.create();
+  dbgScratch.model = mat4.create();
+  dbgScratch.mvp = mat4.create();
+  dbgScratch.q = quat.create();
+  dbgScratch.p = vec3.create();
+  dbgScratch.s = vec3.create();
   debugVbo = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
+  gl.bufferData(gl.ARRAY_BUFFER, makeBoxLineVerts(1, 1, 1), gl.STATIC_DRAW);
 }
 
 function drawDebug(eye, center, up, aspect) {
@@ -274,23 +294,23 @@ function drawDebug(eye, center, up, aspect) {
   if (!showWireframe || !HK || !worldId) return;
   gl.enable(gl.DEPTH_TEST);
   gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
+  const S = dbgScratch;
+  mat4.lookAt(S.view, eye, center, up);
+  mat4.perspective(S.proj, 75 * Math.PI / 180, aspect, 0.01, 10000.0);
+  mat4.multiply(S.vp, S.proj, S.view);
   gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
+  gl.enableVertexAttribArray(debugAPos);
+  gl.vertexAttribPointer(debugAPos, 3, gl.FLOAT, false, 0, 0);
 
   function drawBox(size, color, p, r) {
-    const model = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    gl.uniformMatrix4fv(uMVP, false, mat4.multiply(mat4.create(), vp, model));
-    gl.uniform4fv(uColor, color);
-    const verts = makeBoxLineVerts(size[0], size[1], size[2]);
-    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, verts.length / 3);
+    quat.set(S.q, r[0], r[1], r[2], r[3]);
+    vec3.set(S.p, p[0], p[1], p[2]);
+    vec3.set(S.s, size[0], size[1], size[2]);
+    mat4.fromRotationTranslationScale(S.model, S.q, S.p, S.s);
+    mat4.multiply(S.mvp, S.vp, S.model);
+    gl.uniformMatrix4fv(debugUMVP, false, S.mvp);
+    gl.uniform4fv(debugUColor, color);
+    gl.drawArrays(gl.LINES, 0, UNIT_CUBE_LINE_COUNT);
   }
 
   drawBox(GROUND.size, DEBUG_COLOR_STATIC, GROUND.pos, IDENTITY_QUATERNION);
@@ -299,7 +319,7 @@ function drawDebug(eye, center, up, aspect) {
     const qr = HK.HP_Body_GetOrientation(cubeBodyId);
     drawBox(CUBE_SIZE, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
   }
-  gl.disableVertexAttribArray(aPos);
+  gl.disableVertexAttribArray(debugAPos);
 }
 
 // ---- W-key wireframe toggle ----

--- a/examples/filament/havok/minimum/index.js
+++ b/examples/filament/havok/minimum/index.js
@@ -1,15 +1,16 @@
 // Filament + Havok — Minimum sample (PBR).
 //
-// A textured cube falls onto a ground and settles, simulated by Havok and rendered by Filament with
-// a lit, physically-based material. There is no lit .filamat we can load, so the scene is emitted
-// as an in-code glTF (GLB): a single cube mesh (the JPEG as baseColorTexture, with hand-authored
-// flat per-face normals so the lighting reads correctly) loaded through Filament's gltfio. The
-// papermill IBL and a directional sun light the scene, so the cube is shaded instead of looking
-// flat. The cube node is matched to its Havok box body and synced every frame.
+// A textured cube falls onto a textured ground and settles, simulated by Havok and rendered by
+// Filament with lit, physically-based materials. There is no lit .filamat we can load, so the scene
+// is emitted as an in-code glTF (GLB): a cube mesh + a ground quad (both sharing the same JPEG as
+// baseColorTexture, with hand-authored flat per-face normals so the lighting reads correctly),
+// loaded through Filament's gltfio. The papermill IBL and a directional sun light the scene, so the
+// cube is shaded instead of looking flat. The cube node is matched to its Havok box body and synced
+// every frame.
 //
 // Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines); the ground is shown only as a wireframe. Press W to
-// toggle them.
+// camera (Filament can't easily draw lines); the ground collider's wireframe is the green box.
+// Press W to toggle them.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -122,10 +123,10 @@ function initPhysics() {
   HK.HP_World_AddBody(worldId, cubeBodyId, false);
 }
 
-// ---- In-code GLB assembly (one textured cube node) ----
+// ---- In-code GLB assembly (textured cube + textured ground quad) ----
 function alignTo4(n) { return (n + 3) & ~3; }
 
-function buildCubeGlb(textureBytes) {
+function buildSceneGlb(textureBytes) {
   const accessors = [];
   const bufferViews = [];
   const binChunks = [];
@@ -144,26 +145,56 @@ function buildCubeGlb(textureBytes) {
     return index;
   }
 
-  const posBV = addBufferView(CUBE_POSITIONS, 34962);
-  accessors.push({ bufferView: posBV, componentType: 5126, count: 24, type: 'VEC3', min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] });
-  const nrmBV = addBufferView(CUBE_NORMALS, 34962);
-  accessors.push({ bufferView: nrmBV, componentType: 5126, count: 24, type: 'VEC3' });
-  const uvBV = addBufferView(CUBE_UVS, 34962);
-  accessors.push({ bufferView: uvBV, componentType: 5126, count: 24, type: 'VEC2' });
-  const idxBV = addBufferView(CUBE_INDICES, 34963);
-  accessors.push({ bufferView: idxBV, componentType: 5125, count: 36, type: 'SCALAR' });
+  function addMeshAccessors(positions, normals, uvs, indices, min, max) {
+    const posBV = addBufferView(positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: positions.length / 3, type: 'VEC3', min, max });
+    const nrmBV = addBufferView(normals, 34962);
+    const nrmAcc = accessors.length;
+    accessors.push({ bufferView: nrmBV, componentType: 5126, count: normals.length / 3, type: 'VEC3' });
+    const uvBV = addBufferView(uvs, 34962);
+    const uvAcc = accessors.length;
+    accessors.push({ bufferView: uvBV, componentType: 5126, count: uvs.length / 2, type: 'VEC2' });
+    const idxBV = addBufferView(indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: indices.length, type: 'SCALAR' });
+    return { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc, indices: idxAcc };
+  }
+
+  // Cube mesh.
+  const cube = addMeshAccessors(CUBE_POSITIONS, CUBE_NORMALS, CUBE_UVS, CUBE_INDICES, [-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]);
+
+  // Ground quad at the collider's top surface, with a single frog stretched across it.
+  const halfX = GROUND.size[0] / 2, halfZ = GROUND.size[2] / 2;
+  const gy = GROUND.pos[1] + GROUND.size[1] / 2;
+  const groundPositions = new Float32Array([-halfX, gy, -halfZ, halfX, gy, -halfZ, halfX, gy, halfZ, -halfX, gy, halfZ]);
+  const groundNormals = new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0]);
+  const groundUVs = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+  const groundIndices = new Uint32Array([0, 1, 2, 0, 2, 3]);
+  const ground = addMeshAccessors(groundPositions, groundNormals, groundUVs, groundIndices, [-halfX, gy, -halfZ], [halfX, gy, halfZ]);
+
+  // Single embedded image shared by both materials.
   const imgBV = addBufferView(textureBytes, undefined);
 
   const gltf = {
     asset: { version: '2.0', generator: 'filament-havok-minimum' },
     scene: 0,
-    scenes: [{ nodes: [0] }],
-    nodes: [{ name: 'cube', mesh: 0 }],
-    meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1, TEXCOORD_0: 2 }, indices: 3, material: 0 }] }],
-    materials: [{
-      name: 'cube',
-      pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: CUBE_ROUGHNESS },
-    }],
+    scenes: [{ nodes: [0, 1] }],
+    nodes: [
+      { name: 'cube', mesh: 0 },
+      { name: 'ground', mesh: 1 },
+    ],
+    meshes: [
+      { primitives: [{ attributes: { POSITION: cube.POSITION, NORMAL: cube.NORMAL, TEXCOORD_0: cube.TEXCOORD_0 }, indices: cube.indices, material: 0 }] },
+      { primitives: [{ attributes: { POSITION: ground.POSITION, NORMAL: ground.NORMAL, TEXCOORD_0: ground.TEXCOORD_0 }, indices: ground.indices, material: 1 }] },
+    ],
+    materials: [
+      // doubleSided so back-face culling can't hide faces whose winding happens to be reversed
+      // (the hand-authored cube indices are not all CCW outward; doubleSided keeps every face
+      // visible without having to rewind every index).
+      { name: 'cube',   pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: CUBE_ROUGHNESS }, doubleSided: true },
+      { name: 'ground', pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: 0.9 },            doubleSided: true },
+    ],
     images: [{ bufferView: imgBV, mimeType: 'image/jpeg' }],
     samplers: [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }],
     textures: [{ sampler: 0, source: 0 }],
@@ -335,9 +366,9 @@ async function main() {
   HK = await HavokPhysics();
   initPhysics();
 
-  // Build & load the cube GLB (the texture is embedded so gltfio resolves no external URIs).
+  // Build & load the scene GLB (cube + ground both reference the same embedded frog texture).
   const textureBytes = await fetchBytes(TEXTURE_URL);
-  const glb = buildCubeGlb(textureBytes);
+  const glb = buildSceneGlb(textureBytes);
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(glb);
   await new Promise((resolve) => {

--- a/examples/filament/havok/shogi/index.js
+++ b/examples/filament/havok/shogi/index.js
@@ -9,9 +9,9 @@
 // pieces are shaded instead of looking flat. Each piece collides as a convex hull of its own mesh
 // (HP_Shape_CreateConvexHull) and its node is synced every frame.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines); the four walls are shown only as wireframes. Press W to
-// toggle them.
+// Collider wireframes are baked into the same GLB as LINES primitives with KHR_materials_unlit
+// (orange piece outline = convex-hull collider; green = ground + walls), so they render in the same
+// Filament pass — no second canvas. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -26,6 +26,7 @@ const PIECE_H = 1.6;
 const PIECE_D = 0.45;
 const COLLIDER_SIZE = [PIECE_W, PIECE_H, PIECE_D * 1.4]; // box fallback only
 const PIECE_ROUGHNESS = 0.65; // lacquered-wood look
+const WIREFRAME_OUTSET = 1.005;
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
@@ -39,19 +40,18 @@ const WALLS = [
   { size: [1, 10, 10], pos: [5, 5, 0] },
 ];
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
+const COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
+let scene = null;
 let asset = null;
-const pieces = [];      // { entity, bodyId, curPos, curRot }
-const staticBoxes = []; // ground + walls, for the debug overlay
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null, pieceLines = null;
+let showWireframe = true;
+const pieces = [];                   // { entity, wireframeEntity, bodyId }
+const staticWireframeEntities = [];  // ground + walls
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -70,9 +70,7 @@ function checkResult(result, label) {
   console.warn('[Havok] ' + label + ' returned:', result);
 }
 
-// ---- Geometry ----
-// Flat per-face normals: each vertex belongs only to coplanar triangles (faces don't share
-// vertices), so accumulating triangle normals and normalising yields the face normal.
+// ---- Geometry (triangle meshes) ----
 function computeFlatNormals(positions, indices) {
   const normals = new Float32Array(positions.length);
   for (let i = 0; i < indices.length; i += 3) {
@@ -100,8 +98,6 @@ function minMax3(positions) {
   return { min, max };
 }
 
-// Faceted shogi-piece prism (positions + uv0 + flat normals). UVs follow the glTF top-left
-// convention the atlas was authored for, so gltfio maps the kanji onto the faces with no flip.
 function createShogiGeometry(w, h, d) {
   const positions = new Float32Array([
     -0.5 * w, -0.5 * h, 0.7 * d, 0.5 * w, -0.5 * h, 0.7 * d, 0.35 * w, 0.5 * h, 0.4 * d, -0.35 * w, 0.5 * h, 0.4 * d,
@@ -155,13 +151,45 @@ function buildQuadGeometry(halfX, halfZ, y, tiles) {
   };
 }
 
+// ---- Geometry (LINES wireframes) ----
+const LINE_BOX_INDICES = new Uint32Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBox(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  const positions = new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+  return {
+    positions, indices: LINE_BOX_INDICES,
+    min: [cx - hx, cy - hy, cz - hz], max: [cx + hx, cy + hy, cz + hz],
+  };
+}
+
+// Triangle-edge line list from a triangle mesh — a faithful outline of the convex-hull collider.
+function buildPieceLineMesh(geo) {
+  const pos = geo.positions, idx = geo.indices, verts = [];
+  for (let i = 0; i < idx.length; i += 3) {
+    const a = idx[i] * 3, b = idx[i + 1] * 3, c = idx[i + 2] * 3;
+    verts.push(pos[a], pos[a + 1], pos[a + 2], pos[b], pos[b + 1], pos[b + 2]);
+    verts.push(pos[b], pos[b + 1], pos[b + 2], pos[c], pos[c + 1], pos[c + 2]);
+    verts.push(pos[c], pos[c + 1], pos[c + 2], pos[a], pos[a + 1], pos[a + 2]);
+  }
+  const positionArr = new Float32Array(verts);
+  const indicesArr = new Uint32Array(positionArr.length / 3);
+  for (let i = 0; i < indicesArr.length; i++) indicesArr[i] = i;
+  return {
+    positions: positionArr, indices: indicesArr,
+    min: geo.min.slice(), max: geo.max.slice(),
+  };
+}
+
 // ---- In-code GLB assembly ----
-// Generic builder: meshGeos (each carrying a `material` index), materials, nodes (each referencing a
-// mesh by index), and embedded images (each { bytes, mimeType }). Materials' baseColorTexture index
-// refers into the images array. Produces a single self-contained GLB (JSON + embedded BIN).
 function alignTo4(n) { return (n + 3) & ~3; }
 
-function buildGlb(meshGeos, materials, nodes, images) {
+function buildSceneGlb(pieceSpecs, pieceGeo, shogiImage, grassImage) {
   const accessors = [];
   const bufferViews = [];
   const binChunks = [];
@@ -180,7 +208,7 @@ function buildGlb(meshGeos, materials, nodes, images) {
     return index;
   }
 
-  const meshes = meshGeos.map((g) => {
+  function addTriMesh(g) {
     const posBV = addBufferView(g.positions, 34962);
     const posAcc = accessors.length;
     accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
@@ -193,28 +221,85 @@ function buildGlb(meshGeos, materials, nodes, images) {
     const idxBV = addBufferView(g.indices, 34963);
     const idxAcc = accessors.length;
     accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
-    return { primitives: [{ attributes: { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc }, indices: idxAcc, material: g.material }] };
+    return { POSITION: posAcc, NORMAL: nrmAcc, TEXCOORD_0: uvAcc, indices: idxAcc };
+  }
+  function addLineMesh(g) {
+    const posBV = addBufferView(g.positions, 34962);
+    const posAcc = accessors.length;
+    accessors.push({ bufferView: posBV, componentType: 5126, count: g.positions.length / 3, type: 'VEC3', min: g.min, max: g.max });
+    const idxBV = addBufferView(g.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: g.indices.length, type: 'SCALAR' });
+    return { POSITION: posAcc, indices: idxAcc };
+  }
+
+  const meshes = [];
+  const materials = [];
+
+  // ---- PBR piece + ground ----
+  const pieceAccs = addTriMesh(pieceGeo);
+  materials.push({
+    name: 'piece',
+    pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: PIECE_ROUGHNESS },
+    doubleSided: true,
+  });
+  meshes.push({ primitives: [{ attributes: { POSITION: pieceAccs.POSITION, NORMAL: pieceAccs.NORMAL, TEXCOORD_0: pieceAccs.TEXCOORD_0 }, indices: pieceAccs.indices, material: materials.length - 1 }] });
+  const pieceMeshIndex = meshes.length - 1;
+
+  const groundAccs = addTriMesh(buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES));
+  materials.push({
+    name: 'ground',
+    pbrMetallicRoughness: { baseColorTexture: { index: 1 }, metallicFactor: 0.0, roughnessFactor: 0.9 },
+    doubleSided: true,
+  });
+  meshes.push({ primitives: [{ attributes: { POSITION: groundAccs.POSITION, NORMAL: groundAccs.NORMAL, TEXCOORD_0: groundAccs.TEXCOORD_0 }, indices: groundAccs.indices, material: materials.length - 1 }] });
+  const groundMeshIndex = meshes.length - 1;
+
+  // ---- Unlit wireframe materials ----
+  const pieceWireMatIndex = materials.length;
+  materials.push({ name: 'pieceWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_DYNAMIC } });
+  const staticWireMatIndex = materials.length;
+  materials.push({ name: 'staticWireframe', extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: COLOR_STATIC } });
+
+  // ---- LINES piece wireframe (shared by all pieces) ----
+  const pieceLineAccs = addLineMesh(buildPieceLineMesh(pieceGeo));
+  meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: pieceLineAccs.POSITION }, indices: pieceLineAccs.indices, material: pieceWireMatIndex }] });
+  const pieceWireMeshIndex = meshes.length - 1;
+
+  // ---- LINES static wireframes (ground + 4 walls, size + position baked) ----
+  const staticDefs = [{ size: GROUND.size, pos: GROUND.pos }, ...WALLS];
+  const staticWireMeshIndices = staticDefs.map((d) => {
+    const hx = d.size[0] / 2 * WIREFRAME_OUTSET, hy = d.size[1] / 2 * WIREFRAME_OUTSET, hz = d.size[2] / 2 * WIREFRAME_OUTSET;
+    const accs = addLineMesh(buildLineBox(hx, hy, hz, d.pos[0], d.pos[1], d.pos[2]));
+    meshes.push({ primitives: [{ mode: 1, attributes: { POSITION: accs.POSITION }, indices: accs.indices, material: staticWireMatIndex }] });
+    return meshes.length - 1;
   });
 
-  const textureBlocks = {};
-  if (images && images.length) {
-    const imgs = [], texs = [];
-    images.forEach((im, i) => {
-      const bv = addBufferView(im.bytes, undefined);
-      imgs.push({ bufferView: bv, mimeType: im.mimeType });
-      texs.push({ sampler: 0, source: i });
-    });
-    textureBlocks.images = imgs;
-    textureBlocks.samplers = [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }];
-    textureBlocks.textures = texs;
-  }
+  // ---- Nodes ----
+  const nodes = [];
+  pieceSpecs.forEach((s, i) => nodes.push({ name: 'piece' + i, mesh: pieceMeshIndex, translation: s.position }));
+  nodes.push({ name: 'ground', mesh: groundMeshIndex });
+  pieceSpecs.forEach((s, i) => nodes.push({ name: 'pieceWireframe' + i, mesh: pieceWireMeshIndex, translation: s.position }));
+  staticWireMeshIndices.forEach((mi, i) => nodes.push({ name: 'staticWireframe' + i, mesh: mi }));
+
+  // ---- Embedded textures (shogi + grass) ----
+  const images = [shogiImage, grassImage];
+  const imgs = [], texs = [];
+  images.forEach((im, i) => {
+    const bv = addBufferView(im.bytes, undefined);
+    imgs.push({ bufferView: bv, mimeType: im.mimeType });
+    texs.push({ sampler: 0, source: i });
+  });
 
   const gltf = {
     asset: { version: '2.0', generator: 'filament-havok-shogi' },
+    extensionsUsed: ['KHR_materials_unlit'],
     scene: 0,
     scenes: [{ nodes: nodes.map((_, i) => i) }],
     nodes, meshes, materials, accessors, bufferViews,
-    ...textureBlocks,
+    images: imgs,
+    samplers: [{ magFilter: 9729, minFilter: 9987, wrapS: 10497, wrapT: 10497 }],
+    textures: texs,
     buffers: [{ byteLength: binOffset }],
   };
 
@@ -234,43 +319,16 @@ function buildGlb(meshGeos, materials, nodes, images) {
   const glb = new Uint8Array(totalLen);
   const dv = new DataView(glb.buffer);
   let p = 0;
-  dv.setUint32(p, 0x46546C67, true); p += 4; // 'glTF'
+  dv.setUint32(p, 0x46546C67, true); p += 4;
   dv.setUint32(p, 2, true); p += 4;
   dv.setUint32(p, totalLen, true); p += 4;
   dv.setUint32(p, jsonBytes.length, true); p += 4;
-  dv.setUint32(p, 0x4E4F534A, true); p += 4; // 'JSON'
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
   glb.set(jsonBytes, p); p += jsonBytes.length;
   dv.setUint32(p, binBuf.length, true); p += 4;
-  dv.setUint32(p, 0x004E4942, true); p += 4; // 'BIN\0'
+  dv.setUint32(p, 0x004E4942, true); p += 4;
   glb.set(binBuf, p);
   return glb;
-}
-
-// Piece mesh/material (0, shogi texture) + grass ground slab (1). Piece nodes are named "piece<i>"
-// so they can be matched to Havok bodies; physics drives their orientation, so node rotation is left
-// at identity.
-function buildSceneGlb(pieceSpecs, pieceGeo, shogiImage, grassImage) {
-  pieceGeo.material = 0;
-  const groundGeo = buildQuadGeometry(GROUND.size[0] / 2, GROUND.size[2] / 2, GROUND.pos[1] + GROUND.size[1] / 2, GROUND_TILES);
-  groundGeo.material = 1;
-
-  const materials = [
-    {
-      name: 'piece',
-      pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0.0, roughnessFactor: PIECE_ROUGHNESS },
-      doubleSided: true,
-    },
-    {
-      name: 'ground',
-      pbrMetallicRoughness: { baseColorTexture: { index: 1 }, metallicFactor: 0.0, roughnessFactor: 0.9 },
-      doubleSided: true,
-    },
-  ];
-
-  const nodes = pieceSpecs.map((s, i) => ({ name: 'piece' + i, mesh: 0, translation: s.position }));
-  nodes.push({ name: 'ground', mesh: 1 });
-
-  return buildGlb([pieceGeo, groundGeo], materials, nodes, [shogiImage, grassImage]);
 }
 
 // ---- Scene setup ----
@@ -282,11 +340,8 @@ function createStaticBox(size, pos) {
   HK.HP_Body_SetPosition(b[1], pos);
   HK.HP_Body_SetOrientation(b[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, b[1], false);
-  staticBoxes.push({ size, pos });
 }
 
-// Convex-hull collider from the piece's own mesh vertices (a shogi piece is convex). Dynamic bodies
-// need a convex shape in Havok, so a hull — not a triangle mesh — is used. Falls back to a box.
 function createPieceShape(positions) {
   if (typeof HK.HP_Shape_CreateConvexHull === 'function') {
     const nPoints = positions.length / 3;
@@ -319,7 +374,7 @@ function randomDrop() {
   return [(Math.random() - 0.5) * 8, 12 + Math.random() * 26, (Math.random() - 0.5) * 8];
 }
 
-function addPieceBody(shapeId, entity, pos, rot) {
+function addPieceBody(shapeId, entity, wireframeEntity, pos, rot) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -329,8 +384,11 @@ function addPieceBody(shapeId, entity, pos, rot) {
   HK.HP_Body_SetPosition(bodyId, pos);
   HK.HP_Body_SetOrientation(bodyId, rot);
   HK.HP_World_AddBody(worldId, bodyId, false);
-  pieces.push({ entity, bodyId, curPos: pos.slice(), curRot: rot.slice() });
+  pieces.push({ entity, wireframeEntity, bodyId });
 }
+
+// Scratch buffers reused by stepAndSync; initialised in main() once gl-matrix is available.
+let tmpMat = null, tmpQuat = null, tmpVec = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -346,123 +404,36 @@ function stepAndSync() {
       pos = HK.HP_Body_GetPosition(p.bodyId)[1];
     }
     const r = HK.HP_Body_GetOrientation(p.bodyId)[1];
-    p.curPos[0] = pos[0]; p.curPos[1] = pos[1]; p.curPos[2] = pos[2];
-    p.curRot[0] = r[0]; p.curRot[1] = r[1]; p.curRot[2] = r[2]; p.curRot[3] = r[3];
-    if (!p.entity) continue;
-    const m = mat4.fromRotationTranslation(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(pos[0], pos[1], pos[2]));
-    const inst = tcm.getInstance(p.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, pos[0], pos[1], pos[2]);
+    mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+    if (p.entity) {
+      const inst = tcm.getInstance(p.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (p.wireframeEntity) {
+      const inst = tcm.getInstance(p.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
 
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-// Triangle-edge line list from the piece geometry — a faithful outline of the convex-hull collider.
-function makePieceLineVerts(geo) {
-  const pos = geo.positions, idx = geo.indices, v = [];
-  for (let i = 0; i < idx.length; i += 3) {
-    const a = idx[i] * 3, b = idx[i + 1] * 3, c = idx[i + 2] * 3;
-    v.push(pos[a], pos[a + 1], pos[a + 2], pos[b], pos[b + 1], pos[b + 2]);
-    v.push(pos[b], pos[b + 1], pos[b + 2], pos[c], pos[c + 1], pos[c + 2]);
-    v.push(pos[c], pos[c + 1], pos[c + 2], pos[a], pos[a + 1], pos[a + 2]);
-  }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function drawScaled(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground + walls (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const cubeCount = unitCubeLines.length / 3;
-  for (const sb of staticBoxes) {
-    drawScaled(sb.pos, IDENTITY_QUATERNION, sb.size);
-    gl.drawArrays(gl.LINES, 0, cubeCount);
-  }
-
-  // Pieces (orange convex-hull / mesh outline at the body transform)
-  if (pieceLines) {
-    gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-    gl.bufferData(gl.ARRAY_BUFFER, pieceLines, gl.DYNAMIC_DRAW);
-    const pieceCount = pieceLines.length / 3;
-    const one = [1, 1, 1];
-    for (const p of pieces) {
-      drawScaled(p.curPos, p.curRot, one);
-      gl.drawArrays(gl.LINES, 0, pieceCount);
-    }
-  }
-  gl.disableVertexAttribArray(aPos);
-}
-
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const p of pieces) {
+    if (!p.wireframeEntity) continue;
+    if (visible) scene.addEntity(p.wireframeEntity); else scene.remove(p.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -486,11 +457,14 @@ Filament.init([IBL_URL], () => {
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
-  // IBL for lighting + reflections; no skybox, so the background stays the dark clear colour.
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
   scene.setIndirectLight(ibl);
@@ -511,13 +485,9 @@ async function main() {
   const view = engine.createView();
   view.setCamera(camera);
   view.setScene(scene);
-  // Explicit LINEAR color grading; the default path trips a "uniform buffer too small" GL error
-  // at feature level 1.
   const colorGrading = Filament.ColorGrading.Builder().toneMapping(ToneMapping.LINEAR).build(engine);
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
-
-  initDebugCanvas(canvas);
 
   // Physics world + static ground / walls (walls are wireframe-only).
   HK = await HavokPhysics();
@@ -528,12 +498,11 @@ async function main() {
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
 
-  // Assign a spawn point to each piece, then build & load the GLB (pieces + ground).
+  // Assign a spawn point to each piece, then build & load the GLB (pieces + wires + ground).
   const pieceSpecs = [];
   for (let i = 0; i < PIECE_COUNT; i++) pieceSpecs.push({ position: randomDrop() });
 
   const pieceGeo = createShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
-  pieceLines = makePieceLineVerts(pieceGeo);
 
   const shogiImage = { bytes: await fetchBytes(SHOGI_URL), mimeType: 'image/png' };
   const grassImage = { bytes: await fetchBytes(GRASS_URL), mimeType: 'image/jpeg' };
@@ -544,28 +513,36 @@ async function main() {
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      // Pop every renderable into the scene now so the W toggle can manage wireframes by name.
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
-      for (const e of asset.getEntities()) {
-        const inst = rm.getInstance(e);
-        if (inst) { rm.setCastShadows(inst, true); rm.setReceiveShadows(inst, true); inst.delete(); }
+      for (const ent of asset.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) {
+          rm.setCastShadows(inst, true);
+          rm.setReceiveShadows(inst, true);
+          rm.setCulling(inst, false);
+          inst.delete();
+        }
       }
       resolve();
     }, () => {}, '');
   });
 
-  // One shared convex-hull collider; match each piece node to its Filament entity and create its body.
+  // One shared convex-hull collider; match each piece node to its Filament entities + wireframe.
   const pieceShape = createPieceShape(pieceGeo.positions);
   for (let i = 0; i < pieceSpecs.length; i++) {
-    const named = asset.getEntitiesByName('piece' + i);
-    const entity = named.length > 0 ? named[0] : null;
-    if (entity) {
-      const rm = engine.getRenderableManager();
-      const inst = rm.getInstance(entity);
-      if (inst) { rm.setCulling(inst, false); inst.delete(); }
-    }
-    addPieceBody(pieceShape, entity, pieceSpecs[i].position, randomQuat());
+    const entity = asset.getEntitiesByName('piece' + i)[0] || null;
+    const wireframeEntity = asset.getEntitiesByName('pieceWireframe' + i)[0] || null;
+    addPieceBody(pieceShape, entity, wireframeEntity, pieceSpecs[i].position, randomQuat());
   }
-  console.log('[Filament+Havok] pieces ready:', pieces.length);
+  // Ground + 4 wall wireframes.
+  for (let i = 0; i < 1 + WALLS.length; i++) {
+    const ent = asset.getEntitiesByName('staticWireframe' + i)[0];
+    if (ent) staticWireframeEntities.push(ent);
+  }
+  console.log('[Filament+Havok] pieces ready:', pieces.length, 'static wires:', staticWireframeEntities.length);
 
   const center = [0, 2, 0];
   const orbitDist = 30;
@@ -576,7 +553,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -587,26 +563,22 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time — pure function of `now`, no accumulator drift.
+  const ORBIT_SPEED = 0.24; // rad/s
+  const ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
 
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
 
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }


### PR DESCRIPTION
## Summary

Applies the same fix that smoothed out the Minimum sample to the other three gltfio-in-code Falling samples: drop the overlay WebGL2 canvas and bake the collider wireframes into the same GLB as **LINES** primitives with **KHR_materials_unlit**, so the whole scene renders in a single Filament pass / single canvas / one compositor target. The orbit camera is also switched to a pure function of wall time so any leftover frame-interval jitter doesn't compound.

This is Group A of 3 planned PRs covering all 15 Filament + Havok samples (the in-code gltfio ones first because they're the closest analogue to Minimum). Groups B (`gltf_physics_*`, `gltf`, `marbles` — external GLBs) and C (`box`, `cone`, `domino`, `football` — `.filamat` dev build) will follow.

## Per-sample summary

| Sample | Wireframe entities added to the GLB |
|---|---|
| balls | 200 ball-wire LINES nodes (sphere outline per type) + 5 static-wire LINES nodes (ground + 4 walls) |
| coins | 500 coin-wire LINES nodes (sphere outline per type) + 1 static-wire LINES node (ground) |
| shogi | 220 piece-wire LINES nodes (shared mesh-edge outline of the convex-hull collider) + 5 static-wire LINES nodes (ground + 4 walls) |

The wireframe boxes / spheres are scaled by ~0.5% outward so the lines sit just outside the textured surface and don't z-fight. Each dynamic body's wireframe entity is synced alongside its PBR entity in `stepAndSync`; the **W** toggle adds / removes the wireframe entities from the scene.

## Verification

`index.js` syntax-checked for all three; each GLB's byte layout (PBR mesh accessors, LINES accessors, `KHR_materials_unlit` declaration, wireframe node counts, bufferView alignment, baseColorTexture wiring) was validated offline. **In-browser smoothness still needs your visual check** — particularly the orbit smoothness once the bodies have settled, and that the W toggle and wireframe colours / outlines look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)