### PR TITLE
Filament + Havok: single-canvas wireframes for box / cone / domino / football (Group C)

### DIFF
--- a/examples/filament/havok/box/index.js
+++ b/examples/filament/havok/box/index.js
@@ -3,7 +3,10 @@
 // 256 coloured cubes (a 16x16 bitmap picture) fall and pile up on a grass ground, simulated by
 // Havok and rendered by Filament. Geometry and materials are built by hand: cube.filamat (vertex-
 // colour unlit material) gives each cube a flat colour, texture.filamat textures the grass floor.
-// Press W to toggle the collider wireframes.
+//
+// Collider wireframes are rendered in the same Filament pass as LINES renderables using
+// `cube.filamat` (an unlit vertex-colour material) — no second canvas, no compositor stutter.
+// Press W to toggle them in / out of the scene.
 //
 // A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
 // (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
@@ -49,18 +52,19 @@ const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BOX_SIZE = 1;
 const RESET_Y_THRESHOLD = -10;
 const GROUND = { size: [30, 0.4, 30], pos: [0, 0, 0] };
+const WIREFRAME_OUTSET = 1.005;
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [255, 128, 51, 255];  // orange
+const COLOR_STATIC = [51, 255, 102, 255];   // green
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
-const boxes = []; // { entity, bodyId, curPos, curRot }
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null;
+let scene = null;
+let showWireframe = true;
+const boxes = []; // { entity, wireframeEntity, bodyId, curPos, curRot }
+const staticWireframeEntities = [];
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -93,12 +97,10 @@ const CUBE_INDICES = new Uint16Array([
   12, 13, 14, 12, 14, 15, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23,
 ]);
 
-// Cube vertex buffer with a flat per-vertex COLOR (cube.filamat uses getColor() as baseColor).
 function buildColorCubeVB(eng, rgb) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(24)
-    .bufferCount(2)
+    .vertexCount(24).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
     .normalized(VA.COLOR)
@@ -111,7 +113,6 @@ function buildColorCubeVB(eng, rgb) {
   return vb;
 }
 
