### PR TITLE
Add W-key physics wireframe toggle to PlayCanvas + ammo.js examples

### DIFF
--- a/examples/playcanvas/ammo/balls/index.html
+++ b/examples/playcanvas/ammo/balls/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/balls/index.js
+++ b/examples/playcanvas/ammo/balls/index.js
@@ -9,8 +9,53 @@ const dataSet = [
     {imageFile:"../../../../assets/textures/TennisBall.jpg", scale:0.3}, // TennisBall.jpg
 ];
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireSphere(app, pos, radius, color) {
+    const pts = [];
+    const segs = 16;
+    for (let axis = 0; axis < 3; axis++) {
+        let prev = null;
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius;
+            const s = Math.sin(t) * radius;
+            let cur;
+            if      (axis === 0) cur = new pc.Vec3(pos.x,     pos.y + c, pos.z + s);
+            else if (axis === 1) cur = new pc.Vec3(pos.x + c, pos.y,     pos.z + s);
+            else                 cur = new pc.Vec3(pos.x + c, pos.y + s, pos.z    );
+            if (prev) { pts.push(prev); pts.push(cur); }
+            prev = cur;
+        }
+    }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphere(app, entity.getPosition(), col.radius, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -26,6 +71,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
@@ -103,7 +156,7 @@ function init() {
         { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
     ];
 
-    let surfaces = [];
+    const staticDebugEntities = [];
     for (let i = 0; i < boxDataSet.length; i++) {
         let size = boxDataSet[i].size
         let pos = boxDataSet[i].pos;
@@ -119,6 +172,7 @@ function init() {
         boxModel.addComponent("model", { type: "box", material: whiteMaterial });
         box.addChild(boxModel);
         app.root.addChild(box);
+        staticDebugEntities.push(box);
     }
 
     let spheres = [];
@@ -148,6 +202,7 @@ function init() {
     floorModel.addComponent("model", { type: "box", material: floorMaterial });
     floor.addChild(floorModel);
     app.root.addChild(floor);
+    staticDebugEntities.push(floor);
 
     let numBalls = 0;
     let balls = [];
@@ -192,5 +247,10 @@ function init() {
         
         camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
         camera.lookAt(0, 0, 0);
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, balls);
+        }
     });
 }

