### PR TITLE
Filament + Havok: single-canvas + closer camera for gltf_physics_* (Group B-2a)

### DIFF
--- a/examples/filament/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/filament/havok/gltf_physics_Materials_Friction/index.js
@@ -4,8 +4,9 @@
 // simulates it with Havok, driven by the KHR_physics_rigid_bodies / KHR_implicit_shapes
 // extensions embedded in the GLB (box colliders with per-collider friction materials).
 //
-// Filament cannot easily draw line wireframes, so the collider debug view is rendered on a
-// separate transparent WebGL2 canvas overlaid on top, using the same camera. Press W to toggle it.
+// Collider wireframes are loaded as a second gltfio asset built in-code (LINES primitives with
+// KHR_materials_unlit), so they render in the same Filament pass as the model — no second canvas,
+// no compositor stutter. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, and gl-matrix
 // (vec3 / quat / mat4).
@@ -26,21 +27,17 @@ let worldId = null;
 
 // Filament objects
 let engine = null;
+let scene = null;
 let asset = null;
 
-// Physics <-> Filament bookkeeping
-const physicsNodes = [];   // dynamic bodies: { entity, bodyId, nodeScale, initPos, initRot, parentInvWorldMat, size }
-const staticBodies = [];   // static bodies:  { bodyId, size }
+// Physics <-> Filament bookkeeping; wireframeEntity is filled in by loadWireframeAsset().
+const physicsNodes = [];   // dynamic bodies: { entity, bodyId, nodeScale, initPos, initRot, parentInvWorldMat, size, wireframeEntity }
+const staticBodies = [];   // static bodies:  { bodyId, size, wireframeEntity }
 
 // Camera framing (computed from collider bounds)
 const sceneMin = [Infinity, Infinity, Infinity];
 const sceneMax = [-Infinity, -Infinity, -Infinity];
 
-// Debug overlay
-let debugCanvas = null;
-let debugGl = null;
-let debugProg = null;
-let debugVbo = null;
 let showWireframe = true;
 
 // ---- Havok helpers ----
@@ -304,20 +301,28 @@ function physicsStep() {
   const tcm = engine.getTransformManager();
   tcm.openLocalTransformTransaction();
   for (const entry of physicsNodes) {
-    if (!entry.entity) continue;
     const pr = HK.HP_Body_GetPosition(entry.bodyId);
     const qr = HK.HP_Body_GetOrientation(entry.bodyId);
     const p = pr[1], r = qr[1];
-    const physWorld = mat4.fromRotationTranslationScale(
-      mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]),
-      vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
-    );
-    const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
-    const inst = tcm.getInstance(entry.entity);
-    tcm.setTransform(inst, localMat);
-    inst.delete();
+    if (entry.entity) {
+      const physWorld = mat4.fromRotationTranslationScale(
+        mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]),
+        vec3.fromValues(p[0], p[1], p[2]),
+        vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
+      );
+      const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
+      const inst = tcm.getInstance(entry.entity);
+      tcm.setTransform(inst, localMat);
+      inst.delete();
+    }
+    if (entry.wireframeEntity) {
+      const wireMat = mat4.fromRotationTranslation(mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+      const inst = tcm.getInstance(entry.wireframeEntity);
+      tcm.setTransform(inst, wireMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
@@ -335,79 +340,139 @@ function makeBoxLineVerts(sx, sy, sz) {
   return new Float32Array(v);
 }
 
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
+// ---- In-code wireframe GLB (LINES primitives + KHR_materials_unlit) ----
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function buildWireframeGlb(meshes, nodes) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
   }
-  debugVbo = gl.createBuffer();
+  const gltfMeshes = [], gltfMaterials = [];
+  for (const m of meshes) {
+    const posBV = addBufferView(m.positions, 34962);
+    const posAcc = accessors.length;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < m.positions.length; i += 3) {
+      const x = m.positions[i], y = m.positions[i + 1], z = m.positions[i + 2];
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+    if (minX > maxX) { minX = minY = minZ = 0; maxX = maxY = maxZ = 0; }
+    accessors.push({ bufferView: posBV, componentType: 5126, count: m.positions.length / 3, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] });
+    const idxBV = addBufferView(m.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: m.indices.length, type: 'SCALAR' });
+    gltfMaterials.push({ extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: m.color } });
+    gltfMeshes.push({ primitives: [{ mode: 1, attributes: { POSITION: posAcc }, indices: idxAcc, material: gltfMaterials.length - 1 }] });
+  }
+  const gltfNodes = nodes.map((n) => ({ name: n.name, mesh: n.meshIndex }));
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-wireframe' },
+    extensionsUsed: ['KHR_materials_unlit'],
+    scene: 0,
+    scenes: [{ nodes: gltfNodes.map((_, i) => i) }],
+    nodes: gltfNodes, meshes: gltfMeshes, materials: gltfMaterials, accessors, bufferViews,
+    buffers: [{ byteLength: binOffset }],
+  };
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) { const t = new Uint8Array(jsonBytes.length + jsonPad); t.set(jsonBytes); t.fill(0x20, jsonBytes.length); jsonBytes = t; }
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0; for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4;
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4;
+  glb.set(binBuf, p);
+  return glb;
 }
 
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const view = mat4.lookAt(mat4.create(), eye, center, up);
-  const proj = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), proj, view);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  function drawBox(size, color, p, r) {
-    const model = mat4.fromRotationTranslation(mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    const mvp = mat4.multiply(mat4.create(), vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-    gl.uniform4fv(uColor, color);
-    const verts = makeBoxLineVerts(size[0], size[1], size[2]);
-    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, verts.length / 3);
+async function loadWireframeAsset() {
+  const meshes = [];
+  const nodes = [];
+  function seqIndices(n) { const out = new Uint32Array(n); for (let i = 0; i < n; i++) out[i] = i; return out; }
+  for (let i = 0; i < physicsNodes.length; i++) {
+    const v = makeBoxLineVerts(physicsNodes[i].size[0], physicsNodes[i].size[1], physicsNodes[i].size[2]);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_DYNAMIC });
+    nodes.push({ name: 'dynWire' + i, meshIndex: meshes.length - 1 });
   }
-
-  for (const entry of physicsNodes) {
-    const pr = HK.HP_Body_GetPosition(entry.bodyId);
-    const qr = HK.HP_Body_GetOrientation(entry.bodyId);
-    drawBox(entry.size, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
+  for (let i = 0; i < staticBodies.length; i++) {
+    const v = makeBoxLineVerts(staticBodies[i].size[0], staticBodies[i].size[1], staticBodies[i].size[2]);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_STATIC });
+    nodes.push({ name: 'staticWire' + i, meshIndex: meshes.length - 1 });
   }
+  if (meshes.length === 0) return null;
+
+  const glb = buildWireframeGlb(meshes, nodes);
+  const loader = engine.createAssetLoader();
+  const a = loader.createAsset(glb);
+  await new Promise((resolve) => {
+    a.loadResources(() => {
+      loader.delete();
+      let e = a.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = a.popRenderable(); }
+      const rm = engine.getRenderableManager();
+      for (const ent of a.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) { rm.setCulling(inst, false); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+  for (let i = 0; i < physicsNodes.length; i++) physicsNodes[i].wireframeEntity = a.getEntitiesByName('dynWire' + i)[0] || null;
+  for (let i = 0; i < staticBodies.length; i++) staticBodies[i].wireframeEntity = a.getEntitiesByName('staticWire' + i)[0] || null;
+  // Place static wireframes at their initial transform once; they don't move afterward.
+  const tcm = engine.getTransformManager();
+  tcm.openLocalTransformTransaction();
   for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
     const pr = HK.HP_Body_GetPosition(sb.bodyId);
     const qr = HK.HP_Body_GetOrientation(sb.bodyId);
-    drawBox(sb.size, DEBUG_COLOR_STATIC, pr[1], qr[1]);
+    const p = pr[1], r = qr[1];
+    const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+    const inst = tcm.getInstance(sb.wireframeEntity);
+    tcm.setTransform(inst, m);
+    inst.delete();
   }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
+  return a;
 }
 
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const entry of physicsNodes) {
+    if (!entry.wireframeEntity) continue;
+    if (visible) scene.addEntity(entry.wireframeEntity); else scene.remove(entry.wireframeEntity);
+  }
+  for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
+    if (visible) scene.addEntity(sb.wireframeEntity); else scene.remove(sb.wireframeEntity);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -429,7 +494,7 @@ Filament.init([IBL_URL, SKY_URL], () => {
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
@@ -460,34 +525,31 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.6, 0.6, 0.6, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
-  // Load the model.
+  // Load the model. The model carries KHR_lights_punctual lights, but addEntities() would add them
+  // and trip "glDrawElementsInstanced: uniform buffer too small" on base_lit_opaque at feature
+  // level 1. We skip them by using popRenderable() (which only yields renderables) and light the
+  // scene with IBL + a directional SUN instead.
   const bytes = new Uint8Array(await (await fetch(MODEL_URL)).arrayBuffer());
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(bytes);
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
       for (const e of asset.getEntities()) {
         const inst = rm.getInstance(e);
         if (inst) { rm.setCastShadows(inst, true); inst.delete(); }
       }
-      // Renderables are added to the scene incrementally in render() via popRenderable()
-      // (the canonical Filament gltfio pattern — addEntities() does not make them draw).
-      //
-      // NOTE: this model carries KHR_lights_punctual lights. Adding them makes Filament use
-      // froxelized punctual lighting, which trips "glDrawElementsInstanced: uniform buffer too
-      // small" on base_lit_opaque at feature level 1. We light the scene with IBL + a directional
-      // SUN (neither is froxelized) instead and skip the model's punctual lights.
       resolve();
     }, () => {}, '');
   });
 
