### PR TITLE
Add W-key physics wireframe toggle to remaining PlayCanvas + ammo.js examples

### DIFF
--- a/examples/playcanvas/ammo/eraser/index.html
+++ b/examples/playcanvas/ammo/eraser/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/eraser/index.js
+++ b/examples/playcanvas/ammo/eraser/index.js
@@ -95,8 +95,25 @@ let options = {
     uvs: textureCoords
 };
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        const isDynamic = entity.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
-    'Ammo', 
+    'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.wasm',
     init);
@@ -112,6 +129,14 @@ function init() {
 
     window.addEventListener("resize", function () {
         app.resizeCanvas(canvas.width, canvas.height);
+    });
+
+    window.addEventListener("keydown", function (event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
 	function createEraserMesh() {
@@ -198,7 +223,7 @@ function init() {
         { size:[ 1, 10, 10], pos:[ 5, 5, 0], rot:[0,0,0] } 
     ];
 
-    let surfaces = [];
+    const staticDebugEntities = [];
     for (let i = 0; i < boxDataSet.length; i++) {
         let size = boxDataSet[i].size
         let pos = boxDataSet[i].pos;
@@ -214,6 +239,7 @@ function init() {
         boxModel.addComponent("model", { type: "box", material: whiteMaterial });
         box.addChild(boxModel);
         app.root.addChild(box);
+        staticDebugEntities.push(box);
     }
 
     const SCALE = 2;
@@ -254,6 +280,7 @@ function init() {
     floorModel.addComponent("model", { type: "box", material: floorMaterial });
     floor.addChild(floorModel);
     app.root.addChild(floor);
+    staticDebugEntities.push(floor);
 
     let numErasers = 0;
     let erasers = [];
@@ -294,5 +321,10 @@ function init() {
         
         camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
         camera.lookAt(0, 0, 0);
+
+        if (showWireframe) {
+            drawPhysicsDebug(app, staticDebugEntities);
+            drawPhysicsDebug(app, erasers);
+        }
     });
 }

--- a/examples/playcanvas/ammo/eraser/style.css
+++ b/examples/playcanvas/ammo/eraser/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
@@ -449,15 +449,40 @@ function drawPhysicsDebug(app, entities) {
     }
 }
 
-// Draw AABB boxes for entities whose collision was registered directly in Ammo
-// (no PlayCanvas collision component, so they can't appear in drawPhysicsDebug).
+// Draw the actual mesh wireframe for entities whose collision was registered
+// directly in Ammo as btBvhTriangleMeshShape (no PlayCanvas collision component).
+// Uses pc.Mesh.getPositions/getIndices to read the CPU-side vertex data and draws
+// all triangle edges in world space. Falls back to AABB if data is unavailable.
 function drawMeshStaticDebug(app, entities) {
+    const pa = new pc.Vec3(), pb = new pc.Vec3();
+    const wa = new pc.Vec3(), wb = new pc.Vec3();
     for (const e of entities) {
         if (!e.render) continue;
+        const worldMat = e.getWorldTransform();
         for (const mi of e.render.meshInstances) {
-            const c = mi.aabb.center, h = mi.aabb.halfExtents;
-            const mat = new pc.Mat4().setTranslate(c.x, c.y, c.z);
-            _drawWireBoxLocal(app, mat, h.x, h.y, h.z, _DBG_COLOR_STATIC);
+            const mesh = mi.mesh;
+            const positions = [], indices = [];
+            mesh.getPositions(positions);
+            mesh.getIndices(indices);
+            if (positions.length > 0 && indices.length > 0) {
+                const pts = [];
+                for (let i = 0; i < indices.length; i += 3) {
+                    const a = indices[i]*3, b = indices[i+1]*3, c = indices[i+2]*3;
+                    for (const [s, t] of [[a,b],[b,c],[c,a]]) {
+                        pa.set(positions[s], positions[s+1], positions[s+2]);
+                        pb.set(positions[t], positions[t+1], positions[t+2]);
+                        worldMat.transformPoint(pa, wa);
+                        worldMat.transformPoint(pb, wb);
+                        pts.push(wa.clone(), wb.clone());
+                    }
+                }
+                if (pts.length > 0) app.drawLines(pts, pts.map(() => _DBG_COLOR_STATIC), false);
+            } else {
+                // Fallback: AABB when mesh data is not CPU-accessible
+                const c = mi.aabb.center, h = mi.aabb.halfExtents;
+                const mat = new pc.Mat4().setTranslate(c.x, c.y, c.z);
+                _drawWireBoxLocal(app, mat, h.x, h.y, h.z, _DBG_COLOR_STATIC);
+            }
         }
     }
 }

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.js
@@ -4,6 +4,25 @@ import { loadWasmModuleAsync } from 'https://rawcdn.githack.com/playcanvas/engin
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
 const RESET_Y_THRESHOLD = -20;
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || col.type !== 'box') continue;
+        let rbOwner = entity;
+        while (rbOwner && !rbOwner.rigidbody) rbOwner = rbOwner.parent;
+        const isDynamic = rbOwner?.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        const h = col.halfExtents;
+        app.drawWireAlignedBox(new pc.Vec3(-h.x, -h.y, -h.z), new pc.Vec3(h.x, h.y, h.z), color, false, undefined, mat);
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
     'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
@@ -135,6 +154,14 @@ function init() {
         app.resizeCanvas(canvas.width, canvas.height);
     });
 
+    window.addEventListener('keydown', function(event) {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
     app.scene.ambientLight = new pc.Color(0.68, 0.7, 0.76);
 
     const light = new pc.Entity('light');
@@ -262,6 +289,13 @@ function init() {
             }
         }
 
+        const debugEntities = [];
+        const visitForDebug = (e) => {
+            if (e.collision && e.collision.type && e.collision.type !== 'compound') debugEntities.push(e);
+            for (const c of e.children) visitForDebug(c);
+        };
+        visitForDebug(root);
+
         const bounds = computeWorldBounds(root);
         const center = bounds.center;
         const radius = bounds.radius;
@@ -279,6 +313,8 @@ function init() {
 
             camera.setLocalPosition(x, y, z);
             camera.lookAt(center);
+
+            if (showWireframe) drawPhysicsDebug(app, debugEntities);
 
             for (const body of dynamicBodies) {
                 if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) {

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Friction/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Friction/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script type="module" src="index.js"></script>
 </body>

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.js
@@ -4,6 +4,110 @@ import { loadWasmModuleAsync } from 'https://rawcdn.githack.com/playcanvas/engin
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
 const RESET_Y_THRESHOLD = -20;
 
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _ringPoints(axis, radius, segments, out, mat) {
+    const tmp = new pc.Vec3();
+    const transformed = new pc.Vec3();
+    let prev = null;
+    for (let i = 0; i <= segments; i++) {
+        const t = (i / segments) * Math.PI * 2;
+        const c = Math.cos(t) * radius, s = Math.sin(t) * radius;
+        if      (axis === 0) tmp.set(0, c, s);
+        else if (axis === 1) tmp.set(c, 0, s);
+        else                 tmp.set(c, s, 0);
+        mat.transformPoint(tmp, transformed);
+        const cur = transformed.clone();
+        if (prev) { out.push(prev); out.push(cur); }
+        prev = cur;
+    }
+}
+
+function _drawWireSphereLocal(app, mat, radius, color) {
+    const pts = [];
+    _ringPoints(0, radius, 16, pts, mat);
+    _ringPoints(1, radius, 16, pts, mat);
+    _ringPoints(2, radius, 16, pts, mat);
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function _drawWireBoxLocal(app, mat, hx, hy, hz, color) {
+    app.drawWireAlignedBox(new pc.Vec3(-hx, -hy, -hz), new pc.Vec3(hx, hy, hz), color, false, undefined, mat);
+}
+
+function _drawWireCylinderLocal(app, mat, radius, halfHeight, axis, color) {
+    const pts = [];
+    const segs = 16;
+    const oA = new pc.Vec3(), oB = new pc.Vec3();
+    if      (axis === 0) { oA.set(-halfHeight, 0, 0); oB.set(halfHeight, 0, 0); }
+    else if (axis === 1) { oA.set(0, -halfHeight, 0); oB.set(0, halfHeight, 0); }
+    else                 { oA.set(0, 0, -halfHeight); oB.set(0, 0, halfHeight); }
+    const tmp = new pc.Vec3(), tr = new pc.Vec3();
+    const verts = [];
+    for (const off of [oA, oB]) {
+        const ring = [];
+        for (let i = 0; i <= segs; i++) {
+            const t = (i / segs) * Math.PI * 2;
+            const c = Math.cos(t) * radius, s = Math.sin(t) * radius;
+            if      (axis === 0) tmp.set(off.x, c, s);
+            else if (axis === 1) tmp.set(c, off.y, s);
+            else                 tmp.set(c, s, off.z);
+            mat.transformPoint(tmp, tr);
+            ring.push(tr.clone());
+        }
+        verts.push(ring);
+        for (let i = 0; i < segs; i++) { pts.push(ring[i]); pts.push(ring[i + 1]); }
+    }
+    const step = Math.floor(segs / 4);
+    for (let k = 0; k < 4; k++) { pts.push(verts[0][k * step]); pts.push(verts[1][k * step]); }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+
+function _drawWireCapsuleLocal(app, mat, radius, cylHalf, axis, color) {
+    _drawWireCylinderLocal(app, mat, radius, cylHalf, axis, color);
+    const off = new pc.Vec3();
+    for (const sign of [-1, 1]) {
+        if      (axis === 0) off.set(sign * cylHalf, 0, 0);
+        else if (axis === 1) off.set(0, sign * cylHalf, 0);
+        else                 off.set(0, 0, sign * cylHalf);
+        const local = new pc.Mat4().setTranslate(off.x, off.y, off.z);
+        _drawWireSphereLocal(app, new pc.Mat4().mul2(mat, local), radius, color);
+    }
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision;
+        if (!col || !col.type) continue;
+        let rbOwner = entity;
+        while (rbOwner && !rbOwner.rigidbody) rbOwner = rbOwner.parent;
+        const isDynamic = rbOwner?.rigidbody?.type === pc.BODYTYPE_DYNAMIC;
+        const color = isDynamic ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = new pc.Mat4().setTRS(entity.getPosition(), entity.getRotation(), pc.Vec3.ONE);
+        switch (col.type) {
+            case 'box': {
+                const h = col.halfExtents;
+                _drawWireBoxLocal(app, mat, h.x, h.y, h.z, color);
+                break;
+            }
+            case 'sphere':
+                _drawWireSphereLocal(app, mat, col.radius, color);
+                break;
+            case 'capsule': {
+                const r = col.radius;
+                _drawWireCapsuleLocal(app, mat, r, Math.max(0, (col.height - 2 * r) * 0.5), col.axis ?? 1, color);
+                break;
+            }
+            case 'cylinder':
+                _drawWireCylinderLocal(app, mat, col.radius, col.height * 0.5, col.axis ?? 1, color);
+                break;
+        }
+    }
+}
+
+let showWireframe = true;
+
 loadWasmModuleAsync(
     'Ammo',
     'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/lib/ammo/ammo.wasm.js',
@@ -245,6 +349,14 @@ function init() {
     app.setCanvasResolution(pc.RESOLUTION_AUTO);
     window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
 
+    window.addEventListener('keydown', event => {
+        const isWKey = event.code === 'KeyW' || event.key === 'w' || event.key === 'W';
+        if (!isWKey || event.repeat) return;
+        showWireframe = !showWireframe;
+        const hint = document.getElementById('hint');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+    });
+
     app.scene.ambientLight = new pc.Color(0.68, 0.7, 0.76);
     const light = new pc.Entity('light');
     light.addComponent('light', { type: 'directional', color: new pc.Color(1,1,1),
@@ -273,6 +385,13 @@ function init() {
         const entityMap = buildEntityMap(gltfJson, root);
         dynamicBodies = initPhysics(gltfJson, entityMap);
 
+        const debugEntities = [];
+        const visitForDebug = (e) => {
+            if (e.collision && e.collision.type && e.collision.type !== 'compound') debugEntities.push(e);
+            for (const c of e.children) visitForDebug(c);
+        };
+        visitForDebug(root);
+
         const { center, radius } = computeWorldBounds(root);
         let angle = 0;
         const expectedFps = 60;
@@ -285,6 +404,8 @@ function init() {
                 center.z + Math.cos(Math.PI * angle / 180) * radius
             );
             camera.lookAt(center);
+
+            if (showWireframe) drawPhysicsDebug(app, debugEntities);
 
             for (const body of dynamicBodies) {
                 if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) continue;

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/style.css
@@ -9,3 +9,16 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Add W-key wireframe debug overlay to the 3 remaining PlayCanvas + ammo.js examples that didn't have it: **eraser**, **gltf_physics_Materials_Friction**, **gltf_physics_Materials_Restitution**
- Improve **gltf_physics_Basic_Shapes** mesh-shape wireframe: replace the AABB-box approximation with actual mesh-edge drawing using `pc.Mesh.getPositions/getIndices`

| Example | Shapes | Notes |
|---|---|---|
| eraser | box | walls + floor + falling erasers |
| gltf_physics_Materials_Friction | box | entities collected by walking entity tree after async glTF load |
| gltf_physics_Materials_Restitution | box / sphere / capsule / cylinder | full helper set matching gltf_physics_Basic_Shapes |
| gltf_physics_Basic_Shapes | mesh wireframe improved | draws actual triangle edges instead of AABB; AABB fallback retained |

**Known issue**: Suzanne mesh-shape collision (`btBvhTriangleMeshShape`) is not yet functioning correctly — to be investigated in a follow-up.

## Test plan

- [ ] eraser / Friction / Restitution: W key toggles wireframe; shapes match collision volumes
- [ ] gltf_physics_Basic_Shapes: mesh static entities now show triangle-edge wireframe (yellow) instead of AABB boxes
- [ ] Fallback to AABB if `mesh.getPositions()` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)