### PR TITLE
Add PlayCanvas + ammo.js Falling Shogi example

### DIFF
--- a/examples/playcanvas/ammo/shogi/index.html
+++ b/examples/playcanvas/ammo/shogi/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>[WIP] PlayCanvas + ammo.js Falling Shogi Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+      "imports": {
+          "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+      }
+  }
+  </script>
+</head>
+<body>
+<canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
+
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -267,23 +267,43 @@ function init() {
     shogiMesh.setIndices(geo.indices);
     shogiMesh.update();
 
-    // Build a shared btConvexHullShape from the mesh vertices.
-    // All dynamic pieces share this one shape instance; Bullet supports this safely.
-    function buildConvexHull(positions) {
+    // Pre-compute the unique vertex positions (10 points) for the convex hull.
+    // Using only unique points produces a cleaner hull and avoids degenerate faces
+    // that cause contact instability. Each piece gets its OWN btConvexHullShape
+    // instance — sharing one shape between many dynamic bodies confuses Bullet's
+    // contact-manifold cache and causes jitter.
+    const uniqueHullPositions = (() => {
+        const seen = new Set();
+        const pts = [];
+        const pos = geo.pos;
+        for (let i = 0; i < pos.length; i += 3) {
+            const key = `${pos[i].toFixed(4)},${pos[i+1].toFixed(4)},${pos[i+2].toFixed(4)}`;
+            if (!seen.has(key)) {
+                seen.add(key);
+                pts.push(pos[i], pos[i+1], pos[i+2]);
+            }
+        }
+        return pts;
+    })();
+
+    function buildConvexHull() {
         const shape = new Ammo.btConvexHullShape();
-        for (let i = 0; i < positions.length; i += 3) {
-            const v = new Ammo.btVector3(positions[i], positions[i+1], positions[i+2]);
+        for (let i = 0; i < uniqueHullPositions.length; i += 3) {
+            const v = new Ammo.btVector3(
+                uniqueHullPositions[i],
+                uniqueHullPositions[i+1],
+                uniqueHullPositions[i+2]
+            );
             shape.addPoint(v, false);
             Ammo.destroy(v);
         }
         shape.recalcLocalAabb();
         return shape;
     }
-    const convexHull = buildConvexHull(geo.pos);
 
     // A dummy box halfExtents is still given to the PlayCanvas collision component
     // so the entity participates in the PC collision event system. The Ammo body's
-    // actual shape is replaced with the convex hull immediately after spawn.
+    // actual shape is replaced with a per-piece convex hull immediately after spawn.
     const halfW = PIECE_W / 2;
     const halfH = PIECE_H / 2;
     const halfD = PIECE_D * 0.7;
@@ -313,16 +333,20 @@ function init() {
         piece.addChild(visual);
         app.root.addChild(piece);
 
-        // Replace the box shape on the Ammo rigid body with the convex hull.
+        // Replace the box shape on the Ammo rigid body with a fresh convex hull.
         // The body is created synchronously during addChild, so it is available here.
         const body = piece.rigidbody.body;
         if (body) {
-            body.setCollisionShape(convexHull);
+            const hull = buildConvexHull();
+            body.setCollisionShape(hull);
             const li = new Ammo.btVector3(0, 0, 0);
-            convexHull.calculateLocalInertia(1.0, li);
+            hull.calculateLocalInertia(1.0, li);
             body.setMassProps(1.0, li);
             body.updateInertiaTensor();
             Ammo.destroy(li);
+            // Damping and sleep thresholds help pieces settle without jitter.
+            body.setDamping(0.05, 0.1);
+            body.setSleepingThresholds(0.1, 0.1);
         }
 
         return piece;

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -105,6 +105,32 @@ function drawPhysicsDebug(app, entities) {
     }
 }
 
+// Draw the actual pentagon-prism mesh edges for each shogi piece.
+// All pieces are batched into a single drawLines call for efficiency.
+function drawShogiMeshWireframe(app, pieces, geo) {
+    if (pieces.length === 0) return;
+    const positions = geo.pos;
+    const indices   = geo.indices;
+    const pa = new pc.Vec3(), pb = new pc.Vec3();
+    const wa = new pc.Vec3(), wb = new pc.Vec3();
+    const pts = [];
+    for (const piece of pieces) {
+        const mat = new pc.Mat4().setTRS(
+            piece.getPosition(), piece.getRotation(), pc.Vec3.ONE
+        );
+        for (let i = 0; i < indices.length; i += 3) {
+            const i0 = indices[i], i1 = indices[i+1], i2 = indices[i+2];
+            for (const [a, b] of [[i0,i1],[i1,i2],[i2,i0]]) {
+                pa.set(positions[a*3], positions[a*3+1], positions[a*3+2]);
+                pb.set(positions[b*3], positions[b*3+1], positions[b*3+2]);
+                mat.transformPoint(pa, wa); mat.transformPoint(pb, wb);
+                pts.push(wa.clone(), wb.clone());
+            }
+        }
+    }
+    app.drawLines(pts, pts.map(() => _DBG_COLOR_DYNAMIC), false);
+}
+
 let showWireframe = true;
 
 loadWasmModuleAsync(
@@ -241,7 +267,23 @@ function init() {
     shogiMesh.setIndices(geo.indices);
     shogiMesh.update();
 
-    // Box collision half-extents that tightly wrap the pentagon-prism mesh.
+    // Build a shared btConvexHullShape from the mesh vertices.
+    // All dynamic pieces share this one shape instance; Bullet supports this safely.
+    function buildConvexHull(positions) {
+        const shape = new Ammo.btConvexHullShape();
+        for (let i = 0; i < positions.length; i += 3) {
+            const v = new Ammo.btVector3(positions[i], positions[i+1], positions[i+2]);
+            shape.addPoint(v, false);
+            Ammo.destroy(v);
+        }
+        shape.recalcLocalAabb();
+        return shape;
+    }
+    const convexHull = buildConvexHull(geo.pos);
+
+    // A dummy box halfExtents is still given to the PlayCanvas collision component
+    // so the entity participates in the PC collision event system. The Ammo body's
+    // actual shape is replaced with the convex hull immediately after spawn.
     const halfW = PIECE_W / 2;
     const halfH = PIECE_H / 2;
     const halfD = PIECE_D * 0.7;
@@ -270,6 +312,19 @@ function init() {
         });
         piece.addChild(visual);
         app.root.addChild(piece);
+
+        // Replace the box shape on the Ammo rigid body with the convex hull.
+        // The body is created synchronously during addChild, so it is available here.
+        const body = piece.rigidbody.body;
+        if (body) {
+            body.setCollisionShape(convexHull);
+            const li = new Ammo.btVector3(0, 0, 0);
+            convexHull.calculateLocalInertia(1.0, li);
+            body.setMassProps(1.0, li);
+            body.updateInertiaTensor();
+            Ammo.destroy(li);
+        }
+
         return piece;
     }
 
@@ -312,8 +367,8 @@ function init() {
         }
 
         if (showWireframe) {
-            drawPhysicsDebug(app, staticDebugEntities);
-            drawPhysicsDebug(app, pieces);
+            drawPhysicsDebug(app, staticDebugEntities);   // box wireframe for floor/walls
+            drawShogiMeshWireframe(app, pieces, geo);      // mesh edge wireframe for pieces
         }
     });
 }

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -145,11 +145,10 @@ function init() {
         return m;
     }
 