-// Plane (XZ) with POSITION + UV0 for the textured grass ground.
 function makePlaneGeometry(size, tiles) {
   const h = size / 2;
   return {
@@ -124,8 +125,7 @@ function makePlaneGeometry(size, tiles) {
 function buildUvVB(eng, positions, uvs, vertexCount) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
+    .vertexCount(vertexCount).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
     .build(eng);
@@ -143,8 +143,52 @@ function buildIB(eng, indices) {
   return ib;
 }
 
-// ---- Body creation (builds the matching Filament renderable) ----
-function addBox(scene, vb, ib, matInstance, shapeId, pos) {
+// ---- LINES wireframes (cube.filamat: POSITION + COLOR per vertex) ----
+const LINE_BOX_INDICES = new Uint16Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBoxPositions(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  return new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+}
+
+function buildLineVB(eng, positions, color4) {
+  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
+  const vertexCount = positions.length / 3;
+  const vb = Filament.VertexBuffer.Builder()
+    .vertexCount(vertexCount).bufferCount(2)
+    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
+    .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
+    .normalized(VA.COLOR)
+    .build(eng);
+  vb.setBufferAt(eng, 0, positions);
+  const col = new Uint8Array(vertexCount * 4);
+  for (let i = 0; i < vertexCount; i++) {
+    col[i * 4] = color4[0]; col[i * 4 + 1] = color4[1]; col[i * 4 + 2] = color4[2]; col[i * 4 + 3] = color4[3];
+  }
+  vb.setBufferAt(eng, 1, col);
+  return vb;
+}
+
+function buildLineRenderable(vb, ib, matInstance, halfExtent) {
+  const entity = Filament.EntityManager.get().create();
+  Filament.RenderableManager.Builder(1)
+    .boundingBox({ center: [0, 0, 0], halfExtent })
+    .material(0, matInstance)
+    .geometry(0, Filament.RenderableManager$PrimitiveType.LINES, vb, ib)
+    .build(engine, entity);
+  const rm = engine.getRenderableManager();
+  const inst = rm.getInstance(entity);
+  if (inst) { rm.setCulling(inst, false); inst.delete(); }
+  return entity;
+}
+
+// ---- Body creation (builds the matching PBR + wireframe renderables) ----
+function addBox(coneScene, vb, ib, matInstance, shapeId, pos, wireVB, wireIB, wireMatInstance) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -161,17 +205,22 @@ function addBox(scene, vb, ib, matInstance, shapeId, pos) {
     .material(0, matInstance)
     .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
     .build(engine, entity);
-  scene.addEntity(entity);
+  coneScene.addEntity(entity);
   const rm = engine.getRenderableManager();
   const inst = rm.getInstance(entity);
   if (inst) { rm.setCulling(inst, false); inst.delete(); }
 
-  boxes.push({ entity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
+  const wireframeEntity = buildLineRenderable(wireVB, wireIB, wireMatInstance, [BOX_SIZE / 2, BOX_SIZE / 2, BOX_SIZE / 2]);
+  coneScene.addEntity(wireframeEntity);
+
+  boxes.push({ entity, wireframeEntity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
 }
 
 function randomRespawn() {
   return [-5 + Math.random() * 10, 20 + Math.random() * 10, -5 + Math.random() * 10];
 }
+
+let tmpMat = null, tmpQuat = null, tmpVec = null, tmpScale = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -188,96 +237,25 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(b.bodyId)[1];
     b.curPos[0] = p[0]; b.curPos[1] = p[1]; b.curPos[2] = p[2];
     b.curRot[0] = r[0]; b.curRot[1] = r[1]; b.curRot[2] = r[2]; b.curRot[3] = r[3];
-    const m = mat4.fromRotationTranslationScale(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]), vec3.fromValues(BOX_SIZE, BOX_SIZE, BOX_SIZE));
-    const inst = tcm.getInstance(b.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, p[0], p[1], p[2]);
+    // PBR cube uses a unit-size mesh and scales by BOX_SIZE.
+    vec3.set(tmpScale, BOX_SIZE, BOX_SIZE, BOX_SIZE);
+    mat4.fromRotationTranslationScale(tmpMat, tmpQuat, tmpVec, tmpScale);
+    if (b.entity) {
+      const inst = tcm.getInstance(b.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    // Wireframe is pre-sized so a non-scaling transform is correct.
+    if (b.wireframeEntity) {
+      mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+      const inst = tcm.getInstance(b.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
-}
-
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const count = unitCubeLines.length / 3;
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function drawScaled(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  drawScaled(GROUND.pos, IDENTITY_QUATERNION, GROUND.size);
-  gl.drawArrays(gl.LINES, 0, count);
-
-  // Boxes (orange)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  const boxScale = [BOX_SIZE, BOX_SIZE, BOX_SIZE];
-  for (const b of boxes) {
-    drawScaled(b.curPos, b.curRot, boxScale);
-    gl.drawArrays(gl.LINES, 0, count);
-  }
-  gl.disableVertexAttribArray(aPos);
 }
 
 // ---- W-key wireframe toggle ----
@@ -285,6 +263,14 @@ function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const b of boxes) {
+    if (!b.wireframeEntity) continue;
+    if (visible) scene.addEntity(b.wireframeEntity); else scene.remove(b.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -301,16 +287,27 @@ Filament.init([FILAMAT_CUBE_URL, FILAMAT_TEX_URL, GRASS_URL], () => {
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+  tmpScale = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   // Boxes: one vertex-colour material (cube.filamat), with a per-colour cube vertex buffer.
   const cubeMat = engine.createMaterial(FILAMAT_CUBE_URL);
   const cubeInst = cubeMat.getDefaultInstance();
+  const wireMatInstance = cubeInst; // cube.filamat just samples vertex colour — same instance is fine
   const cubeVBByKey = {};
   for (const [key, rgb] of Object.entries(colorHash)) cubeVBByKey[key] = buildColorCubeVB(engine, rgb);
   const cubeIB = buildIB(engine, CUBE_INDICES);
+
+  // Shared LINES box wireframe (unit cube outset slightly so it sits just outside the PBR cube).
+  const wireHalf = 0.5 * WIREFRAME_OUTSET;
+  const cubeWireVB = buildLineVB(engine, buildLineBoxPositions(wireHalf, wireHalf, wireHalf), COLOR_DYNAMIC);
+  const cubeWireIB = buildIB(engine, LINE_BOX_INDICES);
 
   // Grass ground (texture.filamat).
   const texMat = engine.createMaterial(FILAMAT_TEX_URL);
@@ -328,8 +325,6 @@ async function main() {
   view.setCamera(camera);
   view.setScene(scene);
   renderer.setClearOptions({ clearColor: [0.1, 0.1, 0.15, 1.0], clear: true });
-
-  initDebugCanvas(canvas);
 
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
@@ -363,6 +358,16 @@ async function main() {
     if (ri) { rm.setCulling(ri, false); ri.delete(); }
   }
 
+  // Ground LINES wireframe (size + position baked).
+  {
+    const ghx = GROUND.size[0] / 2 * WIREFRAME_OUTSET, ghy = GROUND.size[1] / 2 * WIREFRAME_OUTSET, ghz = GROUND.size[2] / 2 * WIREFRAME_OUTSET;
+    const vb = buildLineVB(engine, buildLineBoxPositions(ghx, ghy, ghz, GROUND.pos[0], GROUND.pos[1], GROUND.pos[2]), COLOR_STATIC);
+    const ib = buildIB(engine, LINE_BOX_INDICES);
+    const entity = buildLineRenderable(vb, ib, wireMatInstance, [ghx, ghy, ghz]);
+    scene.addEntity(entity);
+    staticWireframeEntities.push(entity);
+  }
+
   const boxShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [BOX_SIZE, BOX_SIZE, BOX_SIZE])[1];
 
   // 16x16 cubes forming the picture (a vertical wall that collapses into a pile).
@@ -372,7 +377,7 @@ async function main() {
       const px = -12 + x * BOX_SIZE * 1.5 + Math.random() * 0.1;
       const py = (15 - y) * BOX_SIZE * 1.2 + Math.random() * 0.1;
       const pz = Math.random() * 0.1;
-      addBox(scene, cubeVBByKey[colorKey] || cubeVBByKey['無'], cubeIB, cubeInst, boxShape, [px, py, pz]);
+      addBox(scene, cubeVBByKey[colorKey] || cubeVBByKey['無'], cubeIB, cubeInst, boxShape, [px, py, pz], cubeWireVB, cubeWireIB, wireMatInstance);
     }
   }
 
@@ -385,7 +390,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -396,18 +400,18 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time.
+  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/cone/index.js
+++ b/examples/filament/havok/cone/index.js
@@ -2,19 +2,24 @@
 //
 // Many carrot-textured cones drop into a walled box and pile up, simulated by Havok and rendered
 // by Filament. The cone geometry + its textured material (texture.filamat) are built by hand; each
-// cone collides as a convex hull (apex + base ring). The four walls are collider-only wireframes.
-// Press W to toggle the collider wireframes.
+// cone collides as a convex hull (apex + base ring). The four walls are collider-only.
+//
+// Collider wireframes are rendered in the same Filament pass as LINES renderables using
+// `cube.filamat` (an unlit vertex-colour material) — no second canvas, no compositor stutter.
+// Press W to toggle them in / out of the scene.
 //
 // A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
 // (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
 
 const FILAMAT_TEX_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
+const FILAMAT_CUBE_URL = 'https://cx20.github.io/webgl-test/examples/filament/cube/cube.filamat';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 const CARROT_URL = '../../../../assets/textures/carrot.jpg';
 
 const CONE_COUNT = 200;
 const CONE_HALF_HEIGHT = 2;
 const CONE_RADIUS = 1;
+const WIREFRAME_OUTSET = 1.005;
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
@@ -27,18 +32,18 @@ const WALLS = [
   { size: [1, 10, 10], pos: [5, 5, 0] },
 ];
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+// Packed UBYTE4 colours that cube.filamat samples as the line colour.
+const COLOR_DYNAMIC = [255, 128, 51, 255];  // orange (linear-ish; cube.filamat is unlit so it's literally what we see)
+const COLOR_STATIC = [51, 255, 102, 255];   // green
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
-const cones = [];       // { entity, bodyId, curPos, curRot }
-const staticBoxes = []; // ground + walls, for the debug overlay
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null, coneLines = null;
+let scene = null;
+let showWireframe = true;
+const cones = [];                    // { entity, wireframeEntity, bodyId, curPos, curRot }
+const staticWireframeEntities = [];  // ground + walls (no per-frame sync)
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -95,11 +100,10 @@ function createConeShape() {
   return res[1];
 }
 
-// ---- Geometry ----
-// Cone visual (side + base cap), POSITION + UV0 (texture.filamat is unlit, so normals are dropped).
+// ---- Textured-cone geometry (POSITION + UV0; texture.filamat is unlit, normals dropped) ----
 function buildConeGeometry(halfHeight, radius, segments) {
   const pos = [], uv = [], idx = [];
-  pos.push(0, halfHeight, 0); uv.push(0.5, 0); // apex
+  pos.push(0, halfHeight, 0); uv.push(0.5, 0);
   for (let i = 0; i <= segments; i++) {
     const a = (i / segments) * Math.PI * 2;
     pos.push(radius * Math.cos(a), -halfHeight, radius * Math.sin(a));
@@ -107,7 +111,7 @@ function buildConeGeometry(halfHeight, radius, segments) {
   }
   for (let i = 0; i < segments; i++) idx.push(0, i + 2, i + 1);
   const capCenter = pos.length / 3;
-  pos.push(0, -halfHeight, 0); uv.push(0.5, 0.5); // base centre
+  pos.push(0, -halfHeight, 0); uv.push(0.5, 0.5);
   for (let i = 0; i <= segments; i++) {
     const a = (i / segments) * Math.PI * 2;
     pos.push(radius * Math.cos(a), -halfHeight, radius * Math.sin(a));
@@ -129,8 +133,7 @@ function makePlaneGeometry(size, tiles) {
 function buildVB(eng, positions, uvs, vertexCount) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
+    .vertexCount(vertexCount).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
     .build(eng);
@@ -148,6 +151,69 @@ function buildIB(eng, indices) {
   return ib;
 }
 
+// ---- LINES wireframes (cube.filamat: POSITION + COLOR per vertex) ----
+// Apex + base ring; the spokes and the ring loop form the cone outline.
+function buildConeLineGeometry(halfHeight, radius, segments = 16) {
+  const positions = [0, halfHeight, 0];
+  for (let i = 0; i < segments; i++) {
+    const a = (i / segments) * Math.PI * 2;
+    positions.push(radius * Math.cos(a), -halfHeight, radius * Math.sin(a));
+  }
+  const indices = [];
+  for (let i = 0; i < segments; i++) {
+    indices.push(0, 1 + i);                                // apex -> ring vertex
+    indices.push(1 + i, 1 + ((i + 1) % segments));         // ring loop edge
+  }
+  return { positions: new Float32Array(positions), indices: new Uint16Array(indices) };
+}
+
+const LINE_BOX_INDICES = new Uint16Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBoxGeometry(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  return {
+    positions: new Float32Array([
+      cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+      cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+    ]),
+    indices: LINE_BOX_INDICES,
+  };
+}
+
+function buildLineVB(eng, positions, color4) {
+  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
+  const vertexCount = positions.length / 3;
+  const vb = Filament.VertexBuffer.Builder()
+    .vertexCount(vertexCount).bufferCount(2)
+    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
+    .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
+    .normalized(VA.COLOR)
+    .build(eng);
+  vb.setBufferAt(eng, 0, positions);
+  const col = new Uint8Array(vertexCount * 4);
+  for (let i = 0; i < vertexCount; i++) {
+    col[i * 4] = color4[0]; col[i * 4 + 1] = color4[1]; col[i * 4 + 2] = color4[2]; col[i * 4 + 3] = color4[3];
+  }
+  vb.setBufferAt(eng, 1, col);
+  return vb;
+}
+
+function buildLineRenderable(vb, ib, matInstance, halfExtent) {
+  const entity = Filament.EntityManager.get().create();
+  Filament.RenderableManager.Builder(1)
+    .boundingBox({ center: [0, 0, 0], halfExtent })
+    .material(0, matInstance)
+    .geometry(0, Filament.RenderableManager$PrimitiveType.LINES, vb, ib)
+    .build(engine, entity);
+  const rm = engine.getRenderableManager();
+  const inst = rm.getInstance(entity);
+  if (inst) { rm.setCulling(inst, false); inst.delete(); }
+  return entity;
+}
+
+// ---- Physics ----
 function createStaticBox(size, pos) {
   const s = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
   const b = HK.HP_Body_Create();
@@ -156,15 +222,13 @@ function createStaticBox(size, pos) {
   HK.HP_Body_SetPosition(b[1], pos);
   HK.HP_Body_SetOrientation(b[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, b[1], false);
-  staticBoxes.push({ size, pos });
 }
 
 function randomDrop(half) {
   return [-half + Math.random() * (2 * half), 20 + Math.random() * 10, -half + Math.random() * (2 * half)];
 }
 
-// ---- Body creation (builds the matching Filament renderable) ----
-function addCone(scene, vb, ib, matInstance, shapeId, pos) {
+function addCone(coneScene, vb, ib, matInstance, shapeId, pos, wireVB, wireIB, wireMatInstance) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -181,13 +245,18 @@ function addCone(scene, vb, ib, matInstance, shapeId, pos) {
     .material(0, matInstance)
     .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
     .build(engine, entity);
-  scene.addEntity(entity);
+  coneScene.addEntity(entity);
   const rm = engine.getRenderableManager();
   const inst = rm.getInstance(entity);
   if (inst) { rm.setCulling(inst, false); inst.delete(); }
 
-  cones.push({ entity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
+  const wireframeEntity = buildLineRenderable(wireVB, wireIB, wireMatInstance, [CONE_RADIUS, CONE_HALF_HEIGHT, CONE_RADIUS]);
+  coneScene.addEntity(wireframeEntity);
+
+  cones.push({ entity, wireframeEntity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
 }
+
+let tmpMat = null, tmpQuat = null, tmpVec = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -204,124 +273,36 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(c.bodyId)[1];
     c.curPos[0] = pos[0]; c.curPos[1] = pos[1]; c.curPos[2] = pos[2];
     c.curRot[0] = r[0]; c.curRot[1] = r[1]; c.curRot[2] = r[2]; c.curRot[3] = r[3];
-    const m = mat4.fromRotationTranslation(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(pos[0], pos[1], pos[2]));
-    const inst = tcm.getInstance(c.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, pos[0], pos[1], pos[2]);
+    mat4.fromRotationTranslation(tmpMat, tmpQuat, tmpVec);
+    if (c.entity) {
+      const inst = tcm.getInstance(c.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (c.wireframeEntity) {
+      const inst = tcm.getInstance(c.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
 
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-// Cone outline: apex->base spokes + base ring loop.
-function makeConeLineVerts(halfHeight, radius, segments = 12) {
-  const apex = [0, halfHeight, 0];
-  const ring = [];
-  for (let i = 0; i < segments; i++) {
-    const a = (i / segments) * Math.PI * 2;
-    ring.push([radius * Math.cos(a), -halfHeight, radius * Math.sin(a)]);
-  }
-  const v = [];
-  for (let i = 0; i < segments; i++) {
-    const n = ring[(i + 1) % segments];
-    v.push(apex[0], apex[1], apex[2], ring[i][0], ring[i][1], ring[i][2]);
-    v.push(ring[i][0], ring[i][1], ring[i][2], n[0], n[1], n[2]);
-  }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-  coneLines = makeConeLineVerts(CONE_HALF_HEIGHT, CONE_RADIUS);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function setMVP(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground + walls (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const cubeCount = unitCubeLines.length / 3;
-  for (const sb of staticBoxes) {
-    setMVP(sb.pos, IDENTITY_QUATERNION, sb.size);
-    gl.drawArrays(gl.LINES, 0, cubeCount);
-  }
-
-  // Cones (orange, native-size outline placed at the body transform)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  gl.bufferData(gl.ARRAY_BUFFER, coneLines, gl.DYNAMIC_DRAW);
-  const coneCount = coneLines.length / 3;
-  const one = [1, 1, 1];
-  for (const c of cones) {
-    setMVP(c.curPos, c.curRot, one);
-    gl.drawArrays(gl.LINES, 0, coneCount);
-  }
-  gl.disableVertexAttribArray(aPos);
-}
-
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const c of cones) {
+    if (!c.wireframeEntity) continue;
+    if (visible) scene.addEntity(c.wireframeEntity); else scene.remove(c.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -332,17 +313,23 @@ window.addEventListener('keydown', (event) => {
 });
 
 // ---- Filament app ----
-Filament.init([FILAMAT_TEX_URL, GRASS_URL, CARROT_URL], () => {
+Filament.init([FILAMAT_TEX_URL, FILAMAT_CUBE_URL, GRASS_URL, CARROT_URL], () => {
   window.Fov = Filament.Camera$Fov;
   main().catch(e => console.error(e));
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const texMat = engine.createMaterial(FILAMAT_TEX_URL);
+  const cubeMat = engine.createMaterial(FILAMAT_CUBE_URL);
+  const wireMatInstance = cubeMat.getDefaultInstance(); // shared by every wireframe renderable
 
   // Cone material + geometry (one shared mesh + one material instance for all cones).
   const coneInst = texMat.createInstance();
@@ -352,7 +339,12 @@ async function main() {
   const coneVB = buildVB(engine, coneGeo.positions, coneGeo.uvs, coneGeo.positions.length / 3);
   const coneIB = buildIB(engine, coneGeo.indices);
 
-  // Grass ground
+  // One shared LINES cone (apex + ring) per-cone wireframe.
+  const coneWireGeo = buildConeLineGeometry(CONE_HALF_HEIGHT * WIREFRAME_OUTSET, CONE_RADIUS * WIREFRAME_OUTSET);
+  const coneWireVB = buildLineVB(engine, coneWireGeo.positions, COLOR_DYNAMIC);
+  const coneWireIB = buildIB(engine, coneWireGeo.indices);
+
+  // Grass ground (textured, unlit) — visible part of the ground.
   const repeat = new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.REPEAT);
   const groundInst = texMat.createInstance();
   groundInst.setTextureParameter('texture', engine.createTextureFromJpeg(GRASS_URL, { nomips: true }), repeat);
@@ -368,15 +360,14 @@ async function main() {
   view.setScene(scene);
   renderer.setClearOptions({ clearColor: [0.13, 0.14, 0.16, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
   checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
 
-  // Ground collider + grass renderable; four wall colliders (wireframe-only).
+  // Ground collider + grass renderable; four wall colliders. Each static body also gets a LINES
+  // wireframe renderable (size + position baked into its VB so no transform sync is needed).
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
 
@@ -397,9 +388,20 @@ async function main() {
     if (ri) { rm.setCulling(ri, false); ri.delete(); }
   }
 
+  // One static-wire renderable per static box (size + position baked).
+  for (const def of [{ size: GROUND.size, pos: GROUND.pos }, ...WALLS]) {
+    const hx = def.size[0] / 2 * WIREFRAME_OUTSET, hy = def.size[1] / 2 * WIREFRAME_OUTSET, hz = def.size[2] / 2 * WIREFRAME_OUTSET;
+    const g = buildLineBoxGeometry(hx, hy, hz, def.pos[0], def.pos[1], def.pos[2]);
+    const vb = buildLineVB(engine, g.positions, COLOR_STATIC);
+    const ib = buildIB(engine, g.indices);
+    const entity = buildLineRenderable(vb, ib, wireMatInstance, [hx, hy, hz]);
+    scene.addEntity(entity);
+    staticWireframeEntities.push(entity);
+  }
+
   const coneShape = createConeShape();
   for (let i = 0; i < CONE_COUNT; i++) {
-    addCone(scene, coneVB, coneIB, coneInst, coneShape, randomDrop(3.5));
+    addCone(scene, coneVB, coneIB, coneInst, coneShape, randomDrop(3.5), coneWireVB, coneWireIB, wireMatInstance);
   }
 
   const center = [0, 2, 0];
@@ -411,7 +413,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -422,18 +423,19 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
+  const ORBIT_SPEED = 0.24; // rad/s
+  const ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/domino/index.js
+++ b/examples/filament/havok/domino/index.js
@@ -3,14 +3,15 @@
 // A 16x16 grid of coloured dominoes (a bitmap picture) is knocked over by a row of balls,
 // simulated by Havok and rendered by Filament. Geometry (cube + sphere) and materials are built
 // by hand in Filament: the compiled `texture.filamat` (unlit textured material) is reused with a
-// tiny 1x1 solid-colour texture per domino colour, so every domino samples a flat colour. Press W
-// to toggle the collider wireframes.
+// tiny 1x1 solid-colour texture per domino colour, so every domino samples a flat colour.
+//
+// Collider wireframes are rendered in the same Filament pass as LINES renderables using
+// `cube.filamat` (an unlit vertex-colour material) — no second canvas, no compositor stutter.
+// Press W to toggle them in / out of the scene.
 //
 // A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
 // (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
 
-// cube.filamat = vertex-colour unlit material (for dominoes); texture.filamat = textured unlit
-// material (for the football). Both target the dev Filament build (see index.html).
 const FILAMAT_CUBE_URL = 'https://cx20.github.io/webgl-test/examples/filament/cube/cube.filamat';
 const FILAMAT_TEX_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
 const FOOTBALL_URL = '../../../../assets/textures/football.png';
@@ -55,18 +56,19 @@ const DOMINO_H = BOX_SIZE * 1.5;
 const DOMINO_D = BOX_SIZE * 1.0;
 const BALL_RADIUS = BOX_SIZE / 2;
 const GROUND = { size: [100, 0.2, 100], pos: [0, 0, 0] };
+const WIREFRAME_OUTSET = 1.005;
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [255, 128, 51, 255];
+const COLOR_STATIC = [51, 255, 102, 255];
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
-const bodies = []; // { entity, bodyId, scale:[x,y,z], kind:'box'|'sphere', curPos, curRot }
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null, unitSphereLines = null;
+let scene = null;
+let showWireframe = true;
+const bodies = []; // { entity, wireframeEntity, bodyId, scale, kind, curPos, curRot }
+const staticWireframeEntities = [];
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -118,13 +120,10 @@ function makeSphereGeometry(segments, rings) {
   return { positions: new Float32Array(pos), uvs: new Float32Array(uv), indices: new Uint16Array(idx) };
 }
 
-// ---- Filament geometry helpers ----
-// Cube vertex buffer with a flat per-vertex COLOR (cube.filamat uses getColor() as baseColor).
 function buildColorCubeVB(eng, rgb) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(24)
-    .bufferCount(2)
+    .vertexCount(24).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
     .normalized(VA.COLOR)
@@ -137,7 +136,6 @@ function buildColorCubeVB(eng, rgb) {
   return vb;
 }
 
-// Flat ground quad (XZ plane) at y=0 with tiled UVs.
 function makePlaneGeometry(size, tiles) {
   const h = size / 2;
   return {
@@ -147,12 +145,10 @@ function makePlaneGeometry(size, tiles) {
   };
 }
 
-// Vertex buffer with POSITION + UV0 (texture.filamat needs uv0) — used for the football sphere.
 function buildVB(eng, positions, uvs, vertexCount) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
+    .vertexCount(vertexCount).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
     .build(eng);
@@ -170,8 +166,70 @@ function buildIB(eng, indices) {
   return ib;
 }
 
-// ---- Physics body creation (also builds the matching Filament renderable) ----
-function addBody(scene, vb, ib, halfExtentBox, matInstance, shapeId, motionType, scale, pos, rot, kind) {
+// ---- LINES wireframes (cube.filamat: POSITION + COLOR per vertex) ----
+const LINE_BOX_INDICES = new Uint16Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBoxPositions(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  return new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+}
+
+function buildSphereLineGeometry(radius, segments = 16) {
+  const positions = [];
+  for (let plane = 0; plane < 3; plane++) {
+    for (let i = 0; i < segments; i++) {
+      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
+      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius;
+      const c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
+      if (plane === 0)      positions.push(c0, s0, 0, c1, s1, 0);
+      else if (plane === 1) positions.push(c0, 0, s0, c1, 0, s1);
+      else                  positions.push(0, c0, s0, 0, c1, s1);
+    }
+  }
+  const positionArr = new Float32Array(positions);
+  const indices = new Uint16Array(positionArr.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return { positions: positionArr, indices };
+}
+
+function buildLineVB(eng, positions, color4) {
+  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
+  const vertexCount = positions.length / 3;
+  const vb = Filament.VertexBuffer.Builder()
+    .vertexCount(vertexCount).bufferCount(2)
+    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
+    .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
+    .normalized(VA.COLOR)
+    .build(eng);
+  vb.setBufferAt(eng, 0, positions);
+  const col = new Uint8Array(vertexCount * 4);
+  for (let i = 0; i < vertexCount; i++) {
+    col[i * 4] = color4[0]; col[i * 4 + 1] = color4[1]; col[i * 4 + 2] = color4[2]; col[i * 4 + 3] = color4[3];
+  }
+  vb.setBufferAt(eng, 1, col);
+  return vb;
+}
+
+function buildLineRenderable(vb, ib, matInstance, halfExtent) {
+  const entity = Filament.EntityManager.get().create();
+  Filament.RenderableManager.Builder(1)
+    .boundingBox({ center: [0, 0, 0], halfExtent })
+    .material(0, matInstance)
+    .geometry(0, Filament.RenderableManager$PrimitiveType.LINES, vb, ib)
+    .build(engine, entity);
+  const rm = engine.getRenderableManager();
+  const inst = rm.getInstance(entity);
+  if (inst) { rm.setCulling(inst, false); inst.delete(); }
+  return entity;
+}
+
+// ---- Body creation (PBR + wireframe) ----
+function addBody(dynScene, vb, ib, halfExtentBox, matInstance, shapeId, motionType, scale, pos, rot, kind, wireVB, wireIB, wireMatInstance) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -190,13 +248,21 @@ function addBody(scene, vb, ib, halfExtentBox, matInstance, shapeId, motionType,
     .material(0, matInstance)
     .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
     .build(engine, entity);
-  scene.addEntity(entity);
+  dynScene.addEntity(entity);
   const rm = engine.getRenderableManager();
   const inst = rm.getInstance(entity);
   if (inst) { rm.setCulling(inst, false); inst.delete(); }
 
-  bodies.push({ entity, bodyId, scale, kind, curPos: pos.slice(), curRot: rot.slice() });
+  let wireframeEntity = null;
+  if (wireVB && wireIB) {
+    wireframeEntity = buildLineRenderable(wireVB, wireIB, wireMatInstance, halfExtentBox);
+    dynScene.addEntity(wireframeEntity);
+  }
+
+  bodies.push({ entity, wireframeEntity, bodyId, scale, kind, curPos: pos.slice(), curRot: rot.slice() });
 }
+
+let tmpMat = null, tmpQuat = null, tmpVec = null, tmpScale = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -207,121 +273,23 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(b.bodyId)[1];
     b.curPos[0] = p[0]; b.curPos[1] = p[1]; b.curPos[2] = p[2];
     b.curRot[0] = r[0]; b.curRot[1] = r[1]; b.curRot[2] = r[2]; b.curRot[3] = r[3];
-    const m = mat4.fromRotationTranslationScale(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]), vec3.fromValues(b.scale[0], b.scale[1], b.scale[2]));
-    const inst = tcm.getInstance(b.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
-  }
-  tcm.commitLocalTransformTransaction();
-}
-
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function makeSphereLineVerts(radius, segments = 12) {
-  const v = [];
-  for (let c = 0; c < 3; c++) {
-    for (let i = 0; i < segments; i++) {
-      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
-      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius, c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
-      if (c === 0) v.push(c0, s0, 0, c1, s1, 0);
-      else if (c === 1) v.push(c0, 0, s0, c1, 0, s1);
-      else v.push(0, c0, s0, 0, c1, s1);
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, p[0], p[1], p[2]);
+    vec3.set(tmpScale, b.scale[0], b.scale[1], b.scale[2]);
+    mat4.fromRotationTranslationScale(tmpMat, tmpQuat, tmpVec, tmpScale);
+    if (b.entity) {
+      const inst = tcm.getInstance(b.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (b.wireframeEntity) {
+      // Wireframe shares the same unit-shape VB as the PBR mesh, so the same scaled transform fits.
+      const inst = tcm.getInstance(b.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
     }
   }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-  unitSphereLines = makeSphereLineVerts(1);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function drawScaled(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  drawScaled(GROUND.pos, IDENTITY_QUATERNION, GROUND.size);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  gl.drawArrays(gl.LINES, 0, unitCubeLines.length / 3);
-
-  // Dominoes (orange boxes)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  const cubeCount = unitCubeLines.length / 3;
-  for (const b of bodies) {
-    if (b.kind !== 'box') continue;
-    drawScaled(b.curPos, b.curRot, b.scale);
-    gl.drawArrays(gl.LINES, 0, cubeCount);
-  }
-
-  // Balls (orange spheres)
-  gl.bufferData(gl.ARRAY_BUFFER, unitSphereLines, gl.DYNAMIC_DRAW);
-  const sphCount = unitSphereLines.length / 3;
-  for (const b of bodies) {
-    if (b.kind !== 'sphere') continue;
-    drawScaled(b.curPos, b.curRot, b.scale);
-    gl.drawArrays(gl.LINES, 0, sphCount);
-  }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
 }
 
 // ---- W-key wireframe toggle ----
@@ -329,6 +297,14 @@ function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const b of bodies) {
+    if (!b.wireframeEntity) continue;
+    if (visible) scene.addEntity(b.wireframeEntity); else scene.remove(b.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -345,17 +321,30 @@ Filament.init([FILAMAT_CUBE_URL, FILAMAT_TEX_URL, FOOTBALL_URL, GRASS_URL], () =
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+  tmpScale = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
-  // Dominoes: one vertex-colour material (cube.filamat) shared by all, with a per-colour cube
-  // vertex buffer carrying that colour.
+  // Dominoes: one vertex-colour material (cube.filamat) shared by all, with a per-colour cube VB.
   const cubeMat = engine.createMaterial(FILAMAT_CUBE_URL);
   const cubeInst = cubeMat.getDefaultInstance();
+  const wireMatInstance = cubeInst; // cube.filamat just samples vertex colour
   const cubeVBByKey = {};
   for (const [key, rgb] of Object.entries(colorHash)) cubeVBByKey[key] = buildColorCubeVB(engine, rgb);
   const cubeIB = buildIB(engine, CUBE_INDICES);
+
+  // Unit-size LINES box + sphere wireframes (sized to the unit shape; per-body scale takes care of
+  // the actual domino / ball dimensions in the sync). Outset to avoid z-fighting with PBR.
+  const cubeWireVB = buildLineVB(engine, buildLineBoxPositions(0.5 * WIREFRAME_OUTSET, 0.5 * WIREFRAME_OUTSET, 0.5 * WIREFRAME_OUTSET), COLOR_DYNAMIC);
+  const cubeWireIB = buildIB(engine, LINE_BOX_INDICES);
+  const sphereWireGeo = buildSphereLineGeometry(WIREFRAME_OUTSET);
+  const sphereWireVB = buildLineVB(engine, sphereWireGeo.positions, COLOR_DYNAMIC);
+  const sphereWireIB = buildIB(engine, sphereWireGeo.indices);
 
   // Balls: football-textured sphere (texture.filamat).
   const texMat = engine.createMaterial(FILAMAT_TEX_URL);
@@ -398,15 +387,13 @@ async function main() {
   view.setScene(scene);
   renderer.setClearOptions({ clearColor: [0.1, 0.1, 0.15, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
   checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
 
-  // Ground (static box). Not rendered by Filament (shown as the green collider wireframe).
+  // Ground (static box). Not rendered by Filament as PBR — only as the green collider wireframe.
   const gs = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, GROUND.size);
   const gb = HK.HP_Body_Create();
   HK.HP_Body_SetShape(gb[1], gs[1]);
@@ -414,6 +401,16 @@ async function main() {
   HK.HP_Body_SetPosition(gb[1], GROUND.pos);
   HK.HP_Body_SetOrientation(gb[1], IDENTITY_QUATERNION);
   HK.HP_World_AddBody(worldId, gb[1], false);
+
+  // Ground LINES wireframe (size + position baked).
+  {
+    const ghx = GROUND.size[0] / 2 * WIREFRAME_OUTSET, ghy = GROUND.size[1] / 2 * WIREFRAME_OUTSET, ghz = GROUND.size[2] / 2 * WIREFRAME_OUTSET;
+    const vb = buildLineVB(engine, buildLineBoxPositions(ghx, ghy, ghz, GROUND.pos[0], GROUND.pos[1], GROUND.pos[2]), COLOR_STATIC);
+    const ib = buildIB(engine, LINE_BOX_INDICES);
+    const entity = buildLineRenderable(vb, ib, wireMatInstance, [ghx, ghy, ghz]);
+    scene.addEntity(entity);
+    staticWireframeEntities.push(entity);
+  }
 
   // Shared shapes
   const dominoShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [DOMINO_W, DOMINO_H, DOMINO_D])[1];
@@ -429,7 +426,8 @@ async function main() {
       const y = BOX_SIZE;
       const z = -8 * BOX_SIZE + row * BOX_SIZE * 1.2;
       addBody(scene, cubeVBByKey[colorKey] || cubeVBByKey['無'], cubeIB, [0.5, 0.5, 0.5], cubeInst,
-        dominoShape, HK.MotionType.DYNAMIC, dominoScale, [x, y, z], IDENTITY_QUATERNION, 'box');
+        dominoShape, HK.MotionType.DYNAMIC, dominoScale, [x, y, z], IDENTITY_QUATERNION, 'box',
+        cubeWireVB, cubeWireIB, wireMatInstance);
     }
   }
 
@@ -439,7 +437,8 @@ async function main() {
     const y = 8;
     const z = -8 * BOX_SIZE + (15 - i) * BOX_SIZE * 1.2;
     addBody(scene, sphereVB, sphereIB, [1, 1, 1], ballInst,
-      ballShape, HK.MotionType.DYNAMIC, ballScale, [x, y, z], IDENTITY_QUATERNION, 'sphere');
+      ballShape, HK.MotionType.DYNAMIC, ballScale, [x, y, z], IDENTITY_QUATERNION, 'sphere',
+      sphereWireVB, sphereWireIB, wireMatInstance);
   }
 
   const center = [0, 2, 0];
@@ -451,7 +450,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -462,18 +460,18 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time.
+  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/football/index.js
+++ b/examples/filament/havok/football/index.js
@@ -3,13 +3,17 @@
 // 256 balls (a 16x16 bitmap picture) fall and pile up, simulated by Havok and rendered by Filament.
 // Each ball is a sphere textured with the football image tinted by its picture colour. The provided
 // texture.filamat can't multiply texture * colour, so a per-colour "tinted football" texture is
-// baked at load time on a canvas (football.png x colour) and bound to a material instance. Press W
-// to toggle the collider wireframes.
+// baked at load time on a canvas (football.png x colour) and bound to a material instance.
+//
+// Collider wireframes are rendered in the same Filament pass as LINES renderables using
+// `cube.filamat` (an unlit vertex-colour material) — no second canvas, no compositor stutter.
+// Press W to toggle them in / out of the scene.
 //
 // A compiled .filamat is tied to a Filament version, so this sample uses the matching `dev` build
 // (see index.html). Libraries are globals: Filament, HavokPhysics, gl-matrix.
 
 const FILAMAT_TEX_URL = 'https://cx20.github.io/webgl-test/examples/filament/texture/texture.filamat';
+const FILAMAT_CUBE_URL = 'https://cx20.github.io/webgl-test/examples/filament/cube/cube.filamat';
 const FOOTBALL_URL = '../../../../assets/textures/football.png';
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 
@@ -50,21 +54,20 @@ const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const BALL_SIZE = 1;
 const BALL_RADIUS = BALL_SIZE / 2;
 const RESET_Y_THRESHOLD = -10;
-// The balls drop across x = -10..+12.5, so the ground is enlarged to catch all of them (matching
-// the Babylon.js sample, which uses a ground much larger than the ball spread).
 const GROUND = { size: [40, 0.4, 40], pos: [0, 0, 0] };
+const WIREFRAME_OUTSET = 1.005;
 
-const DEBUG_COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
-const DEBUG_COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
+const COLOR_DYNAMIC = [255, 128, 51, 255];
+const COLOR_STATIC = [51, 255, 102, 255];
 
 let HK = null;
 let worldId = null;
 
 let engine = null;
-const balls = []; // { entity, bodyId, curPos, curRot }
-
-let debugCanvas = null, debugGl = null, debugProg = null, debugVbo = null, showWireframe = true;
-let unitCubeLines = null, unitSphereLines = null;
+let scene = null;
+let showWireframe = true;
+const balls = [];                    // { entity, wireframeEntity, bodyId, curPos, curRot }
+const staticWireframeEntities = [];
 
 // ---- Havok helpers ----
 function enumToNumber(value) {
@@ -115,8 +118,7 @@ function makePlaneGeometry(size, tiles) {
 function buildVB(eng, positions, uvs, vertexCount) {
   const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
   const vb = Filament.VertexBuffer.Builder()
-    .vertexCount(vertexCount)
-    .bufferCount(2)
+    .vertexCount(vertexCount).bufferCount(2)
     .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
     .attribute(VA.UV0, 1, AT.FLOAT2, 0, 0)
     .build(eng);
@@ -134,7 +136,6 @@ function buildIB(eng, indices) {
   return ib;
 }
 
-// Bake football.png x colour into a texture (texture.filamat samples it directly, no tint param).
 function tintedFootballTexture(eng, img, rgb) {
   const cv = document.createElement('canvas');
   cv.width = img.naturalWidth || img.width;
@@ -144,7 +145,7 @@ function tintedFootballTexture(eng, img, rgb) {
   ctx.globalCompositeOperation = 'multiply';
   ctx.fillStyle = `rgb(${Math.round(rgb[0] * 255)},${Math.round(rgb[1] * 255)},${Math.round(rgb[2] * 255)})`;
   ctx.fillRect(0, 0, cv.width, cv.height);
-  ctx.globalCompositeOperation = 'destination-in'; // restore the football's own alpha
+  ctx.globalCompositeOperation = 'destination-in';
   ctx.drawImage(img, 0, 0);
   ctx.globalCompositeOperation = 'source-over';
   const b64 = cv.toDataURL('image/png').split(',')[1];
@@ -163,8 +164,70 @@ function loadImage(url) {
   });
 }
 
-// ---- Body creation (builds the matching Filament renderable) ----
-function addBall(scene, vb, ib, matInstance, shapeId, pos) {
+// ---- LINES wireframes (cube.filamat: POSITION + COLOR per vertex) ----
+const LINE_BOX_INDICES = new Uint16Array([
+  0, 1, 1, 2, 2, 3, 3, 0,
+  4, 5, 5, 6, 6, 7, 7, 4,
+  0, 4, 1, 5, 2, 6, 3, 7,
+]);
+function buildLineBoxPositions(hx, hy, hz, cx = 0, cy = 0, cz = 0) {
+  return new Float32Array([
+    cx - hx, cy - hy, cz - hz,  cx + hx, cy - hy, cz - hz,  cx + hx, cy + hy, cz - hz,  cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,  cx + hx, cy - hy, cz + hz,  cx + hx, cy + hy, cz + hz,  cx - hx, cy + hy, cz + hz,
+  ]);
+}
+
+function buildSphereLineGeometry(radius, segments = 16) {
+  const positions = [];
+  for (let plane = 0; plane < 3; plane++) {
+    for (let i = 0; i < segments; i++) {
+      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
+      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius;
+      const c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
+      if (plane === 0)      positions.push(c0, s0, 0, c1, s1, 0);
+      else if (plane === 1) positions.push(c0, 0, s0, c1, 0, s1);
+      else                  positions.push(0, c0, s0, 0, c1, s1);
+    }
+  }
+  const positionArr = new Float32Array(positions);
+  const indices = new Uint16Array(positionArr.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return { positions: positionArr, indices };
+}
+
+function buildLineVB(eng, positions, color4) {
+  const VA = Filament.VertexAttribute, AT = Filament.VertexBuffer$AttributeType;
+  const vertexCount = positions.length / 3;
+  const vb = Filament.VertexBuffer.Builder()
+    .vertexCount(vertexCount).bufferCount(2)
+    .attribute(VA.POSITION, 0, AT.FLOAT3, 0, 0)
+    .attribute(VA.COLOR, 1, AT.UBYTE4, 0, 0)
+    .normalized(VA.COLOR)
+    .build(eng);
+  vb.setBufferAt(eng, 0, positions);
+  const col = new Uint8Array(vertexCount * 4);
+  for (let i = 0; i < vertexCount; i++) {
+    col[i * 4] = color4[0]; col[i * 4 + 1] = color4[1]; col[i * 4 + 2] = color4[2]; col[i * 4 + 3] = color4[3];
+  }
+  vb.setBufferAt(eng, 1, col);
+  return vb;
+}
+
+function buildLineRenderable(vb, ib, matInstance, halfExtent) {
+  const entity = Filament.EntityManager.get().create();
+  Filament.RenderableManager.Builder(1)
+    .boundingBox({ center: [0, 0, 0], halfExtent })
+    .material(0, matInstance)
+    .geometry(0, Filament.RenderableManager$PrimitiveType.LINES, vb, ib)
+    .build(engine, entity);
+  const rm = engine.getRenderableManager();
+  const inst = rm.getInstance(entity);
+  if (inst) { rm.setCulling(inst, false); inst.delete(); }
+  return entity;
+}
+
+// ---- Body creation (PBR + wireframe) ----
+function addBall(ballScene, vb, ib, matInstance, shapeId, pos, wireVB, wireIB, wireMatInstance) {
   const cb = HK.HP_Body_Create();
   const bodyId = cb[1];
   HK.HP_Body_SetShape(bodyId, shapeId);
@@ -181,17 +244,22 @@ function addBall(scene, vb, ib, matInstance, shapeId, pos) {
     .material(0, matInstance)
     .geometry(0, Filament.RenderableManager$PrimitiveType.TRIANGLES, vb, ib)
     .build(engine, entity);
-  scene.addEntity(entity);
+  ballScene.addEntity(entity);
   const rm = engine.getRenderableManager();
   const inst = rm.getInstance(entity);
   if (inst) { rm.setCulling(inst, false); inst.delete(); }
 
-  balls.push({ entity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
+  const wireframeEntity = buildLineRenderable(wireVB, wireIB, wireMatInstance, [BALL_RADIUS, BALL_RADIUS, BALL_RADIUS]);
+  ballScene.addEntity(wireframeEntity);
+
+  balls.push({ entity, wireframeEntity, bodyId, curPos: pos.slice(), curRot: [0, 0, 0, 1] });
 }
 
 function randomRespawn() {
   return [-5 + Math.random() * 10, 20 + Math.random() * 10, -5 + Math.random() * 10];
 }
+
+let tmpMat = null, tmpQuat = null, tmpVec = null, tmpScale = null;
 
 function stepAndSync() {
   checkResult(HK.HP_World_Step(worldId, FIXED_TIMESTEP), 'HP_World_Step');
@@ -208,112 +276,23 @@ function stepAndSync() {
     const r = HK.HP_Body_GetOrientation(b.bodyId)[1];
     b.curPos[0] = p[0]; b.curPos[1] = p[1]; b.curPos[2] = p[2];
     b.curRot[0] = r[0]; b.curRot[1] = r[1]; b.curRot[2] = r[2]; b.curRot[3] = r[3];
-    const m = mat4.fromRotationTranslationScale(
-      mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]), vec3.fromValues(BALL_RADIUS, BALL_RADIUS, BALL_RADIUS));
-    const inst = tcm.getInstance(b.entity);
-    tcm.setTransform(inst, m);
-    inst.delete();
-  }
-  tcm.commitLocalTransformTransaction();
-}
-
-// ---- Debug wireframe overlay ----
-function makeBoxLineVerts(sx, sy, sz) {
-  const hx = sx / 2, hy = sy / 2, hz = sz / 2;
-  const c = [[-hx, -hy, -hz], [hx, -hy, -hz], [hx, hy, -hz], [-hx, hy, -hz], [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz]];
-  const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-  const v = [];
-  for (const [a, b] of edges) v.push(...c[a], ...c[b]);
-  return new Float32Array(v);
-}
-
-function makeSphereLineVerts(radius, segments = 12) {
-  const v = [];
-  for (let c = 0; c < 3; c++) {
-    for (let i = 0; i < segments; i++) {
-      const a0 = (i / segments) * Math.PI * 2, a1 = ((i + 1) / segments) * Math.PI * 2;
-      const c0 = Math.cos(a0) * radius, s0 = Math.sin(a0) * radius, c1 = Math.cos(a1) * radius, s1 = Math.sin(a1) * radius;
-      if (c === 0) v.push(c0, s0, 0, c1, s1, 0);
-      else if (c === 1) v.push(c0, 0, s0, c1, 0, s1);
-      else v.push(0, c0, s0, 0, c1, s1);
+    quat.set(tmpQuat, r[0], r[1], r[2], r[3]);
+    vec3.set(tmpVec, p[0], p[1], p[2]);
+    vec3.set(tmpScale, BALL_RADIUS, BALL_RADIUS, BALL_RADIUS);
+    mat4.fromRotationTranslationScale(tmpMat, tmpQuat, tmpVec, tmpScale);
+    if (b.entity) {
+      const inst = tcm.getInstance(b.entity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
+    }
+    if (b.wireframeEntity) {
+      // Sphere wire is a unit sphere too, so the same scaled transform applies.
+      const inst = tcm.getInstance(b.wireframeEntity);
+      tcm.setTransform(inst, tmpMat);
+      inst.delete();
     }
   }
-  return new Float32Array(v);
-}
-
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
-  unitCubeLines = makeBoxLineVerts(1, 1, 1);
-  unitSphereLines = makeSphereLineVerts(1);
-}
-
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const viewM = mat4.lookAt(mat4.create(), eye, center, up);
-  const projM = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), projM, viewM);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  const model = mat4.create(), mvp = mat4.create(), sq = quat.create(), sp = vec3.create(), ss = vec3.create();
-  function drawScaled(p, r, scale) {
-    quat.set(sq, r[0], r[1], r[2], r[3]);
-    vec3.set(sp, p[0], p[1], p[2]);
-    vec3.set(ss, scale[0], scale[1], scale[2]);
-    mat4.fromRotationTranslationScale(model, sq, sp, ss);
-    mat4.multiply(mvp, vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-  }
-
-  // Ground (static, green)
-  gl.uniform4fv(uColor, DEBUG_COLOR_STATIC);
-  drawScaled(GROUND.pos, IDENTITY_QUATERNION, GROUND.size);
-  gl.bufferData(gl.ARRAY_BUFFER, unitCubeLines, gl.DYNAMIC_DRAW);
-  gl.drawArrays(gl.LINES, 0, unitCubeLines.length / 3);
-
-  // Balls (orange spheres)
-  gl.uniform4fv(uColor, DEBUG_COLOR_DYNAMIC);
-  gl.bufferData(gl.ARRAY_BUFFER, unitSphereLines, gl.DYNAMIC_DRAW);
-  const sphCount = unitSphereLines.length / 3;
-  const ballScale = [BALL_RADIUS, BALL_RADIUS, BALL_RADIUS];
-  for (const b of balls) {
-    drawScaled(b.curPos, b.curRot, ballScale);
-    gl.drawArrays(gl.LINES, 0, sphCount);
-  }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
 }
 
 // ---- W-key wireframe toggle ----
@@ -321,6 +300,14 @@ function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const b of balls) {
+    if (!b.wireframeEntity) continue;
+    if (visible) scene.addEntity(b.wireframeEntity); else scene.remove(b.wireframeEntity);
+  }
+  for (const e of staticWireframeEntities) {
+    if (visible) scene.addEntity(e); else scene.remove(e);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -331,18 +318,30 @@ window.addEventListener('keydown', (event) => {
 });
 
 // ---- Filament app ----
-Filament.init([FILAMAT_TEX_URL, GRASS_URL], () => {
+Filament.init([FILAMAT_TEX_URL, FILAMAT_CUBE_URL, GRASS_URL], () => {
   window.Fov = Filament.Camera$Fov;
   main().catch(e => console.error(e));
 });
 
 async function main() {
+  tmpMat = mat4.create();
+  tmpQuat = quat.create();
+  tmpVec = vec3.create();
+  tmpScale = vec3.create();
+
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const texMat = engine.createMaterial(FILAMAT_TEX_URL);
+  const cubeMat = engine.createMaterial(FILAMAT_CUBE_URL);
+  const wireMatInstance = cubeMat.getDefaultInstance();
   const linear = new Filament.TextureSampler(Filament.MinFilter.LINEAR, Filament.MagFilter.LINEAR, Filament.WrapMode.REPEAT);
+
+  // Unit sphere wireframe shared by all balls (radius=outset; per-body scale = BALL_RADIUS).
+  const sphereWireGeo = buildSphereLineGeometry(WIREFRAME_OUTSET);
+  const sphereWireVB = buildLineVB(engine, sphereWireGeo.positions, COLOR_DYNAMIC);
+  const sphereWireIB = buildIB(engine, sphereWireGeo.indices);
 
   // Per-colour football material instances (football.png x colour).
   const footballImg = await loadImage(FOOTBALL_URL);
@@ -371,8 +370,6 @@ async function main() {
   view.setCamera(camera);
   view.setScene(scene);
   renderer.setClearOptions({ clearColor: [0.1, 0.1, 0.15, 1.0], clear: true });
-
-  initDebugCanvas(canvas);
 
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
@@ -406,6 +403,16 @@ async function main() {
     if (ri) { rm.setCulling(ri, false); ri.delete(); }
   }
 
+  // Ground LINES wireframe (size + position baked).
+  {
+    const ghx = GROUND.size[0] / 2 * WIREFRAME_OUTSET, ghy = GROUND.size[1] / 2 * WIREFRAME_OUTSET, ghz = GROUND.size[2] / 2 * WIREFRAME_OUTSET;
+    const vb = buildLineVB(engine, buildLineBoxPositions(ghx, ghy, ghz, GROUND.pos[0], GROUND.pos[1], GROUND.pos[2]), COLOR_STATIC);
+    const ib = buildIB(engine, LINE_BOX_INDICES);
+    const entity = buildLineRenderable(vb, ib, wireMatInstance, [ghx, ghy, ghz]);
+    scene.addEntity(entity);
+    staticWireframeEntities.push(entity);
+  }
+
   const ballShape = HK.HP_Shape_CreateSphere([0, 0, 0], BALL_RADIUS)[1];
 
   // 16x16 balls forming the picture.
@@ -415,7 +422,7 @@ async function main() {
       const px = -10 + x * BALL_SIZE * 1.5 + Math.random() * 0.1;
       const py = (15 - y) * BALL_SIZE * 1.2 + 2 + Math.random() * 0.1;
       const pz = Math.random() * 0.1;
-      addBall(scene, sphereVB, sphereIB, ballInstByKey[colorKey] || ballInstByKey['無'], ballShape, [px, py, pz]);
+      addBall(scene, sphereVB, sphereIB, ballInstByKey[colorKey] || ballInstByKey['無'], ballShape, [px, py, pz], sphereWireVB, sphereWireIB, wireMatInstance);
     }
   }
 
@@ -428,7 +435,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -439,18 +445,18 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.5;
-  function render() {
+  // Camera orbit driven directly by wall time.
+  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
+  function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    angle += 0.004;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }


### PR DESCRIPTION
## Summary

Group C of the single-canvas refactor: the four `.filamat`-based Filament + Havok samples (`box`, `cone`, `domino`, `football`). These run on the dev Filament build and can't use gltfio + `KHR_materials_unlit` like Group A did, so the wireframes go through **Filament's own `RenderableManager`** with `PrimitiveType.LINES` and `cube.filamat` (the existing unlit vertex-colour material) instead. Either way the result is: one canvas, one render pass, no compositor stutter.

Camera orbit is also switched to a pure function of wall time (rAF timestamp).

## Per-sample summary

| Sample | Wireframe added |
|---|---|
| cone | 200 dynamic cones (apex + ring outline) + ground + 4 walls (size + position baked) |
| box | 256 dynamic cubes (shared unit-cube LINES VB, scaled per body) + ground (baked) |
| domino | 256 dynamic dominoes (shared unit-cube) + 16 balls (shared unit-sphere) + ground |
| football | 256 dynamic balls (shared unit-sphere LINES VB) + ground |

- Wireframe colour is baked into the vertex buffer as UBYTE4 (orange dynamic, green static).
- Wireframes are outset by ~0.5% so they don't z-fight with the textured surface.
- Each dynamic body's wireframe is synced alongside its main entity in `stepAndSync`.
- `box` and `football` start loading `cube.filamat` (the wireframe material) in addition to `texture.filamat`; `cone` and `domino` already loaded it.

## Verification

`node --check` passes on all four. **In-browser smoothness still needs your visual check** — particularly that the wireframes show up as expected when W is on, and the orbit is smooth.

## Remaining work

Group B (`gltf`, `marbles`, the six `gltf_physics_*` samples) is the next planned PR — those load external glTF assets and the wireframes will be added via a secondary in-code wireframe GLB loaded alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)