--- a/examples/playcanvas/ammo/balls/style.css
+++ b/examples/playcanvas/ammo/balls/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/box/index.html
+++ b/examples/playcanvas/ammo/box/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/box/index.js
+++ b/examples/playcanvas/ammo/box/index.js
@@ -41,9 +41,54 @@ let dataSet = [
 ];
 
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireSphere(app, pos, radius, color) {
+    const pts = [];
+    const segs = 16;
+    for (let axis = 0; axis < 3; axis++) {
+        let prev = null;
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius;
+            const s = Math.sin(t) * radius;
+            let cur;
+            if      (axis === 0) cur = new pc.Vec3(pos.x,     pos.y + c, pos.z + s);
+            else if (axis === 1) cur = new pc.Vec3(pos.x + c, pos.y,     pos.z + s);
+            else                 cur = new pc.Vec3(pos.x + c, pos.y + s, pos.z    );
+            if (prev) { pts.push(prev); pts.push(cur); }
+            prev = cur;
+        }
+    }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphere(app, entity.getPosition(), col.radius, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 // ***********    Initialize app   *******************
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -87,6 +132,14 @@ function init() {
     // Fill the available space at full resolution
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     app.scene.ambientLight = new pc.Color(1, 1, 1);
 
@@ -245,8 +298,11 @@ function init() {
         ball.fire();
     }, 1000);
 
+    const debugEntities = [ground.entity, ...wall.bricks, ball.entity];
+
     // Register an update event to rotate the camera
     app.on("update", function (dt) {
       camera.update(dt);
+      if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 }

--- a/examples/playcanvas/ammo/box/style.css
+++ b/examples/playcanvas/ammo/box/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/coins/index.html
+++ b/examples/playcanvas/ammo/coins/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/coins/index.js
+++ b/examples/playcanvas/ammo/coins/index.js
@@ -32,6 +32,51 @@ const SETTLE_Y = 4.0;           // a coin resting below this height is lifted ba
 const SETTLE_SPEED = 0.5;       // linear speed below which a coin counts as "still"
 const SETTLE_FRAMES = 18;
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireSphere(app, pos, radius, color) {
+    const pts = [];
+    const segs = 16;
+    for (let axis = 0; axis < 3; axis++) {
+        let prev = null;
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius;
+            const s = Math.sin(t) * radius;
+            let cur;
+            if      (axis === 0) cur = new pc.Vec3(pos.x,     pos.y + c, pos.z + s);
+            else if (axis === 1) cur = new pc.Vec3(pos.x + c, pos.y,     pos.z + s);
+            else                 cur = new pc.Vec3(pos.x + c, pos.y + s, pos.z    );
+            if (prev) { pts.push(prev); pts.push(cur); }
+            prev = cur;
+        }
+    }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphere(app, entity.getPosition(), col.radius, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
     'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
@@ -49,6 +94,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.5, 0.5, 0.5);
@@ -200,6 +253,11 @@ function init() {
 
         camera.setLocalPosition(Math.sin(Math.PI * angle / 180) * 32, 18, Math.cos(Math.PI * angle / 180) * 32);
         camera.lookAt(0, 6, 0);
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, [floor]);
+            drawPhysicsDebug(app, coins.map(c => c.entity));
+        }
 
         for (const coin of coins) {
             const pos = coin.entity.getPosition();

--- a/examples/playcanvas/ammo/coins/style.css
+++ b/examples/playcanvas/ammo/coins/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/cone/index.html
+++ b/examples/playcanvas/ammo/cone/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/cone/index.js
+++ b/examples/playcanvas/ammo/cone/index.js
@@ -1,8 +1,51 @@
 ﻿import * as pc from 'playcanvas';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireCone(app, mat, radius, height, color) {
+    const apex = new pc.Vec3();
+    mat.transformPoint(new pc.Vec3(0, height * 0.5, 0), apex);
+    const segs = 16;
+    const pts = [];
+    const ring = [];
+    for (let i = 0; i <= segs; i++) {
+        const t = (i / segs) * Math.PI * 2;
+        const p = new pc.Vec3();
+        mat.transformPoint(new pc.Vec3(Math.cos(t) * radius, -height * 0.5, Math.sin(t) * radius), p);
+        ring.push(p);
+        if (i > 0) { pts.push(ring[i - 1]); pts.push(p); }
+    }
+    const step = Math.floor(segs / 4);
+    for (let k = 0; k < 4; k++) { pts.push(apex); pts.push(ring[k * step]); }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'cone':
+                _drawWireCone(app, mat, col.radius, col.height, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -18,6 +61,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
@@ -94,7 +145,7 @@ function init() {
         { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
     ];
 
-    let surfaces = [];
+    const staticDebugEntities = [];
     for (let i = 0; i < boxDataSet.length; i++) {
         let size = boxDataSet[i].size
         let pos = boxDataSet[i].pos;
@@ -110,6 +161,7 @@ function init() {
         boxModel.addComponent("model", { type: "box", material: whiteMaterial });
         box.addChild(boxModel);
         app.root.addChild(box);
+        staticDebugEntities.push(box);
     }
 
     const SCALE = 4;
@@ -135,6 +187,7 @@ function init() {
     floorModel.addComponent("model", { type: "box", material: floorMaterial });
     floor.addChild(floorModel);
     app.root.addChild(floor);
+    staticDebugEntities.push(floor);
 
     let numCarrots = 0;
     let carrots = [];
@@ -177,5 +230,10 @@ function init() {
         
         camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
         camera.lookAt(0, 0, 0);
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, carrots);
+        }
     });
 }

--- a/examples/playcanvas/ammo/cone/style.css
+++ b/examples/playcanvas/ammo/cone/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/domino/index.html
+++ b/examples/playcanvas/ammo/domino/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/domino/index.js
+++ b/examples/playcanvas/ammo/domino/index.js
@@ -1,6 +1,9 @@
 ﻿import * as pc from 'playcanvas';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
 let DOT_SIZE = 16;
 let X_START_POS = -7;
 let Y_START_POS =  0;
@@ -43,10 +46,28 @@ let dataSet = [
 
 // ***********    Initialize app   *******************
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(
+            new pc.Vec3(-h.x, -h.y, -h.z),
+            new pc.Vec3( h.x,  h.y,  h.z),
+            color, false, undefined, mat
+        );
+    }
+}
+
+let showWireframe = true;
 
 function init() {
     // create a few materials for our objects
@@ -85,6 +106,14 @@ function init() {
 
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 
@@ -141,6 +170,8 @@ function init() {
     boxTemplateModel.addComponent("model", { type: "box", mateiral: red });
     boxTemplate.addChild(boxTemplateModel);
 
+    const debugEntities = [floor];
+
     for (let i = 0; i < dataSet.length; i++) {
         let x = X_START_POS + (i % 16) * .8;
         let z = Z_START_POS + Math.floor( i / 16 ) * 1.1;
@@ -149,6 +180,7 @@ function init() {
         clone.children[0].model.material = getRgbColor(dataSet[i]);
         clone.setLocalPosition( x, 1, z );
         app.root.addChild(clone);
+        debugEntities.push(clone);
     }
 
     for (let i = 0; i < 16; i++) {
@@ -157,5 +189,10 @@ function init() {
         let z = Z_START_POS + i * 1.1;
         clone.setLocalPosition( x, 3, z );
         app.root.addChild(clone);
+        debugEntities.push(clone);
     }
+
+    app.on('update', function () {
+        if (showWireframe) drawPhysicsDebug(app, debugEntities);
+    });
 }

--- a/examples/playcanvas/ammo/domino/style.css
+++ b/examples/playcanvas/ammo/domino/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/football/index.html
+++ b/examples/playcanvas/ammo/football/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/football/index.js
+++ b/examples/playcanvas/ammo/football/index.js
@@ -40,9 +40,54 @@ let dataSet = [
     "無","茶","無","無","青","青","青","青","無","無","無","無","無","無","無","無"
 ];
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireSphere(app, pos, radius, color) {
+    const pts = [];
+    const segs = 16;
+    for (let axis = 0; axis < 3; axis++) {
+        let prev = null;
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius;
+            const s = Math.sin(t) * radius;
+            let cur;
+            if      (axis === 0) cur = new pc.Vec3(pos.x,     pos.y + c, pos.z + s);
+            else if (axis === 1) cur = new pc.Vec3(pos.x + c, pos.y,     pos.z + s);
+            else                 cur = new pc.Vec3(pos.x + c, pos.y + s, pos.z    );
+            if (prev) { pts.push(prev); pts.push(cur); }
+            prev = cur;
+        }
+    }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphere(app, entity.getPosition(), col.radius, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 // ***********    Initialize app   *******************
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -89,6 +134,14 @@ function init() {
     // Fill the available space at full resolution
     app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
 
     app.scene.ambientLight = new pc.Color(1, 1, 1);
 
@@ -231,9 +284,12 @@ function init() {
         wall.reset();
     }, 1000);
 
+    const debugEntities = [ground.entity, ...wall.balls.map(b => b.entity)];
+
     // Register an update event to rotate the camera
     app.on("update", function (dt) {
       camera.update(dt);
+      if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 
     function getTexture(imageFile, width, height) {

--- a/examples/playcanvas/ammo/football/style.css
+++ b/examples/playcanvas/ammo/football/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/gltf/index.html
+++ b/examples/playcanvas/ammo/gltf/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/gltf/index.js
+++ b/examples/playcanvas/ammo/gltf/index.js
@@ -1,8 +1,25 @@
 ﻿import * as pc from 'playcanvas';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -18,6 +35,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
@@ -122,6 +147,8 @@ function init() {
     floor.addChild(floorModel);
     app.root.addChild(floor);
 
+    const debugEntities = [duckBody, floor];
+
     let angle = 0;
     let time = 0;
     let maxErasers = 200;
@@ -131,5 +158,6 @@ function init() {
         angle += 0.5 * ADJUST_SPEED;
         camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 4, 3, Math.cos(Math.PI*angle/180) * 4);
         camera.lookAt(0, 0, 0);
+        if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 }

--- a/examples/playcanvas/ammo/gltf/style.css
+++ b/examples/playcanvas/ammo/gltf/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/marbles/index.html
+++ b/examples/playcanvas/ammo/marbles/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/marbles/index.js
+++ b/examples/playcanvas/ammo/marbles/index.js
@@ -9,6 +9,51 @@ const MARBLE_RADIUS = 0.5;
 const MARBLE_VISUAL_SCALE = 0.42;
 const HDR_URL = "https://cx20.github.io/gltf-test/textures/hdr/papermill_playcanvas_texture-tool.hdr";
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _drawWireSphere(app, pos, radius, color) {
+    const pts = [];
+    const segs = 16;
+    for (let axis = 0; axis < 3; axis++) {
+        let prev = null;
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius;
+            const s = Math.sin(t) * radius;
+            let cur;
+            if      (axis === 0) cur = new pc.Vec3(pos.x,     pos.y + c, pos.z + s);
+            else if (axis === 1) cur = new pc.Vec3(pos.x + c, pos.y,     pos.z + s);
+            else                 cur = new pc.Vec3(pos.x + c, pos.y + s, pos.z    );
+            if (prev) { pts.push(prev); pts.push(cur); }
+            prev = cur;
+        }
+    }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphere(app, entity.getPosition(), col.radius, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
     'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
@@ -26,6 +71,14 @@ function init() {
 
     window.addEventListener("resize", function() {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.7, 0.7, 0.7);
@@ -95,6 +148,7 @@ function init() {
         { size: [1, 10, 10], pos: [5, 5, 0] }
     ];
 
+    const staticDebugEntities = [floor];
     for (const wall of wallData) {
         const box = new pc.Entity("box");
         box.setLocalPosition(wall.pos[0], wall.pos[1], wall.pos[2]);
@@ -110,6 +164,7 @@ function init() {
 
         box.addChild(boxModel);
         app.root.addChild(box);
+        staticDebugEntities.push(box);
     }
 
     function randomRange(min, max) {
@@ -224,6 +279,11 @@ function init() {
         const z = Math.cos(Math.PI * angle / 180) * 18;
         camera.setLocalPosition(x, 9, z);
         camera.lookAt(0, 2, 0);
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, marbles);
+        }
 
         for (const marble of marbles) {
             if (marble.getPosition().y < -10) {

--- a/examples/playcanvas/ammo/marbles/style.css
+++ b/examples/playcanvas/ammo/marbles/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/minimum/index.html
+++ b/examples/playcanvas/ammo/minimum/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/minimum/index.js
+++ b/examples/playcanvas/ammo/minimum/index.js
@@ -2,11 +2,32 @@
 
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(
+            new pc.Vec3(-h.x, -h.y, -h.z),
+            new pc.Vec3( h.x,  h.y,  h.z),
+            color, false, undefined, mat
+        );
+    }
+}
+
+let showWireframe = true;
 
 function init() {
     let canvas = document.getElementById("c");
@@ -19,6 +40,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
     app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
@@ -90,5 +119,10 @@ function init() {
     floorModel.addComponent("model", { type: "box", material: textureMaterial });
     floor.addChild(floorModel);
     app.root.addChild(floor);
+
+    const debugEntities = [box, floor];
+    app.on('update', function () {
+        if (showWireframe) drawPhysicsDebug(app, debugEntities);
+    });
 
 }

--- a/examples/playcanvas/ammo/minimum/style.css
+++ b/examples/playcanvas/ammo/minimum/style.css
@@ -9,3 +9,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Add W-key wireframe debug rendering to 9 PlayCanvas + ammo.js examples: minimum, domino, football, box (Stacked Boxes), balls, gltf, cone, coins, marbles
- dynamic bodies drawn in green, static bodies in yellow; hint label shown top-left
- Supported shapes: box (`drawWireAlignedBox`), sphere (3-ring), cone (base circle + 4 apex lines)
- Fix bug in domino: world scale was incorrectly baked into the draw matrix (PlayCanvas does not apply entity scale to box/sphere collision shapes)

## Test plan

- [ ] Open each example in a browser and confirm wireframe shapes are visible on load
- [ ] Press W to toggle OFF — wireframes disappear, hint reads "W: wireframe OFF"
- [ ] Press W again to toggle ON — wireframes reappear
- [ ] Verify wireframe positions track physics bodies correctly during simulation (domino, football, balls, cone, coins, marbles)
- [ ] Confirm cone wireframes rotate with the falling carrot bodies
- [ ] Confirm gltf duck box wireframe appears after the glTF asset loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)