-  // Build physics from the GLB's KHR_physics extensions.
+  // Build physics from the GLB's KHR_physics extensions, then load the wireframe asset.
   HK = await HavokPhysics();
   await initPhysicsFromUrl(MODEL_URL, asset, engine);
+  await loadWireframeAsset();
 
   // Frame the camera on the collider bounds.
   const center = [
@@ -502,16 +564,15 @@ async function main() {
     1,
   );
   const radius = span * 0.5;
-  const orbitDist = radius * 2.6;
-  const orbitHeight = center[1] + radius * 0.7;
+  const orbitDist = radius * 1.6;
+  const orbitHeight = center[1] + radius * 0.4;
   const far = Math.max(2000, radius * 60);
 
-  let width = 0, height = 0, aspect = 1;
+  let aspect = 1;
   function resize() {
     const dpr = window.devicePixelRatio || 1;
-    width = canvas.width = Math.floor(window.innerWidth * dpr);
-    height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
+    const width = canvas.width = Math.floor(window.innerWidth * dpr);
+    const height = canvas.height = Math.floor(window.innerHeight * dpr);
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -522,22 +583,12 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.6;
-  function render() {
+  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
+  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
+  function render(now) {
     requestAnimationFrame(render);
-
-    // Move renderables into the scene as Filament finishes their GPU upload.
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) {
-        scene.addEntity(e);
-        e = asset.popRenderable();
-      }
-    }
-
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-
-    angle += 0.0035;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [
       center[0] + Math.sin(angle) * orbitDist,
       orbitHeight,
@@ -545,9 +596,7 @@ async function main() {
     ];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
-
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/filament/havok/gltf_physics_Materials_Restitution/index.js
@@ -5,8 +5,9 @@
 // extensions embedded in the GLB (box floor + sphere colliders with per-collider restitution
 // materials — balls bounce to heights set by their restitution / bounciness).
 //
-// Filament cannot easily draw line wireframes, so the collider debug view is rendered on a
-// separate transparent WebGL2 canvas overlaid on top, using the same camera. Press W to toggle it.
+// Collider wireframes are loaded as a second gltfio asset built in-code (LINES primitives with
+// KHR_materials_unlit), so they render in the same Filament pass as the model — no second canvas,
+// no compositor stutter. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, and gl-matrix
 // (vec3 / quat / mat4).
@@ -27,21 +28,17 @@ let worldId = null;
 
 // Filament objects
 let engine = null;
+let scene = null;
 let asset = null;
 
-// Physics <-> Filament bookkeeping
-const physicsNodes = [];   // dynamic bodies: { entity, bodyId, nodeScale, initPos, initRot, parentInvWorldMat, size }
-const staticBodies = [];   // static bodies:  { bodyId, size }
+// Physics <-> Filament bookkeeping; wireframeEntity is filled in by loadWireframeAsset().
+const physicsNodes = [];   // dynamic bodies: { entity, bodyId, nodeScale, ..., shapeType, size, radius, wireframeEntity }
+const staticBodies = [];   // static bodies:  { bodyId, shapeType, size, radius, wireframeEntity }
 
 // Camera framing (computed from collider bounds)
 const sceneMin = [Infinity, Infinity, Infinity];
 const sceneMax = [-Infinity, -Infinity, -Infinity];
 
-// Debug overlay
-let debugCanvas = null;
-let debugGl = null;
-let debugProg = null;
-let debugVbo = null;
 let showWireframe = true;
 
 // ---- Havok helpers ----
@@ -327,20 +324,28 @@ function physicsStep() {
   const tcm = engine.getTransformManager();
   tcm.openLocalTransformTransaction();
   for (const entry of physicsNodes) {
-    if (!entry.entity) continue;
     const pr = HK.HP_Body_GetPosition(entry.bodyId);
     const qr = HK.HP_Body_GetOrientation(entry.bodyId);
     const p = pr[1], r = qr[1];
-    const physWorld = mat4.fromRotationTranslationScale(
-      mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]),
-      vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
-    );
-    const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
-    const inst = tcm.getInstance(entry.entity);
-    tcm.setTransform(inst, localMat);
-    inst.delete();
+    if (entry.entity) {
+      const physWorld = mat4.fromRotationTranslationScale(
+        mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]),
+        vec3.fromValues(p[0], p[1], p[2]),
+        vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
+      );
+      const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
+      const inst = tcm.getInstance(entry.entity);
+      tcm.setTransform(inst, localMat);
+      inst.delete();
+    }
+    if (entry.wireframeEntity) {
+      const wireMat = mat4.fromRotationTranslation(mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+      const inst = tcm.getInstance(entry.wireframeEntity);
+      tcm.setTransform(inst, wireMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
@@ -374,81 +379,144 @@ function makeSphereLineVerts(radius, segments = 16) {
   return new Float32Array(v);
 }
 
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
-  }
-  debugVbo = gl.createBuffer();
+// ---- In-code wireframe GLB (LINES primitives + KHR_materials_unlit) ----
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function shapeVertsFor(entry) {
+  return entry.shapeType === 'sphere'
+    ? makeSphereLineVerts(entry.radius)
+    : makeBoxLineVerts(entry.size[0], entry.size[1], entry.size[2]);
 }
 
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const view = mat4.lookAt(mat4.create(), eye, center, up);
-  const proj = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), proj, view);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  function drawShape(entry, color, p, r) {
-    const model = mat4.fromRotationTranslation(mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    const mvp = mat4.multiply(mat4.create(), vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-    gl.uniform4fv(uColor, color);
-    const verts = entry.shapeType === 'sphere'
-      ? makeSphereLineVerts(entry.radius)
-      : makeBoxLineVerts(entry.size[0], entry.size[1], entry.size[2]);
-    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, verts.length / 3);
+function buildWireframeGlb(meshes, nodes) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
   }
-
-  for (const entry of physicsNodes) {
-    const pr = HK.HP_Body_GetPosition(entry.bodyId);
-    const qr = HK.HP_Body_GetOrientation(entry.bodyId);
-    drawShape(entry, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
+  const gltfMeshes = [], gltfMaterials = [];
+  for (const m of meshes) {
+    const posBV = addBufferView(m.positions, 34962);
+    const posAcc = accessors.length;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < m.positions.length; i += 3) {
+      const x = m.positions[i], y = m.positions[i + 1], z = m.positions[i + 2];
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+    if (minX > maxX) { minX = minY = minZ = 0; maxX = maxY = maxZ = 0; }
+    accessors.push({ bufferView: posBV, componentType: 5126, count: m.positions.length / 3, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] });
+    const idxBV = addBufferView(m.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: m.indices.length, type: 'SCALAR' });
+    gltfMaterials.push({ extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: m.color } });
+    gltfMeshes.push({ primitives: [{ mode: 1, attributes: { POSITION: posAcc }, indices: idxAcc, material: gltfMaterials.length - 1 }] });
   }
+  const gltfNodes = nodes.map((n) => ({ name: n.name, mesh: n.meshIndex }));
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-wireframe' },
+    extensionsUsed: ['KHR_materials_unlit'],
+    scene: 0,
+    scenes: [{ nodes: gltfNodes.map((_, i) => i) }],
+    nodes: gltfNodes, meshes: gltfMeshes, materials: gltfMaterials, accessors, bufferViews,
+    buffers: [{ byteLength: binOffset }],
+  };
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) { const t = new Uint8Array(jsonBytes.length + jsonPad); t.set(jsonBytes); t.fill(0x20, jsonBytes.length); jsonBytes = t; }
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0; for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4;
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4;
+  glb.set(binBuf, p);
+  return glb;
+}
+
+async function loadWireframeAsset() {
+  const meshes = [];
+  const nodes = [];
+  function seqIndices(n) { const out = new Uint32Array(n); for (let i = 0; i < n; i++) out[i] = i; return out; }
+  for (let i = 0; i < physicsNodes.length; i++) {
+    const v = shapeVertsFor(physicsNodes[i]);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_DYNAMIC });
+    nodes.push({ name: 'dynWire' + i, meshIndex: meshes.length - 1 });
+  }
+  for (let i = 0; i < staticBodies.length; i++) {
+    const v = shapeVertsFor(staticBodies[i]);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_STATIC });
+    nodes.push({ name: 'staticWire' + i, meshIndex: meshes.length - 1 });
+  }
+  if (meshes.length === 0) return null;
+
+  const glb = buildWireframeGlb(meshes, nodes);
+  const loader = engine.createAssetLoader();
+  const a = loader.createAsset(glb);
+  await new Promise((resolve) => {
+    a.loadResources(() => {
+      loader.delete();
+      let e = a.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = a.popRenderable(); }
+      const rm = engine.getRenderableManager();
+      for (const ent of a.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) { rm.setCulling(inst, false); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+  for (let i = 0; i < physicsNodes.length; i++) physicsNodes[i].wireframeEntity = a.getEntitiesByName('dynWire' + i)[0] || null;
+  for (let i = 0; i < staticBodies.length; i++) staticBodies[i].wireframeEntity = a.getEntitiesByName('staticWire' + i)[0] || null;
+  const tcm = engine.getTransformManager();
+  tcm.openLocalTransformTransaction();
   for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
     const pr = HK.HP_Body_GetPosition(sb.bodyId);
     const qr = HK.HP_Body_GetOrientation(sb.bodyId);
-    drawShape(sb, DEBUG_COLOR_STATIC, pr[1], qr[1]);
+    const p = pr[1], r = qr[1];
+    const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+    const inst = tcm.getInstance(sb.wireframeEntity);
+    tcm.setTransform(inst, m);
+    inst.delete();
   }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
+  return a;
 }
 
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const entry of physicsNodes) {
+    if (!entry.wireframeEntity) continue;
+    if (visible) scene.addEntity(entry.wireframeEntity); else scene.remove(entry.wireframeEntity);
+  }
+  for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
+    if (visible) scene.addEntity(sb.wireframeEntity); else scene.remove(sb.wireframeEntity);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -470,7 +538,7 @@ Filament.init([IBL_URL, SKY_URL], () => {
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
@@ -501,34 +569,30 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.6, 0.6, 0.6, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
-  // Load the model.
+  // Load the model. addEntities() would include the KHR_lights_punctual lights which trips
+  // "glDrawElementsInstanced: uniform buffer too small" on base_lit_opaque at feature level 1, so
+  // we use popRenderable() to add only renderables. Lighting comes from IBL + a directional SUN.
   const bytes = new Uint8Array(await (await fetch(MODEL_URL)).arrayBuffer());
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(bytes);
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
       for (const e of asset.getEntities()) {
         const inst = rm.getInstance(e);
         if (inst) { rm.setCastShadows(inst, true); inst.delete(); }
       }
-      // Renderables are added to the scene incrementally in render() via popRenderable()
-      // (the canonical Filament gltfio pattern — addEntities() does not make them draw).
-      //
-      // NOTE: this model carries KHR_lights_punctual lights. Adding them makes Filament use
-      // froxelized punctual lighting, which trips "glDrawElementsInstanced: uniform buffer too
-      // small" on base_lit_opaque at feature level 1. We light the scene with IBL + a directional
-      // SUN (neither is froxelized) instead and skip the model's punctual lights.
       resolve();
     }, () => {}, '');
   });
 