-    function getTexture(imageFile, flipY) {
-        // Do NOT pre-allocate a fixed size — setSource must match the texture's allocated
-        // dimensions. Passing { width, height } that differ from the actual image causes
-        // GL_INVALID_VALUE in texSubImage2D.
-        const texture = new pc.Texture(app.graphicsDevice);
+    function getTexture(imageFile, w, h, flipY) {
+        // Pre-allocate at the EXACT image dimensions — PlayCanvas uses texSubImage2D for
+        // setSource() and throws GL_INVALID_VALUE if the sizes don't match.
+        const texture = new pc.Texture(app.graphicsDevice, { width: w, height: h });
         const img = new Image();
         img.onload = function () {
             if (flipY === false) texture.flipY = false;
@@ -164,9 +163,10 @@ function init() {
         return texture;
     }
 
-    function createTextureMaterial(imageFile, flipY) {
+    function createTextureMaterial(imageFile, w, h, flipY) {
         const m = new pc.StandardMaterial();
-        m.diffuseMap = getTexture(imageFile, flipY);
+        m.diffuseMap = getTexture(imageFile, w, h, flipY);
+        m.cull = pc.CULLFACE_NONE;
         m.update();
         return m;
     }
@@ -194,8 +194,8 @@ function init() {
     app.root.addChild(camera);
 
     const wallMat  = createTransparentMaterial(new pc.Color(1, 1, 1));
-    const floorMat = createTextureMaterial("../../../../assets/textures/grass.jpg");
-    const shogiMat = createTextureMaterial("../../../../assets/textures/shogi_001/shogi.png", false);
+    const floorMat = createTextureMaterial("../../../../assets/textures/grass.jpg", 512, 512);
+    const shogiMat = createTextureMaterial("../../../../assets/textures/shogi_001/shogi.png", 1024, 512, false);
 
     const floor = new pc.Entity("floor");
     floor.setLocalPosition(0, -2, 0);
@@ -265,11 +265,9 @@ function init() {
             restitution: 0.3
         });
         const visual = new pc.Entity("visual");
-        const pcModel = new pc.Model();
-        pcModel.graph = new pc.GraphNode();
-        pcModel.meshInstances = [new pc.MeshInstance(shogiMesh, shogiMat, pcModel.graph)];
-        visual.addComponent("model");
-        visual.model.model = pcModel;
+        visual.addComponent("render", {
+            meshInstances: [new pc.MeshInstance(shogiMesh, shogiMat)]
+        });
         piece.addChild(visual);
         app.root.addChild(piece);
         return piece;

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -133,10 +133,11 @@ function init() {
         return m;
     }
 
-    function getTexture(imageFile) {
+    function getTexture(imageFile, flipY) {
         const texture = new pc.Texture(app.graphicsDevice, { width: 512, height: 512 });
         const img = new Image();
         img.onload = function () {
+            if (flipY === false) texture.flipY = false;
             texture.minFilter = pc.FILTER_LINEAR;
             texture.magFilter = pc.FILTER_LINEAR;
             texture.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
@@ -148,9 +149,9 @@ function init() {
         return texture;
     }
 
-    function createTextureMaterial(imageFile) {
+    function createTextureMaterial(imageFile, flipY) {
         const m = new pc.StandardMaterial();
-        m.diffuseMap = getTexture(imageFile);
+        m.diffuseMap = getTexture(imageFile, flipY);
         m.cull = pc.CULLFACE_NONE;
         m.update();
         return m;
@@ -179,7 +180,7 @@ function init() {
 
     const wallMat  = createTransparentMaterial(new pc.Color(1, 1, 1));
     const floorMat = createTextureMaterial("../../../../assets/textures/grass.jpg");
-    const shogiMat = createTextureMaterial("../../../../assets/textures/shogi_001/shogi.png");
+    const shogiMat = createTextureMaterial("../../../../assets/textures/shogi_001/shogi.png", false);
 
     const floor = new pc.Entity("floor");
     floor.setLocalPosition(0, -2, 0);

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -146,7 +146,10 @@ function init() {
     }
 
     function getTexture(imageFile, flipY) {
-        const texture = new pc.Texture(app.graphicsDevice, { width: 512, height: 512 });
+        // Do NOT pre-allocate a fixed size — setSource must match the texture's allocated
+        // dimensions. Passing { width, height } that differ from the actual image causes
+        // GL_INVALID_VALUE in texSubImage2D.
+        const texture = new pc.Texture(app.graphicsDevice);
         const img = new Image();
         img.onload = function () {
             if (flipY === false) texture.flipY = false;
@@ -164,7 +167,6 @@ function init() {
     function createTextureMaterial(imageFile, flipY) {
         const m = new pc.StandardMaterial();
         m.diffuseMap = getTexture(imageFile, flipY);
-        m.cull = pc.CULLFACE_NONE;
         m.update();
         return m;
     }
@@ -263,9 +265,11 @@ function init() {
             restitution: 0.3
         });
         const visual = new pc.Entity("visual");
-        visual.addComponent("render", {
-            meshInstances: [new pc.MeshInstance(shogiMesh, shogiMat)]
-        });
+        const pcModel = new pc.Model();
+        pcModel.graph = new pc.GraphNode();
+        pcModel.meshInstances = [new pc.MeshInstance(shogiMesh, shogiMat, pcModel.graph)];
+        visual.addComponent("model");
+        visual.model.model = pcModel;
         piece.addChild(visual);
         app.root.addChild(piece);
         return piece;

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -267,43 +267,6 @@ function init() {
     shogiMesh.setIndices(geo.indices);
     shogiMesh.update();
 
-    // Pre-compute the unique vertex positions (10 points) for the convex hull.
-    // Using only unique points produces a cleaner hull and avoids degenerate faces
-    // that cause contact instability. Each piece gets its OWN btConvexHullShape
-    // instance — sharing one shape between many dynamic bodies confuses Bullet's
-    // contact-manifold cache and causes jitter.
-    const uniqueHullPositions = (() => {
-        const seen = new Set();
-        const pts = [];
-        const pos = geo.pos;
-        for (let i = 0; i < pos.length; i += 3) {
-            const key = `${pos[i].toFixed(4)},${pos[i+1].toFixed(4)},${pos[i+2].toFixed(4)}`;
-            if (!seen.has(key)) {
-                seen.add(key);
-                pts.push(pos[i], pos[i+1], pos[i+2]);
-            }
-        }
-        return pts;
-    })();
-
-    function buildConvexHull() {
-        const shape = new Ammo.btConvexHullShape();
-        for (let i = 0; i < uniqueHullPositions.length; i += 3) {
-            const v = new Ammo.btVector3(
-                uniqueHullPositions[i],
-                uniqueHullPositions[i+1],
-                uniqueHullPositions[i+2]
-            );
-            shape.addPoint(v, false);
-            Ammo.destroy(v);
-        }
-        shape.recalcLocalAabb();
-        return shape;
-    }
-
-    // A dummy box halfExtents is still given to the PlayCanvas collision component
-    // so the entity participates in the PC collision event system. The Ammo body's
-    // actual shape is replaced with a per-piece convex hull immediately after spawn.
     const halfW = PIECE_W / 2;
     const halfH = PIECE_H / 2;
     const halfD = PIECE_D * 0.7;
@@ -332,23 +295,6 @@ function init() {
         });
         piece.addChild(visual);
         app.root.addChild(piece);
-
-        // Replace the box shape on the Ammo rigid body with a fresh convex hull.
-        // The body is created synchronously during addChild, so it is available here.
-        const body = piece.rigidbody.body;
-        if (body) {
-            const hull = buildConvexHull();
-            body.setCollisionShape(hull);
-            const li = new Ammo.btVector3(0, 0, 0);
-            hull.calculateLocalInertia(1.0, li);
-            body.setMassProps(1.0, li);
-            body.updateInertiaTensor();
-            Ammo.destroy(li);
-            // Higher angular damping suppresses wobble on thin flat pieces.
-            body.setDamping(0.05, 0.5);
-            body.setSleepingThresholds(0.1, 0.1);
-        }
-
         return piece;
     }
 
@@ -359,14 +305,6 @@ function init() {
         const z = (Math.random() - 0.5) * 8;
         pieces.push(createPiece(x, y, z));
     }
-
-    // Split impulse separates penetration correction from velocity changes,
-    // which is the primary Bullet fix for resting-contact jitter on stacked objects.
-    // More solver iterations help the constraint solver converge under the pile load.
-    const solverInfo = app.systems.rigidbody.dynamicsWorld.getSolverInfo();
-    solverInfo.m_numIterations = 20;
-    solverInfo.m_splitImpulse = 1;
-    solverInfo.m_splitImpulsePenetrationThreshold = -0.02;
 
     let angle = 0;
     const EXPECTED_FPS = 60;
@@ -399,8 +337,8 @@ function init() {
         }
 
         if (showWireframe) {
-            drawPhysicsDebug(app, staticDebugEntities);   // box wireframe for floor/walls
-            drawShogiMeshWireframe(app, pieces, geo);      // mesh edge wireframe for pieces
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, pieces);
         }
     });
 }

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -344,8 +344,8 @@ function init() {
             body.setMassProps(1.0, li);
             body.updateInertiaTensor();
             Ammo.destroy(li);
-            // Damping and sleep thresholds help pieces settle without jitter.
-            body.setDamping(0.05, 0.1);
+            // Higher angular damping suppresses wobble on thin flat pieces.
+            body.setDamping(0.05, 0.5);
             body.setSleepingThresholds(0.1, 0.1);
         }
 
@@ -359,6 +359,14 @@ function init() {
         const z = (Math.random() - 0.5) * 8;
         pieces.push(createPiece(x, y, z));
     }
+
+    // Split impulse separates penetration correction from velocity changes,
+    // which is the primary Bullet fix for resting-contact jitter on stacked objects.
+    // More solver iterations help the constraint solver converge under the pile load.
+    const solverInfo = app.systems.rigidbody.dynamicsWorld.getSolverInfo();
+    solverInfo.m_numIterations = 20;
+    solverInfo.m_splitImpulse = 1;
+    solverInfo.m_splitImpulsePenetrationThreshold = -0.02;
 
     let angle = 0;
     const EXPECTED_FPS = 60;

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -43,17 +43,29 @@ function buildShogiGeometry(w, h, d) {
         0.75, 0.0,  1.0, 0.0,  1.0, 0.5,  0.75, 0.5,
         0.75, 0.0,  1.0, 0.0,  1.0, 0.5,  0.75, 0.5,
     ];
+    // Winding is corrected so that cross-product normals point outward for each face.
+    // Front and left faces are CCW-from-outside already; the rest are reversed.
     const indices = [
+        // Front  (+Z outward — unchanged)
          0,  1,  2,   0,  2,  3,
-         4,  5,  6,   4,  6,  7,
-         8,  9, 10,   8, 10, 11,
-        12, 13, 14,  12, 14, 15,
-        16, 17, 18,  16, 18, 19,
+        // Back   (−Z outward — reversed)
+         4,  6,  5,   4,  7,  6,
+        // Top    (+Y outward — reversed)
+         8, 10,  9,   8, 11, 10,
+        // Bottom (−Y outward — reversed)
+        12, 14, 13,  12, 15, 14,
+        // Right  (+X outward — reversed)
+        16, 18, 17,  16, 19, 18,
+        // Left   (−X outward — unchanged)
         20, 21, 22,  20, 22, 23,
+        // Apex front  (unchanged)
         24, 25, 26,
-        27, 28, 29,
-        30, 33, 31,  33, 32, 31,
-        34, 35, 36,  34, 36, 37,
+        // Apex back   (reversed)
+        27, 29, 28,
+        // Apex right  (reversed)
+        30, 31, 33,  33, 31, 32,
+        // Apex left   (reversed)
+        34, 36, 35,  34, 37, 36,
     ];
     return { pos, uvs, indices };
 }
@@ -122,7 +134,7 @@ function init() {
         if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
-    app.scene.ambientLight = new pc.Color(0.5, 0.5, 0.5);
+    app.scene.ambientLight = new pc.Color(0.8, 0.8, 0.8);
 
     function createTransparentMaterial(color) {
         const m = new pc.StandardMaterial();
@@ -161,6 +173,7 @@ function init() {
     light.addComponent("light", {
         type: "directional",
         color: new pc.Color(1, 1, 1),
+        intensity: 2.0,
         castShadows: true,
         shadowResolution: 2048,
         shadowBias: 0.2,

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -1,0 +1,303 @@
+import * as pc from 'playcanvas';
+import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
+
+const PIECE_W     = 1.6;
+const PIECE_H     = 1.6;
+const PIECE_D     = 0.45;
+const PIECE_COUNT = 220;
+
+// Pentagon-prism shogi piece geometry.
+// Vertex layout matches the three.js / Filament versions so the same shogi.png UV mapping works.
+function buildShogiGeometry(w, h, d) {
+    const pos = [
+        // Front (0-3)
+        -0.5*w, -0.5*h,  0.7*d,   0.5*w, -0.5*h,  0.7*d,   0.35*w,  0.5*h,  0.4*d,  -0.35*w,  0.5*h,  0.4*d,
+        // Back (4-7)
+        -0.5*w, -0.5*h, -0.7*d,   0.5*w, -0.5*h, -0.7*d,   0.35*w,  0.5*h, -0.4*d,  -0.35*w,  0.5*h, -0.4*d,
+        // Top (8-11)
+         0.35*w,  0.5*h,  0.4*d,  -0.35*w,  0.5*h,  0.4*d,  -0.35*w,  0.5*h, -0.4*d,   0.35*w,  0.5*h, -0.4*d,
+        // Bottom (12-15)
+        -0.5*w, -0.5*h,  0.7*d,   0.5*w, -0.5*h,  0.7*d,   0.5*w, -0.5*h, -0.7*d,  -0.5*w, -0.5*h, -0.7*d,
+        // Right (16-19)
+         0.5*w, -0.5*h,  0.7*d,   0.35*w,  0.5*h,  0.4*d,   0.35*w,  0.5*h, -0.4*d,   0.5*w, -0.5*h, -0.7*d,
+        // Left (20-23)
+        -0.5*w, -0.5*h,  0.7*d,  -0.35*w,  0.5*h,  0.4*d,  -0.35*w,  0.5*h, -0.4*d,  -0.5*w, -0.5*h, -0.7*d,
+        // Apex front (24-26)
+        -0.35*w,  0.5*h,  0.4*d,   0.35*w,  0.5*h,  0.4*d,   0,  0.6*h,  0.35*d,
+        // Apex back (27-29)
+        -0.35*w,  0.5*h, -0.4*d,   0.35*w,  0.5*h, -0.4*d,   0,  0.6*h, -0.35*d,
+        // Apex right (30-33)
+         0.35*w,  0.5*h,  0.4*d,   0.35*w,  0.5*h, -0.4*d,   0,  0.6*h, -0.35*d,   0,  0.6*h,  0.35*d,
+        // Apex left (34-37)
+        -0.35*w,  0.5*h,  0.4*d,  -0.35*w,  0.5*h, -0.4*d,   0,  0.6*h, -0.35*d,   0,  0.6*h,  0.35*d,
+    ];
+    const uvs = [
+        0.5, 0.5,  0.75, 0.5,  0.75-0.25/8, 1.0,  0.5+0.25/8, 1.0,
+        0.5, 0.5,  0.25, 0.5,  0.25+0.25/8, 1.0,  0.5-0.25/8, 1.0,
+        0.75, 0.5,  0.5, 0.5,  0.5, 0.0,  0.75, 0.0,
+        0.0, 0.5,  0.25, 0.5,  0.25, 1.0,  0.0, 1.0,
+        0.0, 0.5,  0.0, 0.0,  0.25, 0.0,  0.25, 0.5,
+        0.5, 0.5,  0.5, 0.0,  0.25, 0.0,  0.25, 0.5,
+        0.75, 0.0,  1.0, 0.0,  1.0, 0.5,
+        0.75, 0.0,  1.0, 0.0,  1.0, 0.5,
+        0.75, 0.0,  1.0, 0.0,  1.0, 0.5,  0.75, 0.5,
+        0.75, 0.0,  1.0, 0.0,  1.0, 0.5,  0.75, 0.5,
+    ];
+    const indices = [
+         0,  1,  2,   0,  2,  3,
+         4,  5,  6,   4,  6,  7,
+         8,  9, 10,   8, 10, 11,
+        12, 13, 14,  12, 14, 15,
+        16, 17, 18,  16, 18, 19,
+        20, 21, 22,  20, 22, 23,
+        24, 25, 26,
+        27, 28, 29,
+        30, 33, 31,  33, 32, 31,
+        34, 35, 36,  34, 36, 37,
+    ];
+    return { pos, uvs, indices };
+}
+
+function computeNormals(pos, indices) {
+    const n = new Array(pos.length).fill(0);
+    for (let i = 0; i < indices.length; i += 3) {
+        const a = indices[i] * 3, b = indices[i + 1] * 3, c = indices[i + 2] * 3;
+        const ux = pos[b]   - pos[a],   uy = pos[b+1] - pos[a+1], uz = pos[b+2] - pos[a+2];
+        const vx = pos[c]   - pos[a],   vy = pos[c+1] - pos[a+1], vz = pos[c+2] - pos[a+2];
+        const nx = uy*vz - uz*vy, ny = uz*vx - ux*vz, nz = ux*vy - uy*vx;
+        for (const k of [a, b, c]) { n[k] += nx; n[k+1] += ny; n[k+2] += nz; }
+    }
+    for (let i = 0; i < n.length; i += 3) {
+        const l = Math.hypot(n[i], n[i+1], n[i+2]) || 1;
+        n[i] /= l; n[i+1] /= l; n[i+2] /= l;
+    }
+    return n;
+}
+
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(
+            new pc.Vec3(-h.x, -h.y, -h.z),
+            new pc.Vec3( h.x,  h.y,  h.z),
+            color, false, undefined, mat
+        );
+    }
+}
+
+let showWireframe = true;
+
+loadWasmModuleAsync(
+    'Ammo',
+    'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
+    'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
+    init
+);
+
+function init() {
+    const canvas = document.getElementById("c");
+    const app = new pc.Application(canvas);
+    app.start();
+
+    app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+    app.setCanvasResolution(pc.RESOLUTION_AUTO);
+
+    window.addEventListener("resize", function () {
+        app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
+    app.scene.ambientLight = new pc.Color(0.5, 0.5, 0.5);
+
+    function createTransparentMaterial(color) {
+        const m = new pc.StandardMaterial();
+        m.diffuse = color;
+        m.opacity = 0.3;
+        m.blendType = pc.BLEND_NORMAL;
+        m.update();
+        return m;
+    }
+
+    function getTexture(imageFile) {
+        const texture = new pc.Texture(app.graphicsDevice, { width: 512, height: 512 });
+        const img = new Image();
+        img.onload = function () {
+            texture.minFilter = pc.FILTER_LINEAR;
+            texture.magFilter = pc.FILTER_LINEAR;
+            texture.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+            texture.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+            texture.setSource(img);
+        };
+        img.crossOrigin = "anonymous";
+        img.src = imageFile;
+        return texture;
+    }
+
+    function createTextureMaterial(imageFile) {
+        const m = new pc.StandardMaterial();
+        m.diffuseMap = getTexture(imageFile);
+        m.cull = pc.CULLFACE_NONE;
+        m.update();
+        return m;
+    }
+
+    const light = new pc.Entity("light");
+    light.addComponent("light", {
+        type: "directional",
+        color: new pc.Color(1, 1, 1),
+        castShadows: true,
+        shadowResolution: 2048,
+        shadowBias: 0.2,
+        normalOffsetBias: 0.05
+    });
+    light.setLocalEulerAngles(45, 45, 45);
+    app.root.addChild(light);
+
+    const camera = new pc.Entity("camera");
+    camera.addComponent("camera", {
+        clearColor: new pc.Color(0.13, 0.14, 0.16),
+        nearClip: 0.01,
+        farClip: 1000,
+        fov: 60
+    });
+    app.root.addChild(camera);
+
+    const wallMat  = createTransparentMaterial(new pc.Color(1, 1, 1));
+    const floorMat = createTextureMaterial("../../../../assets/textures/grass.jpg");
+    const shogiMat = createTextureMaterial("../../../../assets/textures/shogi_001/shogi.png");
+
+    const floor = new pc.Entity("floor");
+    floor.setLocalPosition(0, -2, 0);
+    floor.addComponent("collision", { type: "box", halfExtents: [20, 2, 20] });
+    floor.addComponent("rigidbody", { type: "static", friction: 0.6, restitution: 0.2 });
+    const floorModel = new pc.Entity("floorModel");
+    floorModel.setLocalScale(40, 4, 40);
+    floorModel.addComponent("model", { type: "box", material: floorMat });
+    floor.addChild(floorModel);
+    app.root.addChild(floor);
+
+    const wallData = [
+        { size: [10, 10,  1], pos: [ 0, 5, -5] },
+        { size: [10, 10,  1], pos: [ 0, 5,  5] },
+        { size: [ 1, 10, 10], pos: [-5, 5,  0] },
+        { size: [ 1, 10, 10], pos: [ 5, 5,  0] },
+    ];
+
+    const staticDebugEntities = [floor];
+    for (const wd of wallData) {
+        const box = new pc.Entity("wall");
+        box.setLocalPosition(wd.pos[0], wd.pos[1], wd.pos[2]);
+        box.addComponent("collision", {
+            type: "box",
+            halfExtents: [wd.size[0] / 2, wd.size[1] / 2, wd.size[2] / 2]
+        });
+        box.addComponent("rigidbody", { type: "static", friction: 0.6, restitution: 0.2 });
+        const boxModel = new pc.Entity("wallModel");
+        boxModel.setLocalScale(wd.size[0], wd.size[1], wd.size[2]);
+        boxModel.addComponent("model", { type: "box", material: wallMat });
+        box.addChild(boxModel);
+        app.root.addChild(box);
+        staticDebugEntities.push(box);
+    }
+
+    // Build the shared shogi mesh (pentagon-prism).
+    const geo     = buildShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
+    const normals = computeNormals(geo.pos, geo.indices);
+    const shogiMesh = new pc.Mesh(app.graphicsDevice);
+    shogiMesh.setPositions(geo.pos);
+    shogiMesh.setNormals(normals);
+    shogiMesh.setUvs(0, geo.uvs);
+    shogiMesh.setIndices(geo.indices);
+    shogiMesh.update();
+
+    // Box collision half-extents that tightly wrap the pentagon-prism mesh.
+    const halfW = PIECE_W / 2;
+    const halfH = PIECE_H / 2;
+    const halfD = PIECE_D * 0.7;
+
+    function createPiece(x, y, z) {
+        const piece = new pc.Entity("piece");
+        piece.setLocalPosition(x, y, z);
+        piece.setLocalEulerAngles(
+            Math.random() * 360,
+            Math.random() * 360,
+            Math.random() * 360
+        );
+        piece.addComponent("collision", {
+            type: "box",
+            halfExtents: [halfW, halfH, halfD]
+        });
+        piece.addComponent("rigidbody", {
+            type: "dynamic",
+            mass: 1,
+            friction: 0.4,
+            restitution: 0.3
+        });
+        const visual = new pc.Entity("visual");
+        visual.addComponent("render", {
+            meshInstances: [new pc.MeshInstance(shogiMesh, shogiMat)]
+        });
+        piece.addChild(visual);
+        app.root.addChild(piece);
+        return piece;
+    }
+
+    const pieces = [];
+    for (let i = 0; i < PIECE_COUNT; i++) {
+        const x = (Math.random() - 0.5) * 8;
+        const y = 2 + Math.random() * 36;
+        const z = (Math.random() - 0.5) * 8;
+        pieces.push(createPiece(x, y, z));
+    }
+
+    let angle = 0;
+    const EXPECTED_FPS = 60;
+    app.on("update", function (dt) {
+        const adj = dt / (1 / EXPECTED_FPS);
+        angle += 0.4 * adj;
+
+        camera.setLocalPosition(
+            Math.sin(Math.PI * angle / 180) * 28,
+            14,
+            Math.cos(Math.PI * angle / 180) * 28
+        );
+        camera.lookAt(0, 4, 0);
+
+        for (const piece of pieces) {
+            if (piece.getPosition().y < -10) {
+                const x = (Math.random() - 0.5) * 8;
+                const y = 12 + Math.random() * 26;
+                const z = (Math.random() - 0.5) * 8;
+                piece.setLocalPosition(x, y, z);
+                piece.setLocalEulerAngles(
+                    Math.random() * 360,
+                    Math.random() * 360,
+                    Math.random() * 360
+                );
+                piece.rigidbody.linearVelocity  = pc.Vec3.ZERO;
+                piece.rigidbody.angularVelocity = pc.Vec3.ZERO;
+                piece.rigidbody.syncEntityToBody();
+            }
+        }
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, pieces);
+        }
+    });
+}

--- a/examples/playcanvas/ammo/shogi/style.css
+++ b/examples/playcanvas/ammo/shogi/style.css
@@ -1,0 +1,24 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Add new example: `examples/playcanvas/ammo/shogi/` — 220 shogi pieces (pentagon-prism mesh) tumbling into a walled box
- Pentagon-prism geometry and UV layout match the three.js/cannon-es and Filament/Havok versions, so the same `shogi_001/shogi.png` texture maps correctly
- Collision shape: box with halfExtents `[0.8, 0.8, 0.315]` fitted to the mesh
- W key toggles physics wireframe debug overlay (dynamic=green, static=yellow) — included from the start, consistent with the other PlayCanvas + ammo.js examples

## Test plan

- [ ] Open `examples/playcanvas/ammo/shogi/index.html` and confirm pieces fall and pile up
- [ ] Confirm shogi texture is visible on the piece faces
- [ ] Press W to toggle wireframe OFF — green box wireframes disappear, hint reads "W: wireframe OFF"
- [ ] Press W again to toggle ON — wireframes follow pieces correctly as they rotate
- [ ] Confirm pieces recycle back to the top when they fall below y=-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)