-  // Build physics from the GLB's KHR_physics extensions.
+  // Build physics from the GLB's KHR_physics extensions, then load the wireframe asset.
   HK = await HavokPhysics();
   await initPhysicsFromUrl(MODEL_URL, asset, engine);
+  await loadWireframeAsset();
 
   // Frame the camera on the collider bounds.
   const center = [
@@ -543,16 +607,15 @@ async function main() {
     1,
   );
   const radius = span * 0.5;
-  const orbitDist = radius * 2.6;
-  const orbitHeight = center[1] + radius * 0.7;
+  const orbitDist = radius * 1.6;
+  const orbitHeight = center[1] + radius * 0.4;
   const far = Math.max(2000, radius * 60);
 
-  let width = 0, height = 0, aspect = 1;
+  let aspect = 1;
   function resize() {
     const dpr = window.devicePixelRatio || 1;
-    width = canvas.width = Math.floor(window.innerWidth * dpr);
-    height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
+    const width = canvas.width = Math.floor(window.innerWidth * dpr);
+    const height = canvas.height = Math.floor(window.innerHeight * dpr);
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -563,22 +626,11 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.6;
-  function render() {
+  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
+  function render(now) {
     requestAnimationFrame(render);
-
-    // Move renderables into the scene as Filament finishes their GPU upload.
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) {
-        scene.addEntity(e);
-        e = asset.popRenderable();
-      }
-    }
-
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-
-    angle += 0.0035;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [
       center[0] + Math.sin(angle) * orbitDist,
       orbitHeight,
@@ -586,9 +638,7 @@ async function main() {
     ];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
-
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/filament/havok/gltf_physics_Motion_Properties/index.js
@@ -6,8 +6,9 @@
 // centerOfMass (wobbly toy), and locked / infinite inertia (wheel, box). It uses box / capsule /
 // cylinder implicit shapes plus convex-hull and triangle-mesh colliders.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines). Press W to toggle them.
+// Collider wireframes are loaded as a second gltfio asset built in-code (LINES primitives with
+// KHR_materials_unlit), so they render in the same Filament pass as the model — no second canvas,
+// no compositor stutter. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -28,21 +29,17 @@ let worldId = null;
 
 // Filament objects
 let engine = null;
+let scene = null;
 let asset = null;
 
-// Physics <-> Filament bookkeeping
-const physicsNodes = [];   // dynamic bodies (transform-synced + Y-reset)
-const staticBodies = [];   // static bodies (debug only)
+// Physics <-> Filament bookkeeping; wireframeEntity is filled in by loadWireframeAsset().
+const physicsNodes = [];   // dynamic bodies (transform-synced + Y-reset, with wireframeEntity)
+const staticBodies = [];   // static bodies (wireframeEntity placed once at the initial transform)
 
 // Camera framing (computed from collider bounds)
 const sceneMin = [Infinity, Infinity, Infinity];
 const sceneMax = [-Infinity, -Infinity, -Infinity];
 
-// Debug overlay
-let debugCanvas = null;
-let debugGl = null;
-let debugProg = null;
-let debugVbo = null;
 let showWireframe = true;
 
 // ---- Havok helpers ----
@@ -485,20 +482,30 @@ function physicsStep() {
   const tcm = engine.getTransformManager();
   tcm.openLocalTransformTransaction();
   for (const entry of physicsNodes) {
-    if (!entry.entity) continue;
     const pr = HK.HP_Body_GetPosition(entry.bodyId);
     const qr = HK.HP_Body_GetOrientation(entry.bodyId);
     const p = pr[1], r = qr[1];
-    const physWorld = mat4.fromRotationTranslationScale(
-      mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]),
-      vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
-    );
-    const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
-    const inst = tcm.getInstance(entry.entity);
-    tcm.setTransform(inst, localMat);
-    inst.delete();
+    if (entry.entity) {
+      const physWorld = mat4.fromRotationTranslationScale(
+        mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]),
+        vec3.fromValues(p[0], p[1], p[2]),
+        vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
+      );
+      const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
+      const inst = tcm.getInstance(entry.entity);
+      tcm.setTransform(inst, localMat);
+      inst.delete();
+    }
+    if (entry.wireframeEntity) {
+      // Wireframe lives at the scene root, so no parentInv is needed; its vertices already encode
+      // the collider's size, so no scale is applied either.
+      const wireMat = mat4.fromRotationTranslation(mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+      const inst = tcm.getInstance(entry.wireframeEntity);
+      tcm.setTransform(inst, wireMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
 }
@@ -582,78 +589,153 @@ function debugVertsFor(shape) {
   return verts;
 }
 
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
+// ---- In-code wireframe GLB (LINES primitives + KHR_materials_unlit) ----
+function alignTo4(n) { return (n + 3) & ~3; }
+
+// Builds a GLB from a list of meshes (each with positions + indices + color) and nodes (each
+// referencing a mesh index by name). Returns the GLB bytes.
+function buildWireframeGlb(meshes, nodes) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
   }
-  debugVbo = gl.createBuffer();
+  const gltfMeshes = [], gltfMaterials = [];
+  for (const m of meshes) {
+    const posBV = addBufferView(m.positions, 34962);
+    const posAcc = accessors.length;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < m.positions.length; i += 3) {
+      const x = m.positions[i], y = m.positions[i + 1], z = m.positions[i + 2];
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+    if (minX > maxX) { minX = minY = minZ = 0; maxX = maxY = maxZ = 0; }
+    accessors.push({ bufferView: posBV, componentType: 5126, count: m.positions.length / 3, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] });
+    const idxBV = addBufferView(m.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: m.indices.length, type: 'SCALAR' });
+    gltfMaterials.push({ extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: m.color } });
+    gltfMeshes.push({ primitives: [{ mode: 1, attributes: { POSITION: posAcc }, indices: idxAcc, material: gltfMaterials.length - 1 }] });
+  }
+  const gltfNodes = nodes.map((n) => ({ name: n.name, mesh: n.meshIndex }));
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-wireframe' },
+    extensionsUsed: ['KHR_materials_unlit'],
+    scene: 0,
+    scenes: [{ nodes: gltfNodes.map((_, i) => i) }],
+    nodes: gltfNodes, meshes: gltfMeshes, materials: gltfMaterials, accessors, bufferViews,
+    buffers: [{ byteLength: binOffset }],
+  };
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) { const t = new Uint8Array(jsonBytes.length + jsonPad); t.set(jsonBytes); t.fill(0x20, jsonBytes.length); jsonBytes = t; }
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0; for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4;
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4;
+  glb.set(binBuf, p);
+  return glb;
 }
 
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const view = mat4.lookAt(mat4.create(), eye, center, up);
-  const proj = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), proj, view);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  function draw(shape, color, p, r) {
-    const model = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    const mvp = mat4.multiply(mat4.create(), vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-    gl.uniform4fv(uColor, color);
-    const verts = debugVertsFor(shape);
-    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, verts.length / 3);
+// One LINES mesh per physics body (each shape has unique geometry from debugVertsFor()) + one
+// unlit material per body (orange dynamic, green static). The wireframe entity for each body
+// follows the body's world transform every frame (or is placed once for static bodies).
+async function loadWireframeAsset() {
+  const meshes = [];
+  const nodes = [];
+  function makeSequentialIndices(vertCount) {
+    const out = new Uint32Array(vertCount);
+    for (let i = 0; i < vertCount; i++) out[i] = i;
+    return out;
   }
-
-  for (const entry of physicsNodes) {
-    const pr = HK.HP_Body_GetPosition(entry.bodyId);
-    const qr = HK.HP_Body_GetOrientation(entry.bodyId);
-    draw(entry.shape, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
+  for (let i = 0; i < physicsNodes.length; i++) {
+    const verts = debugVertsFor(physicsNodes[i].shape);
+    meshes.push({ positions: verts, indices: makeSequentialIndices(verts.length / 3), color: DEBUG_COLOR_DYNAMIC });
+    nodes.push({ name: 'dynWire' + i, meshIndex: meshes.length - 1 });
   }
+  for (let i = 0; i < staticBodies.length; i++) {
+    const verts = debugVertsFor(staticBodies[i].shape);
+    meshes.push({ positions: verts, indices: makeSequentialIndices(verts.length / 3), color: DEBUG_COLOR_STATIC });
+    nodes.push({ name: 'staticWire' + i, meshIndex: meshes.length - 1 });
+  }
+  if (meshes.length === 0) return null;
+
+  const glb = buildWireframeGlb(meshes, nodes);
+  const loader = engine.createAssetLoader();
+  const a = loader.createAsset(glb);
+  await new Promise((resolve) => {
+    a.loadResources(() => {
+      loader.delete();
+      let e = a.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = a.popRenderable(); }
+      const rm = engine.getRenderableManager();
+      for (const ent of a.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) { rm.setCulling(inst, false); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+  for (let i = 0; i < physicsNodes.length; i++) {
+    physicsNodes[i].wireframeEntity = a.getEntitiesByName('dynWire' + i)[0] || null;
+  }
+  for (let i = 0; i < staticBodies.length; i++) {
+    staticBodies[i].wireframeEntity = a.getEntitiesByName('staticWire' + i)[0] || null;
+  }
+  // Place static wireframes at their bodies' initial world transforms; they don't move afterward.
+  const tcm = engine.getTransformManager();
+  tcm.openLocalTransformTransaction();
   for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
     const pr = HK.HP_Body_GetPosition(sb.bodyId);
     const qr = HK.HP_Body_GetOrientation(sb.bodyId);
-    draw(sb.shape, DEBUG_COLOR_STATIC, pr[1], qr[1]);
+    const p = pr[1], r = qr[1];
+    const m = mat4.fromRotationTranslation(mat4.create(),
+      quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+    const inst = tcm.getInstance(sb.wireframeEntity);
+    tcm.setTransform(inst, m);
+    inst.delete();
   }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
+  return a;
 }
 
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const entry of physicsNodes) {
+    if (!entry.wireframeEntity) continue;
+    if (visible) scene.addEntity(entry.wireframeEntity); else scene.remove(entry.wireframeEntity);
+  }
+  for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
+    if (visible) scene.addEntity(sb.wireframeEntity); else scene.remove(sb.wireframeEntity);
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -675,7 +757,7 @@ Filament.init([IBL_URL, SKY_URL], () => {
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
@@ -706,38 +788,38 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.6, 0.6, 0.6, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
-  // Load the model.
+  // Load the model. (The model carries KHR_lights_punctual lights; adding them makes Filament
+  // froxelize punctual lighting, which trips "glDrawElementsInstanced: uniform buffer too small" on
+  // base_lit_opaque at feature level 1. We light with IBL + a directional SUN instead — popping
+  // renderables here uses popRenderable() which skips the punctual lights.)
   const bytes = new Uint8Array(await (await fetch(MODEL_URL)).arrayBuffer());
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(bytes);
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
       for (const e of asset.getEntities()) {
         const inst = rm.getInstance(e);
         if (inst) { rm.setCastShadows(inst, true); inst.delete(); }
       }
-      // Renderables are added to the scene in render() via popRenderable(). The model carries
-      // KHR_lights_punctual lights; adding them makes Filament froxelize punctual lighting, which
-      // trips "glDrawElementsInstanced: uniform buffer too small" on base_lit_opaque at feature
-      // level 1. We light with IBL + a directional SUN (neither is froxelized) instead.
       resolve();
     }, () => {}, '');
   });
 
-  // Build physics from the GLB's KHR_physics extensions.
+  // Build physics from the GLB's KHR_physics extensions, then load the wireframe asset.
   HK = await HavokPhysics();
   await initPhysicsFromUrl(MODEL_URL, asset, engine);
+  await loadWireframeAsset();
 
   // Frame the camera on the collider bounds.
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 2.4;
-  const orbitHeight = center[1] + radius * 0.5;
+  const orbitDist = radius * 1.5;
+  const orbitHeight = center[1] + radius * 0.35;
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -745,7 +827,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -756,24 +837,19 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.6;
-  function render() {
+  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
+  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
+  function render(now) {
     requestAnimationFrame(render);
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
 
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
 
-    angle += 0.0035;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
 
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }

--- a/examples/filament/havok/gltf_physics_Triggers/index.js
+++ b/examples/filament/havok/gltf_physics_Triggers/index.js
@@ -6,8 +6,9 @@
 // blocking. A cube falls through the (translucent green) trigger volumes; each trigger's
 // wireframe turns red while a dynamic body is inside it.
 //
-// Collider wireframes are drawn on a separate transparent WebGL2 canvas overlaid with the same
-// camera (Filament can't easily draw lines). Press W to toggle them.
+// Collider wireframes are loaded as a second gltfio asset built in-code (LINES primitives with
+// KHR_materials_unlit), so they render in the same Filament pass as the model — no second canvas,
+// no compositor stutter. Press W to toggle the wireframe entities in / out of the scene.
 //
 // Libraries are loaded as globals via <script> tags: Filament, HavokPhysics, gl-matrix
 // (vec3 / quat / mat4).
@@ -30,22 +31,19 @@ let worldId = null;
 
 // Filament objects
 let engine = null;
+let scene = null;
 let asset = null;
 
-// Physics <-> Filament bookkeeping
-const physicsNodes = [];   // dynamic bodies (transform-synced + Y-reset)
-const staticBodies = [];   // static bodies (debug only)
-const triggerEntries = []; // trigger volumes: { shape, initPos, initRot, worldAABB, active }
+// Physics <-> Filament bookkeeping; wireframeEntity / wireframeIdle / wireframeActive are filled in
+// by loadWireframeAsset().
+const physicsNodes = [];   // dynamic bodies (transform-synced + Y-reset, with wireframeEntity)
+const staticBodies = [];   // static bodies (wireframeEntity placed once)
+const triggerEntries = []; // trigger volumes: { shape, initPos, initRot, worldAABB, active, lastActive, wireframeIdle, wireframeActive }
 
 // Camera framing (computed from collider bounds)
 const sceneMin = [Infinity, Infinity, Infinity];
 const sceneMax = [-Infinity, -Infinity, -Infinity];
 
-// Debug overlay
-let debugCanvas = null;
-let debugGl = null;
-let debugProg = null;
-let debugVbo = null;
 let showWireframe = true;
 
 // ---- Havok helpers ----
@@ -543,22 +541,45 @@ function physicsStep() {
   const tcm = engine.getTransformManager();
   tcm.openLocalTransformTransaction();
   for (const entry of physicsNodes) {
-    if (!entry.entity) continue;
     const pr = HK.HP_Body_GetPosition(entry.bodyId);
     const qr = HK.HP_Body_GetOrientation(entry.bodyId);
     const p = pr[1], r = qr[1];
-    const physWorld = mat4.fromRotationTranslationScale(
-      mat4.create(),
-      quat.fromValues(r[0], r[1], r[2], r[3]),
-      vec3.fromValues(p[0], p[1], p[2]),
-      vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
-    );
-    const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
-    const inst = tcm.getInstance(entry.entity);
-    tcm.setTransform(inst, localMat);
-    inst.delete();
+    if (entry.entity) {
+      const physWorld = mat4.fromRotationTranslationScale(
+        mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]),
+        vec3.fromValues(p[0], p[1], p[2]),
+        vec3.fromValues(entry.nodeScale[0], entry.nodeScale[1], entry.nodeScale[2]),
+      );
+      const localMat = mat4.multiply(mat4.create(), entry.parentInvWorldMat, physWorld);
+      const inst = tcm.getInstance(entry.entity);
+      tcm.setTransform(inst, localMat);
+      inst.delete();
+    }
+    if (entry.wireframeEntity) {
+      const wireMat = mat4.fromRotationTranslation(mat4.create(),
+        quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+      const inst = tcm.getInstance(entry.wireframeEntity);
+      tcm.setTransform(inst, wireMat);
+      inst.delete();
+    }
   }
   tcm.commitLocalTransformTransaction();
+
+  // Trigger active/idle state changes -> swap which wireframe entity is in the scene.
+  if (showWireframe && scene) {
+    for (const t of triggerEntries) {
+      if (t.active === t.lastActive) continue;
+      if (t.active) {
+        if (t.wireframeIdle) scene.remove(t.wireframeIdle);
+        if (t.wireframeActive) scene.addEntity(t.wireframeActive);
+      } else {
+        if (t.wireframeActive) scene.remove(t.wireframeActive);
+        if (t.wireframeIdle) scene.addEntity(t.wireframeIdle);
+      }
+      t.lastActive = t.active;
+    }
+  }
 }
 
 // ---- Debug wireframe overlay (separate transparent WebGL2 canvas) ----
@@ -640,81 +661,171 @@ function debugVertsFor(shape) {
   return verts;
 }
 
-function initDebugCanvas(mainCanvas) {
-  debugCanvas = document.createElement('canvas');
-  debugCanvas.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none';
-  debugCanvas.width = mainCanvas.width;
-  debugCanvas.height = mainCanvas.height;
-  mainCanvas.parentElement.appendChild(debugCanvas);
-  const gl = debugGl = debugCanvas.getContext('webgl2');
-  if (!gl) { console.warn('[debug] WebGL2 unavailable for wireframe overlay'); return; }
-  const vs = gl.createShader(gl.VERTEX_SHADER);
-  gl.shaderSource(vs, '#version 300 es\nin vec3 aPos; uniform mat4 uMVP;\nvoid main(){gl_Position=uMVP*vec4(aPos,1.0);}');
-  gl.compileShader(vs);
-  const fs = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(fs, '#version 300 es\nprecision mediump float; uniform vec4 uColor; out vec4 o;\nvoid main(){o=uColor;}');
-  gl.compileShader(fs);
-  debugProg = gl.createProgram();
-  gl.attachShader(debugProg, vs); gl.attachShader(debugProg, fs);
-  gl.linkProgram(debugProg);
-  gl.deleteShader(vs); gl.deleteShader(fs);
-  if (!gl.getProgramParameter(debugProg, gl.LINK_STATUS)) {
-    console.warn('[debug] shader link error:', gl.getProgramInfoLog(debugProg));
-    debugProg = null; return;
+// ---- In-code wireframe GLB (LINES primitives + KHR_materials_unlit) ----
+function alignTo4(n) { return (n + 3) & ~3; }
+
+function buildWireframeGlb(meshes, nodes) {
+  const accessors = [];
+  const bufferViews = [];
+  const binChunks = [];
+  let binOffset = 0;
+  function addBufferView(typedArray, target) {
+    const padded = alignTo4(binOffset);
+    if (padded > binOffset) { binChunks.push(new Uint8Array(padded - binOffset)); binOffset = padded; }
+    const bytes = new Uint8Array(typedArray.buffer, typedArray.byteOffset, typedArray.byteLength);
+    const index = bufferViews.length;
+    const bv = { buffer: 0, byteOffset: binOffset, byteLength: bytes.byteLength };
+    if (target !== undefined) bv.target = target;
+    bufferViews.push(bv);
+    binChunks.push(bytes);
+    binOffset += bytes.byteLength;
+    return index;
   }
-  debugVbo = gl.createBuffer();
+  const gltfMeshes = [], gltfMaterials = [];
+  for (const m of meshes) {
+    const posBV = addBufferView(m.positions, 34962);
+    const posAcc = accessors.length;
+    let minX = Infinity, minY = Infinity, minZ = Infinity, maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    for (let i = 0; i < m.positions.length; i += 3) {
+      const x = m.positions[i], y = m.positions[i + 1], z = m.positions[i + 2];
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+    if (minX > maxX) { minX = minY = minZ = 0; maxX = maxY = maxZ = 0; }
+    accessors.push({ bufferView: posBV, componentType: 5126, count: m.positions.length / 3, type: 'VEC3', min: [minX, minY, minZ], max: [maxX, maxY, maxZ] });
+    const idxBV = addBufferView(m.indices, 34963);
+    const idxAcc = accessors.length;
+    accessors.push({ bufferView: idxBV, componentType: 5125, count: m.indices.length, type: 'SCALAR' });
+    gltfMaterials.push({ extensions: { KHR_materials_unlit: {} }, pbrMetallicRoughness: { baseColorFactor: m.color } });
+    gltfMeshes.push({ primitives: [{ mode: 1, attributes: { POSITION: posAcc }, indices: idxAcc, material: gltfMaterials.length - 1 }] });
+  }
+  const gltfNodes = nodes.map((n) => ({ name: n.name, mesh: n.meshIndex }));
+  const gltf = {
+    asset: { version: '2.0', generator: 'filament-havok-wireframe' },
+    extensionsUsed: ['KHR_materials_unlit'],
+    scene: 0,
+    scenes: [{ nodes: gltfNodes.map((_, i) => i) }],
+    nodes: gltfNodes, meshes: gltfMeshes, materials: gltfMaterials, accessors, bufferViews,
+    buffers: [{ byteLength: binOffset }],
+  };
+  let jsonBytes = new TextEncoder().encode(JSON.stringify(gltf));
+  const jsonPad = alignTo4(jsonBytes.length) - jsonBytes.length;
+  if (jsonPad) { const t = new Uint8Array(jsonBytes.length + jsonPad); t.set(jsonBytes); t.fill(0x20, jsonBytes.length); jsonBytes = t; }
+  const binBuf = new Uint8Array(alignTo4(binOffset));
+  let o = 0; for (const ch of binChunks) { binBuf.set(ch, o); o += ch.byteLength; }
+  const totalLen = 12 + 8 + jsonBytes.length + 8 + binBuf.length;
+  const glb = new Uint8Array(totalLen);
+  const dv = new DataView(glb.buffer);
+  let p = 0;
+  dv.setUint32(p, 0x46546C67, true); p += 4;
+  dv.setUint32(p, 2, true); p += 4;
+  dv.setUint32(p, totalLen, true); p += 4;
+  dv.setUint32(p, jsonBytes.length, true); p += 4;
+  dv.setUint32(p, 0x4E4F534A, true); p += 4;
+  glb.set(jsonBytes, p); p += jsonBytes.length;
+  dv.setUint32(p, binBuf.length, true); p += 4;
+  dv.setUint32(p, 0x004E4942, true); p += 4;
+  glb.set(binBuf, p);
+  return glb;
 }
 
-function drawDebug(eye, center, up, aspect) {
-  if (!debugGl || !debugProg) return;
-  const gl = debugGl;
-  gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-  gl.clearColor(0, 0, 0, 0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  if (!showWireframe || !HK || !worldId) return;
-  gl.enable(gl.DEPTH_TEST);
-  gl.useProgram(debugProg);
-  const aPos = gl.getAttribLocation(debugProg, 'aPos');
-  const uMVP = gl.getUniformLocation(debugProg, 'uMVP');
-  const uColor = gl.getUniformLocation(debugProg, 'uColor');
-  const view = mat4.lookAt(mat4.create(), eye, center, up);
-  const proj = mat4.perspective(mat4.create(), 75 * Math.PI / 180, aspect, 0.01, 10000.0);
-  const vp = mat4.multiply(mat4.create(), proj, view);
-  gl.bindBuffer(gl.ARRAY_BUFFER, debugVbo);
-  gl.enableVertexAttribArray(aPos);
-  gl.vertexAttribPointer(aPos, 3, gl.FLOAT, false, 0, 0);
-
-  function draw(shape, color, p, r) {
-    const model = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
-    const mvp = mat4.multiply(mat4.create(), vp, model);
-    gl.uniformMatrix4fv(uMVP, false, mvp);
-    gl.uniform4fv(uColor, color);
-    const verts = debugVertsFor(shape);
-    gl.bufferData(gl.ARRAY_BUFFER, verts, gl.DYNAMIC_DRAW);
-    gl.drawArrays(gl.LINES, 0, verts.length / 3);
+async function loadWireframeAsset() {
+  const meshes = [];
+  const nodes = [];
+  function seqIndices(n) { const out = new Uint32Array(n); for (let i = 0; i < n; i++) out[i] = i; return out; }
+  for (let i = 0; i < physicsNodes.length; i++) {
+    const v = debugVertsFor(physicsNodes[i].shape);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_DYNAMIC });
+    nodes.push({ name: 'dynWire' + i, meshIndex: meshes.length - 1 });
   }
+  for (let i = 0; i < staticBodies.length; i++) {
+    const v = debugVertsFor(staticBodies[i].shape);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_STATIC });
+    nodes.push({ name: 'staticWire' + i, meshIndex: meshes.length - 1 });
+  }
+  // Each trigger gets two entities — one with the idle (cyan) colour, one with active (red).
+  // Only one is in the scene at a time, swapped in physicsStep based on t.active.
+  for (let i = 0; i < triggerEntries.length; i++) {
+    const v = debugVertsFor(triggerEntries[i].shape);
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_TRIGGER_IDLE });
+    nodes.push({ name: 'triggerIdleWire' + i, meshIndex: meshes.length - 1 });
+    meshes.push({ positions: v, indices: seqIndices(v.length / 3), color: DEBUG_COLOR_TRIGGER_ACTIVE });
+    nodes.push({ name: 'triggerActiveWire' + i, meshIndex: meshes.length - 1 });
+  }
+  if (meshes.length === 0) return null;
 
-  for (const entry of physicsNodes) {
-    const pr = HK.HP_Body_GetPosition(entry.bodyId);
-    const qr = HK.HP_Body_GetOrientation(entry.bodyId);
-    draw(entry.shape, DEBUG_COLOR_DYNAMIC, pr[1], qr[1]);
+  const glb = buildWireframeGlb(meshes, nodes);
+  const loader = engine.createAssetLoader();
+  const a = loader.createAsset(glb);
+  await new Promise((resolve) => {
+    a.loadResources(() => {
+      loader.delete();
+      let e = a.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = a.popRenderable(); }
+      const rm = engine.getRenderableManager();
+      for (const ent of a.getEntities()) {
+        const inst = rm.getInstance(ent);
+        if (inst) { rm.setCulling(inst, false); inst.delete(); }
+      }
+      resolve();
+    }, () => {}, '');
+  });
+  for (let i = 0; i < physicsNodes.length; i++) physicsNodes[i].wireframeEntity = a.getEntitiesByName('dynWire' + i)[0] || null;
+  for (let i = 0; i < staticBodies.length; i++) staticBodies[i].wireframeEntity = a.getEntitiesByName('staticWire' + i)[0] || null;
+  for (let i = 0; i < triggerEntries.length; i++) {
+    triggerEntries[i].wireframeIdle = a.getEntitiesByName('triggerIdleWire' + i)[0] || null;
+    triggerEntries[i].wireframeActive = a.getEntitiesByName('triggerActiveWire' + i)[0] || null;
+    triggerEntries[i].lastActive = false;
+    // Start with the active variant removed; only the idle one is visible.
+    if (triggerEntries[i].wireframeActive) scene.remove(triggerEntries[i].wireframeActive);
+  }
+  // Place static + trigger wireframes once at their initial transforms.
+  const tcm = engine.getTransformManager();
+  tcm.openLocalTransformTransaction();
+  function setInitial(entity, p, r) {
+    if (!entity) return;
+    const m = mat4.fromRotationTranslation(mat4.create(), quat.fromValues(r[0], r[1], r[2], r[3]), vec3.fromValues(p[0], p[1], p[2]));
+    const inst = tcm.getInstance(entity);
+    tcm.setTransform(inst, m);
+    inst.delete();
   }
   for (const sb of staticBodies) {
     const pr = HK.HP_Body_GetPosition(sb.bodyId);
     const qr = HK.HP_Body_GetOrientation(sb.bodyId);
-    draw(sb.shape, DEBUG_COLOR_STATIC, pr[1], qr[1]);
+    setInitial(sb.wireframeEntity, pr[1], qr[1]);
   }
   for (const t of triggerEntries) {
-    draw(t.shape, t.active ? DEBUG_COLOR_TRIGGER_ACTIVE : DEBUG_COLOR_TRIGGER_IDLE, t.initPos, t.initRot);
+    setInitial(t.wireframeIdle, t.initPos, t.initRot);
+    setInitial(t.wireframeActive, t.initPos, t.initRot);
   }
-  gl.disableVertexAttribArray(aPos);
+  tcm.commitLocalTransformTransaction();
+  return a;
 }
 
-// ---- W-key wireframe toggle ----
+// ---- W-key wireframe toggle (adds / removes the wireframe entities from the scene) ----
 function setWireframeVisible(visible) {
   showWireframe = visible;
   const hint = document.getElementById('hint');
   if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+  if (!scene) return;
+  for (const entry of physicsNodes) {
+    if (!entry.wireframeEntity) continue;
+    if (visible) scene.addEntity(entry.wireframeEntity); else scene.remove(entry.wireframeEntity);
+  }
+  for (const sb of staticBodies) {
+    if (!sb.wireframeEntity) continue;
+    if (visible) scene.addEntity(sb.wireframeEntity); else scene.remove(sb.wireframeEntity);
+  }
+  for (const t of triggerEntries) {
+    if (visible) {
+      // Re-add the variant matching the current active state.
+      if (t.active && t.wireframeActive) scene.addEntity(t.wireframeActive);
+      else if (!t.active && t.wireframeIdle) scene.addEntity(t.wireframeIdle);
+    } else {
+      if (t.wireframeIdle) scene.remove(t.wireframeIdle);
+      if (t.wireframeActive) scene.remove(t.wireframeActive);
+    }
+  }
 }
 
 window.addEventListener('keydown', (event) => {
@@ -736,7 +847,7 @@ Filament.init([IBL_URL, SKY_URL], () => {
 async function main() {
   const canvas = document.getElementsByTagName('canvas')[0];
   engine = Filament.Engine.create(canvas);
-  const scene = engine.createScene();
+  scene = engine.createScene();
 
   const ibl = engine.createIblFromKtx1(IBL_URL);
   ibl.setIntensity(50000);
@@ -767,38 +878,37 @@ async function main() {
   view.setColorGrading(colorGrading);
   renderer.setClearOptions({ clearColor: [0.6, 0.6, 0.6, 1.0], clear: true });
 
-  initDebugCanvas(canvas);
-
-  // Load the model.
+  // Load the model — pop renderables only so the model's KHR_lights_punctual lights stay out (they
+  // trip "glDrawElementsInstanced: uniform buffer too small" at feature level 1). Lighting is the
+  // IBL + a directional SUN.
   const bytes = new Uint8Array(await (await fetch(MODEL_URL)).arrayBuffer());
   const assetLoader = engine.createAssetLoader();
   asset = assetLoader.createAsset(bytes);
   await new Promise((resolve) => {
     asset.loadResources(() => {
       assetLoader.delete();
+      let e = asset.popRenderable();
+      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
       const rm = engine.getRenderableManager();
       for (const e of asset.getEntities()) {
         const inst = rm.getInstance(e);
         if (inst) { rm.setCastShadows(inst, true); inst.delete(); }
       }
-      // Renderables are added to the scene in render() via popRenderable(). The model carries
-      // KHR_lights_punctual lights; adding them makes Filament froxelize punctual lighting, which
-      // trips "glDrawElementsInstanced: uniform buffer too small" on base_lit_opaque at feature
-      // level 1. We light with IBL + a directional SUN (neither is froxelized) instead.
       resolve();
     }, () => {}, '');
   });
 
-  // Build physics from the GLB's KHR_physics extensions.
+  // Build physics from the GLB's KHR_physics extensions, then load the wireframe asset.
   HK = await HavokPhysics();
   await initPhysicsFromUrl(MODEL_URL, asset, engine);
+  await loadWireframeAsset();
 
   // Frame the camera on the collider bounds.
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 2.4;
-  const orbitHeight = center[1] + radius * 0.5;
+  const orbitDist = radius * 1.5;
+  const orbitHeight = center[1] + radius * 0.35;
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -806,7 +916,6 @@ async function main() {
     const dpr = window.devicePixelRatio || 1;
     const width = canvas.width = Math.floor(window.innerWidth * dpr);
     const height = canvas.height = Math.floor(window.innerHeight * dpr);
-    if (debugCanvas) { debugCanvas.width = width; debugCanvas.height = height; }
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
@@ -817,24 +926,16 @@ async function main() {
 
   setWireframeVisible(showWireframe);
 
-  let angle = 0.6;
-  function render() {
+  // Camera orbit driven directly by wall time.
+  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
+  function render(now) {
     requestAnimationFrame(render);
-
-    if (asset) {
-      let e = asset.popRenderable();
-      while (e.getId() !== 0) { scene.addEntity(e); e = asset.popRenderable(); }
-    }
-
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-
-    angle += 0.0035;
+    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
     const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
     const up = [0, 1, 0];
     camera.lookAt(eye, center, up);
-
     renderer.render(swapChain, view);
-    drawDebug(eye, center, up, aspect);
   }
   requestAnimationFrame(render);
 }


### PR DESCRIPTION
## Summary

Group B-2 part 1: the four `gltf_physics_*` samples that don't use compound bodies — **Motion_Properties**, **Materials_Friction**, **Materials_Restitution**, **Triggers**. They follow the single-canvas pattern from Groups A/B-1/C, and the orbit camera is brought closer to the model per recent user feedback.

## What changed per sample

After the existing physics parsing (untouched) finishes, the sample now builds a **secondary in-code wireframe GLB** — one LINES mesh per Havok body, with positions taken from each shape's existing per-shape line-vertex helper (`makeBox/Sphere/Capsule/CylinderLineVerts` + `shape.meshVerts` for hull / trimesh colliders), and `KHR_materials_unlit` materials (orange dynamic / green static). gltfio loads it alongside the model.

- Dynamic bodies' wireframes are synced to their world transforms every frame in `physicsStep`.
- Static wireframes are placed once at the initial body transform.
- **Triggers** keeps the cyan-idle / red-active behaviour by giving each trigger two wireframe entities and swapping which one is in the scene when `t.active` changes.

The overlay WebGL2 canvas and all of `initDebugCanvas` / `drawDebug` / `debugCanvas` / `debugGl` / etc. are gone, and the orbit camera is now a pure function of wall time (rAF timestamp).

## Closer camera

Per the user feedback that the model looks small in the viewport, the orbit-framing multipliers are tightened:
- `orbitDist` factor: ~2.4–2.6 → ~1.5–1.6 (camera closer to the centre).
- `orbitHeight` factor: ~0.5–0.7 → ~0.35–0.4 (slightly lower so the centre sits roughly at viewport mid-height).

## Verification

All four files `node --check`-pass. **In-browser smoothness, framing, and the trigger active/idle swap still need your visual check.**

## Remaining work

Group B-2 part 2 (Filtering + Basic_Shapes — both use compound bodies) will follow. Each compound body's children's local transforms will be **baked into the wireframe line vertices** so the per-body wireframe entity just follows the body, keeping the rendering symmetric with the non-compound case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)