### PR TITLE
Add Filtering, Triggers, JointTypes examples (glTF Physics, PlayCanvas + ammo.js)

### DIFF
--- a/examples/playcanvas/ammo/gltf_physics_Filtering/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Filtering/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>[WIP] PlayCanvas + ammo.js Filtering (glTF Physics extension)</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
+      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+<canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
+
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/playcanvas/ammo/gltf_physics_Filtering/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Filtering/index.js
@@ -1,0 +1,552 @@
+import * as pc from 'playcanvas';
+import { CameraControls } from 'camera-controls';
+
+const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
+const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Filtering/Filtering.glb';
+const RESET_Y_THRESHOLD = -20;
+
+pc.WasmModule.setConfig('Ammo', {
+    glueUrl:     PC_ROOT + '/ammo/ammo.wasm.js',
+    wasmUrl:     PC_ROOT + '/ammo/ammo.wasm.wasm',
+    fallbackUrl: PC_ROOT + '/ammo/ammo.js'
+});
+pc.WasmModule.getInstance('Ammo', init);
+
+async function fetchGlbData(url) {
+    const data = await fetch(url).then(r => r.arrayBuffer());
+    if (new Uint32Array(data, 0, 1)[0] !== 0x46546c67) throw new Error('Invalid GLB header.');
+    let json = null, binary = null;
+    let offset = 12;
+    while (offset < data.byteLength) {
+        const view = new DataView(data, offset, 8);
+        const len  = view.getUint32(0, true);
+        const type = view.getUint32(4, true);
+        if      (type === 0x4e4f534a) json   = JSON.parse(new TextDecoder().decode(data.slice(offset + 8, offset + 8 + len)).replace(/\0+$/, ''));
+        else if (type === 0x004e4942) binary = data.slice(offset + 8, offset + 8 + len);
+        offset += 8 + len;
+    }
+    if (!json) throw new Error('GLB JSON chunk missing.');
+    return { json, binary };
+}
+
+function readGlbFloat32(json, binary, accessorIdx) {
+    const acc = json.accessors[accessorIdx];
+    const bv  = json.bufferViews[acc.bufferView];
+    const totalOffset = (bv.byteOffset ?? 0) + (acc.byteOffset ?? 0);
+    const components  = { SCALAR: 1, VEC2: 2, VEC3: 3, VEC4: 4 }[acc.type] ?? 1;
+    const stride      = bv.byteStride ?? 0;
+    if (!stride || stride === components * 4)
+        return new Float32Array(binary.slice(totalOffset, totalOffset + acc.count * components * 4));
+    const result = new Float32Array(acc.count * components);
+    const dv = new DataView(binary);
+    for (let i = 0; i < acc.count; i++)
+        for (let c = 0; c < components; c++)
+            result[i * components + c] = dv.getFloat32(totalOffset + i * stride + c * 4, true);
+    return result;
+}
+
+function readGlbIndices(json, binary, accessorIdx) {
+    const acc = json.accessors[accessorIdx];
+    const bv  = json.bufferViews[acc.bufferView];
+    const off = (bv.byteOffset ?? 0) + (acc.byteOffset ?? 0);
+    if (acc.componentType === 5125) return new Uint32Array(binary.slice(off, off + acc.count * 4));
+    if (acc.componentType === 5123) return new Uint16Array(binary.slice(off, off + acc.count * 2));
+    return new Uint8Array(binary.slice(off, off + acc.count));
+}
+
+function addAmmoStaticMeshBody(json, binary, meshIdx, entity, friction, restitution, dynamicsWorld, group, mask) {
+    const gltfMesh = json.meshes[meshIdx];
+    if (!gltfMesh) return null;
+    const btTriMesh = new Ammo.btTriangleMesh(true, true);
+    let triCount = 0;
+    for (const prim of gltfMesh.primitives ?? []) {
+        if ((prim.mode ?? 4) !== 4) continue;
+        const posIdx = prim.attributes?.POSITION;
+        if (posIdx === undefined) continue;
+        const pos  = readGlbFloat32(json, binary, posIdx);
+        const idxs = prim.indices !== undefined ? readGlbIndices(json, binary, prim.indices) : null;
+        const n    = idxs ? idxs.length / 3 : pos.length / 9;
+        for (let t = 0; t < n; t++) {
+            const i0 = (idxs ? idxs[t*3]   : t*3)   * 3;
+            const i1 = (idxs ? idxs[t*3+1] : t*3+1) * 3;
+            const i2 = (idxs ? idxs[t*3+2] : t*3+2) * 3;
+            const v0 = new Ammo.btVector3(pos[i0], pos[i0+1], pos[i0+2]);
+            const v1 = new Ammo.btVector3(pos[i1], pos[i1+1], pos[i1+2]);
+            const v2 = new Ammo.btVector3(pos[i2], pos[i2+1], pos[i2+2]);
+            btTriMesh.addTriangle(v0, v1, v2, false);
+            Ammo.destroy(v0); Ammo.destroy(v1); Ammo.destroy(v2);
+            triCount++;
+        }
+    }
+    if (triCount === 0) { Ammo.destroy(btTriMesh); return null; }
+    const shape = new Ammo.btBvhTriangleMeshShape(btTriMesh, true);
+    const ws = entity.getWorldTransform().getScale();
+    const ls = new Ammo.btVector3(Math.abs(ws.x), Math.abs(ws.y), Math.abs(ws.z));
+    shape.setLocalScaling(ls); Ammo.destroy(ls);
+    const p = entity.getPosition(), q = entity.getRotation();
+    const xform = new Ammo.btTransform();
+    xform.setIdentity();
+    xform.setOrigin(new Ammo.btVector3(p.x, p.y, p.z));
+    xform.setRotation(new Ammo.btQuaternion(q.x, q.y, q.z, q.w));
+    const motionState  = new Ammo.btDefaultMotionState(xform);
+    const localInertia = new Ammo.btVector3(0, 0, 0);
+    const rbInfo       = new Ammo.btRigidBodyConstructionInfo(0, motionState, shape, localInertia);
+    const body         = new Ammo.btRigidBody(rbInfo);
+    body.setFriction(friction ?? 0.5); body.setRestitution(restitution ?? 0);
+    if (group !== undefined && mask !== undefined) {
+        dynamicsWorld.addRigidBody(body, group, mask);
+    } else {
+        dynamicsWorld.addRigidBody(body);
+    }
+    Ammo.destroy(xform); Ammo.destroy(localInertia); Ammo.destroy(rbInfo);
+    return body;
+}
+
+// --- Collision filtering helpers ---
+
+function parseSystemList(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) return value.filter(Boolean);
+    return String(value).split(/\s+/).filter(Boolean);
+}
+
+function buildSystemBitMap(filterDefs) {
+    const map = new Map();
+    let nextBit = 0;
+    for (const f of filterDefs) {
+        for (const sys of [...parseSystemList(f.collisionSystems), ...parseSystemList(f.collideWithSystems)]) {
+            if (!map.has(sys)) map.set(sys, 1 << nextBit++);
+        }
+    }
+    return map;
+}
+
+function getFilterGroupMask(filterDef, systemBitMap) {
+    if (!filterDef) return null;
+    const group = parseSystemList(filterDef.collisionSystems).reduce((m, s) => m | (systemBitMap.get(s) ?? 0), 0);
+    const mask  = parseSystemList(filterDef.collideWithSystems).reduce((m, s) => m | (systemBitMap.get(s) ?? 0), 0);
+    return { group: group || 0xFFFF, mask: mask || 0xFFFF };
+}
+
+// Re-add a PlayCanvas-managed rigid body with custom group/mask.
+// PlayCanvas adds the body with default filter on addComponent; we remove and re-add.
+function applyBodyFilter(entity, gm, dynamicsWorld) {
+    if (!gm) return;
+    const body = entity.rigidbody?.body;
+    if (!body) return;
+    dynamicsWorld.removeRigidBody(body);
+    dynamicsWorld.addRigidBody(body, gm.group, gm.mask);
+}
+
+// ---
+
+function buildEntityMap(gltfJson, clonedRoot) {
+    const nodes = gltfJson.nodes ?? [];
+    const map = new Array(nodes.length).fill(null);
+
+    function nameMap(children) {
+        const m = new Map();
+        for (const child of children) {
+            const n = child.name ?? '';
+            if (!m.has(n)) m.set(n, []);
+            m.get(n).push(child);
+        }
+        return m;
+    }
+
+    function walk(nodeIndex, entity) {
+        if (!entity || nodeIndex < 0) return;
+        map[nodeIndex] = entity;
+        const childIndices = nodes[nodeIndex].children ?? [];
+        if (!childIndices.length) return;
+        const byName = nameMap(entity.children);
+        for (const ci of childIndices) {
+            const cName = nodes[ci]?.name ?? '';
+            const candidates = byName.get(cName);
+            if (candidates?.length) walk(ci, candidates.shift());
+        }
+    }
+
+    const scenes = gltfJson.scenes ?? [];
+    const sceneRoots = scenes.length === 1 ? [clonedRoot] : clonedRoot.children;
+    for (let s = 0; s < scenes.length; s++) {
+        const sceneRoot = sceneRoots[s];
+        if (!sceneRoot) continue;
+        const rootIndices = scenes[s].nodes ?? [];
+        if (rootIndices.length === 1 && sceneRoot.name === (nodes[rootIndices[0]]?.name ?? '')) {
+            walk(rootIndices[0], sceneRoot);
+            continue;
+        }
+        const byName = nameMap(sceneRoot.children);
+        for (const ri of rootIndices) {
+            const rName = nodes[ri]?.name ?? '';
+            const candidates = byName.get(rName);
+            if (candidates?.length) walk(ri, candidates.shift());
+        }
+    }
+    return map;
+}
+
+function getCollisionDataFromImplicit(shapeDef, worldScale) {
+    const sx = Math.abs(worldScale.x), sy = Math.abs(worldScale.y), sz = Math.abs(worldScale.z);
+    if (shapeDef.sphere)   return { type: 'sphere', radius: (shapeDef.sphere.radius ?? 0.5) * Math.max(sx, sy, sz) };
+    if (shapeDef.box) {
+        const s = shapeDef.box.size ?? [1, 1, 1];
+        return { type: 'box', halfExtents: new pc.Vec3(Math.abs(s[0]*sx)/2, Math.abs(s[1]*sy)/2, Math.abs(s[2]*sz)/2) };
+    }
+    if (shapeDef.capsule) {
+        const r = ((shapeDef.capsule.radiusTop ?? shapeDef.capsule.radius ?? 0.5) +
+                   (shapeDef.capsule.radiusBottom ?? shapeDef.capsule.radius ?? 0.5)) / 2 * Math.max(sx, sz);
+        return { type: 'capsule', radius: r, height: (shapeDef.capsule.height ?? 1.0) * sy + 2 * r, axis: 1 };
+    }
+    if (shapeDef.cylinder) {
+        const r = Math.max(shapeDef.cylinder.radiusTop ?? shapeDef.cylinder.radius ?? 0.5,
+                           shapeDef.cylinder.radiusBottom ?? shapeDef.cylinder.radius ?? 0.5) * Math.max(sx, sz);
+        return { type: 'cylinder', radius: r, height: (shapeDef.cylinder.height ?? 1.0) * sy, axis: 1 };
+    }
+    return null;
+}
+
+function initPhysics(gltfJson, binary, entityMap, dynamicsWorld) {
+    const matDefs    = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsMaterials ?? [];
+    const filterDefs = gltfJson.extensions?.KHR_physics_rigid_bodies?.collisionFilters ?? [];
+    const shapeDefs  = gltfJson.extensions?.KHR_implicit_shapes?.shapes ?? [];
+    const nodes      = gltfJson.nodes ?? [];
+
+    const systemBitMap = buildSystemBitMap(filterDefs);
+
+    const parentOf = new Array(nodes.length).fill(-1);
+    for (let i = 0; i < nodes.length; i++)
+        for (const c of nodes[i].children ?? []) parentOf[c] = i;
+
+    const hasMotion = i => !!nodes[i]?.extensions?.KHR_physics_rigid_bodies?.motion;
+    function findBodyOwner(idx) {
+        let cur = idx;
+        while (cur >= 0) { if (hasMotion(cur)) return cur; cur = parentOf[cur]; }
+        return -1;
+    }
+
+    // Pass 1: compound collision components for body-owners.
+    const bodyOwnerNodes = [];
+    for (let i = 0; i < nodes.length; i++) {
+        if (!hasMotion(i)) continue;
+        const e = entityMap[i];
+        if (!e) continue;
+        e.addComponent('collision', { type: 'compound' });
+        bodyOwnerNodes.push(i);
+    }
+
+    const standaloneStatics  = [];
+    const meshStaticEntities = [];
+
+    for (let i = 0; i < nodes.length; i++) {
+        const physExt  = nodes[i].extensions?.KHR_physics_rigid_bodies;
+        if (!physExt?.collider?.geometry) continue;
+        const geom     = physExt.collider.geometry;
+        const ownerIdx = findBodyOwner(i);
+        const mat      = physExt.collider.physicsMaterial !== undefined ? (matDefs[physExt.collider.physicsMaterial] ?? {}) : {};
+
+        if (ownerIdx === i) {
+            if (geom.shape === undefined) continue;
+            const parent   = entityMap[i]; if (!parent) continue;
+            const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+            const child = new pc.Entity('__khrCollider');
+            parent.addChild(child);
+            const cd = getCollisionDataFromImplicit(shapeDef, parent.getWorldTransform().getScale());
+            if (cd) child.addComponent('collision', cd);
+        } else {
+            const e = entityMap[i]; if (!e) continue;
+            if (geom.shape !== undefined) {
+                const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+                const cd = getCollisionDataFromImplicit(shapeDef, e.getWorldTransform().getScale());
+                if (!cd) continue;
+                e.addComponent('collision', cd);
+                if (ownerIdx < 0) standaloneStatics.push({ entity: e, collider: physExt.collider });
+            } else if (geom.mesh !== undefined && ownerIdx < 0) {
+                const filterIdx = physExt.collider.collisionFilter;
+                const gm = getFilterGroupMask(filterIdx !== undefined ? filterDefs[filterIdx] : null, systemBitMap);
+                const frict = mat.dynamicFriction ?? mat.staticFriction ?? 0.5;
+                const rest  = mat.restitution ?? 0;
+                const body  = addAmmoStaticMeshBody(gltfJson, binary, geom.mesh, e, frict, rest, dynamicsWorld,
+                    gm?.group, gm?.mask);
+                if (body) meshStaticEntities.push(e);
+            }
+        }
+    }
+
+    // Pass 2: rigidbody components + friction/restitution.
+    const dynamicInfos = [];
+    const staticInfos  = [];
+    const filterTasks  = []; // { entity, filterDef } to apply after component creation
+
+    for (const i of bodyOwnerNodes) {
+        const e = entityMap[i];
+        const m = nodes[i].extensions.KHR_physics_rigid_bodies.motion;
+        const isK = !!m?.isKinematic;
+        const cfg = { type: isK ? 'kinematic' : 'dynamic' };
+        if (!isK) cfg.mass = m?.mass ?? 1;
+        e.addComponent('rigidbody', cfg);
+        const ownC = nodes[i].extensions.KHR_physics_rigid_bodies.collider;
+        const mat  = ownC?.physicsMaterial !== undefined ? (matDefs[ownC.physicsMaterial] ?? {}) : {};
+        const filterIdx = ownC?.collisionFilter;
+        const filterDef = filterIdx !== undefined ? filterDefs[filterIdx] : null;
+        if (!isK) {
+            dynamicInfos.push({ entity: e, mat });
+            if (filterDef) filterTasks.push({ entity: e, filterDef });
+        } else {
+            staticInfos.push({ entity: e, mat });
+            if (filterDef) filterTasks.push({ entity: e, filterDef });
+        }
+    }
+    for (const { entity, collider } of standaloneStatics) {
+        entity.addComponent('rigidbody', { type: 'static' });
+        const mat = collider.physicsMaterial !== undefined ? (matDefs[collider.physicsMaterial] ?? {}) : {};
+        staticInfos.push({ entity, mat });
+        const filterIdx = collider.collisionFilter;
+        const filterDef = filterIdx !== undefined ? filterDefs[filterIdx] : null;
+        if (filterDef) filterTasks.push({ entity, filterDef });
+    }
+
+    for (const info of dynamicInfos) {
+        if (info.mat.dynamicFriction !== undefined) info.entity.rigidbody.friction    = info.mat.dynamicFriction;
+        if (info.mat.restitution     !== undefined) info.entity.rigidbody.restitution = info.mat.restitution;
+    }
+
+    // Apply collision filters (remove + re-add with group/mask).
+    for (const { entity, filterDef } of filterTasks) {
+        applyBodyFilter(entity, getFilterGroupMask(filterDef, systemBitMap), dynamicsWorld);
+    }
+
+    // Collect leaf collision entities for debug wireframe.
+    const debugEntities = [];
+    const visitDebug = e => {
+        if (e.collision?.type && e.collision.type !== 'compound') debugEntities.push(e);
+        for (const c of e.children) visitDebug(c);
+    };
+    for (const info of dynamicInfos) visitDebug(info.entity);
+    for (const info of staticInfos)  visitDebug(info.entity);
+
+    return {
+        dynamicBodies: dynamicInfos.map(info => ({
+            entity: info.entity,
+            initialPosition: info.entity.getPosition().clone(),
+            initialRotation: info.entity.getRotation().clone()
+        })),
+        debugEntities,
+        meshStaticEntities
+    };
+}
+
+// --- Debug wireframe ---
+
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _ringPoints(axis, radius, segs, out, mat) {
+    const tmp = new pc.Vec3(); let prev = null;
+    for (let i = 0; i <= segs; i++) {
+        const t = (i / segs) * Math.PI * 2, c = Math.cos(t) * radius, s = Math.sin(t) * radius;
+        if      (axis === 0) tmp.set(0, c, s);
+        else if (axis === 1) tmp.set(c, 0, s);
+        else                 tmp.set(c, s, 0);
+        const cur = new pc.Vec3(); mat.transformPoint(tmp, cur);
+        if (prev) { out.push(prev); out.push(cur); }
+        prev = cur;
+    }
+}
+
+function _getPosRotMat(e) { return new pc.Mat4().setTRS(e.getPosition(), e.getRotation(), pc.Vec3.ONE); }
+
+function _drawWireSphereLocal(app, mat, r, color) {
+    const pts = []; _ringPoints(0, r, 16, pts, mat); _ringPoints(1, r, 16, pts, mat); _ringPoints(2, r, 16, pts, mat);
+    app.drawLines(pts, pts.map(() => color), false);
+}
+function _drawWireBoxLocal(app, mat, hx, hy, hz, color) {
+    app.drawWireAlignedBox(new pc.Vec3(-hx, -hy, -hz), new pc.Vec3(hx, hy, hz), color, false, undefined, mat);
+}
+function _drawWireCylinderLocal(app, mat, radius, halfH, axis, color) {
+    const pts = [], segs = 16;
+    const oA = new pc.Vec3(), oB = new pc.Vec3();
+    if      (axis === 0) { oA.set(-halfH,0,0); oB.set(halfH,0,0); }
+    else if (axis === 1) { oA.set(0,-halfH,0); oB.set(0,halfH,0); }
+    else                 { oA.set(0,0,-halfH); oB.set(0,0,halfH); }
+    const tmp = new pc.Vec3(), rings = [];
+    for (const off of [oA, oB]) {
+        const ring = [];
+        for (let i = 0; i <= segs; i++) {
+            const t = (i/segs)*Math.PI*2, c = Math.cos(t)*radius, s = Math.sin(t)*radius;
+            if      (axis === 0) tmp.set(off.x, c, s);
+            else if (axis === 1) tmp.set(c, off.y, s);
+            else                 tmp.set(c, s, off.z);
+            const v = new pc.Vec3(); mat.transformPoint(tmp, v); ring.push(v);
+        }
+        rings.push(ring);
+        for (let i = 0; i < segs; i++) { pts.push(ring[i]); pts.push(ring[i+1]); }
+    }
+    const step = Math.floor(segs/4);
+    for (let k = 0; k < 4; k++) { pts.push(rings[0][k*step]); pts.push(rings[1][k*step]); }
+    app.drawLines(pts, pts.map(() => color), false);
+}
+function _drawWireCapsuleLocal(app, mat, r, cylHalf, axis, color) {
+    _drawWireCylinderLocal(app, mat, r, cylHalf, axis, color);
+    const off = new pc.Vec3();
+    for (const sign of [-1, 1]) {
+        if      (axis === 0) off.set(sign*cylHalf,0,0);
+        else if (axis === 1) off.set(0,sign*cylHalf,0);
+        else                 off.set(0,0,sign*cylHalf);
+        _drawWireSphereLocal(app, new pc.Mat4().mul2(mat, new pc.Mat4().setTranslate(off.x,off.y,off.z)), r, color);
+    }
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision; if (!col?.type) continue;
+        let rb = entity; while (rb && !rb.rigidbody) rb = rb.parent;
+        const color = rb?.rigidbody?.type === pc.BODYTYPE_DYNAMIC ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = _getPosRotMat(entity);
+        switch (col.type) {
+            case 'box':      _drawWireBoxLocal(app, mat, col.halfExtents.x, col.halfExtents.y, col.halfExtents.z, color); break;
+            case 'sphere':   _drawWireSphereLocal(app, mat, col.radius, color); break;
+            case 'capsule':  _drawWireCapsuleLocal(app, mat, col.radius, Math.max(0,(col.height-2*col.radius)*0.5), col.axis??1, color); break;
+            case 'cylinder': _drawWireCylinderLocal(app, mat, col.radius, col.height*0.5, col.axis??1, color); break;
+        }
+    }
+}
+
+function drawMeshStaticDebug(app, entities) {
+    const pa = new pc.Vec3(), pb = new pc.Vec3(), wa = new pc.Vec3(), wb = new pc.Vec3();
+    for (const e of entities) {
+        if (!e.render) continue;
+        const wm = e.getWorldTransform();
+        for (const mi of e.render.meshInstances) {
+            const pos = [], idx = [];
+            mi.mesh.getPositions(pos); mi.mesh.getIndices(idx);
+            if (pos.length > 0 && idx.length > 0) {
+                const pts = [];
+                for (let i = 0; i < idx.length; i += 3) {
+                    const a = idx[i]*3, b = idx[i+1]*3, c = idx[i+2]*3;
+                    for (const [s,t] of [[a,b],[b,c],[c,a]]) {
+                        pa.set(pos[s],pos[s+1],pos[s+2]); pb.set(pos[t],pos[t+1],pos[t+2]);
+                        wm.transformPoint(pa,wa); wm.transformPoint(pb,wb);
+                        pts.push(wa.clone(), wb.clone());
+                    }
+                }
+                if (pts.length) app.drawLines(pts, pts.map(() => _DBG_COLOR_STATIC), false);
+            } else {
+                const c = mi.aabb.center, h = mi.aabb.halfExtents;
+                _drawWireBoxLocal(app, new pc.Mat4().setTranslate(c.x,c.y,c.z), h.x, h.y, h.z, _DBG_COLOR_STATIC);
+            }
+        }
+    }
+}
+
+// ---
+
+function enableShadows(e) {
+    if (e.render) { e.render.castShadows = true; e.render.receiveShadows = true; }
+    if (e.model)  { e.model.castShadows  = true; e.model.receiveShadows  = true; }
+    for (const c of e.children) enableShadows(c);
+}
+
+function computeBodyBounds(dynamicBodies) {
+    if (!dynamicBodies.length) return { center: new pc.Vec3(0, 2, 0), radius: 12 };
+    let minX=Infinity,minY=Infinity,minZ=Infinity,maxX=-Infinity,maxY=-Infinity,maxZ=-Infinity;
+    for (const b of dynamicBodies) {
+        const p = b.initialPosition;
+        minX=Math.min(minX,p.x); maxX=Math.max(maxX,p.x);
+        minY=Math.min(minY,p.y); maxY=Math.max(maxY,p.y);
+        minZ=Math.min(minZ,p.z); maxZ=Math.max(maxZ,p.z);
+    }
+    const center = new pc.Vec3((minX+maxX)*0.5,(minY+maxY)*0.5,(minZ+maxZ)*0.5);
+    const d = Math.sqrt((maxX-minX)**2+(maxY-minY)**2+(maxZ-minZ)**2);
+    return { center, radius: Math.max(d+8, 12) };
+}
+
+let showWireframe = true;
+
+function init() {
+    const canvas = document.getElementById('c');
+    const app = new pc.Application(canvas, {
+        mouse: new pc.Mouse(canvas),
+        touch: new pc.TouchDevice(canvas)
+    });
+    if (typeof Ammo !== 'undefined' && app.systems.rigidbody) {
+        app.systems.rigidbody.gravity.set(0, -9.81, 0);
+        app.systems.rigidbody.onLibraryLoaded();
+    }
+    app.start();
+    app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+    app.setCanvasResolution(pc.RESOLUTION_AUTO);
+    window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
+    window.addEventListener('keydown', event => {
+        if ((event.code === 'KeyW' || event.key === 'w' || event.key === 'W') && !event.repeat) {
+            showWireframe = !showWireframe;
+            const hint = document.getElementById('hint');
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        }
+    });
+
+    app.scene.ambientLight = new pc.Color(0.4, 0.45, 0.5);
+
+    const light = new pc.Entity('light');
+    light.addComponent('light', { type: 'directional', color: new pc.Color(1, 0.95, 0.85),
+        intensity: 1.0, castShadows: true, shadowResolution: 2048, shadowBias: 0.3, normalOffsetBias: 0.02 });
+    light.setLocalEulerAngles(45, 45, 0);
+    app.root.addChild(light);
+
+    const fillLight = new pc.Entity('fillLight');
+    fillLight.addComponent('light', { type: 'directional', color: new pc.Color(0.45, 0.6, 1.0),
+        intensity: 0.5, castShadows: false });
+    fillLight.setLocalEulerAngles(-30, 180, 0);
+    app.root.addChild(fillLight);
+
+    const camera = new pc.Entity('camera');
+    camera.addComponent('camera', { clearColor: new pc.Color(0.96,0.97,0.99), nearClip: 0.05, farClip: 1000, fov: 45 });
+    camera.addComponent('script');
+    camera.setPosition(0, 2, 15);
+    app.root.addChild(camera);
+    const controls = camera.script.create(CameraControls, { properties: { enableFly: false } });
+
+    let dynamicBodies    = [];
+    let debugEntities    = [];
+    let meshStaticEntities = [];
+
+    Promise.all([
+        fetchGlbData(MODEL_URL),
+        new Promise((resolve, reject) => {
+            app.assets.loadFromUrlAndFilename(MODEL_URL, MODEL_URL.split('/').pop(), 'container',
+                (err, asset) => err ? reject(err) : resolve(asset));
+        })
+    ]).then(([glbData, asset]) => {
+        const { json: gltfJson, binary } = glbData;
+        const res  = asset.resource;
+        const root = res.instantiateRenderEntity ? res.instantiateRenderEntity() : res.instantiateModelEntity();
+        app.root.addChild(root);
+        enableShadows(root);
+
+        const entityMap = buildEntityMap(gltfJson, root);
+        const result    = initPhysics(gltfJson, binary, entityMap, app.systems.rigidbody.dynamicsWorld);
+        dynamicBodies      = result.dynamicBodies;
+        debugEntities      = result.debugEntities;
+        meshStaticEntities = result.meshStaticEntities;
+
+        const { center, radius } = computeBodyBounds(dynamicBodies);
+        const startPos = new pc.Vec3(center.x, center.y + 1.5, center.z + radius);
+        controls.reset(center, startPos);
+
+        app.on('update', () => {
+            if (showWireframe) {
+                drawPhysicsDebug(app, debugEntities);
+                drawMeshStaticDebug(app, meshStaticEntities);
+            }
+            for (const body of dynamicBodies) {
+                if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) continue;
+                body.entity.setPosition(body.initialPosition);
+                body.entity.setRotation(body.initialRotation);
+                body.entity.rigidbody.linearVelocity  = pc.Vec3.ZERO;
+                body.entity.rigidbody.angularVelocity = pc.Vec3.ZERO;
+                body.entity.rigidbody.syncEntityToBody();
+            }
+        });
+    }).catch(console.error);
+}

--- a/examples/playcanvas/ammo/gltf_physics_Filtering/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Filtering/style.css
@@ -1,0 +1,26 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/gltf_physics_JointTypes/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_JointTypes/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>[WIP] PlayCanvas + ammo.js JointTypes (glTF Physics extension)</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
+      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+<canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
+
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/playcanvas/ammo/gltf_physics_JointTypes/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_JointTypes/index.js
@@ -1,0 +1,590 @@
+import * as pc from 'playcanvas';
+import { CameraControls } from 'camera-controls';
+
+const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
+const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/JointTypes/JointTypes.glb';
+const RESET_Y_THRESHOLD = -30;
+
+pc.WasmModule.setConfig('Ammo', {
+    glueUrl:     PC_ROOT + '/ammo/ammo.wasm.js',
+    wasmUrl:     PC_ROOT + '/ammo/ammo.wasm.wasm',
+    fallbackUrl: PC_ROOT + '/ammo/ammo.js'
+});
+pc.WasmModule.getInstance('Ammo', init);
+
+async function fetchGlbData(url) {
+    const data = await fetch(url).then(r => r.arrayBuffer());
+    if (new Uint32Array(data, 0, 1)[0] !== 0x46546c67) throw new Error('Invalid GLB header.');
+    let json = null, binary = null;
+    let offset = 12;
+    while (offset < data.byteLength) {
+        const view = new DataView(data, offset, 8);
+        const len  = view.getUint32(0, true);
+        const type = view.getUint32(4, true);
+        if      (type === 0x4e4f534a) json   = JSON.parse(new TextDecoder().decode(data.slice(offset + 8, offset + 8 + len)).replace(/\0+$/, ''));
+        else if (type === 0x004e4942) binary = data.slice(offset + 8, offset + 8 + len);
+        offset += 8 + len;
+    }
+    if (!json) throw new Error('GLB JSON chunk missing.');
+    return { json, binary };
+}
+
+function buildEntityMap(gltfJson, clonedRoot) {
+    const nodes = gltfJson.nodes ?? [];
+    const map = new Array(nodes.length).fill(null);
+
+    function nameMap(children) {
+        const m = new Map();
+        for (const child of children) {
+            const n = child.name ?? '';
+            if (!m.has(n)) m.set(n, []);
+            m.get(n).push(child);
+        }
+        return m;
+    }
+
+    function walk(nodeIndex, entity) {
+        if (!entity || nodeIndex < 0) return;
+        map[nodeIndex] = entity;
+        const childIndices = nodes[nodeIndex].children ?? [];
+        if (!childIndices.length) return;
+        const byName = nameMap(entity.children);
+        for (const ci of childIndices) {
+            const cName = nodes[ci]?.name ?? '';
+            const candidates = byName.get(cName);
+            if (candidates?.length) walk(ci, candidates.shift());
+        }
+    }
+
+    const scenes = gltfJson.scenes ?? [];
+    const sceneRoots = scenes.length === 1 ? [clonedRoot] : clonedRoot.children;
+    for (let s = 0; s < scenes.length; s++) {
+        const sceneRoot = sceneRoots[s];
+        if (!sceneRoot) continue;
+        const rootIndices = scenes[s].nodes ?? [];
+        if (rootIndices.length === 1 && sceneRoot.name === (nodes[rootIndices[0]]?.name ?? '')) {
+            walk(rootIndices[0], sceneRoot);
+            continue;
+        }
+        const byName = nameMap(sceneRoot.children);
+        for (const ri of rootIndices) {
+            const candidates = byName.get(nodes[ri]?.name ?? '');
+            if (candidates?.length) walk(ri, candidates.shift());
+        }
+    }
+    return map;
+}
+
+function getCollisionDataFromImplicit(shapeDef, worldScale) {
+    const sx = Math.abs(worldScale.x), sy = Math.abs(worldScale.y), sz = Math.abs(worldScale.z);
+    if (shapeDef.sphere) return { type: 'sphere', radius: (shapeDef.sphere.radius ?? 0.5) * Math.max(sx, sy, sz) };
+    if (shapeDef.box) {
+        const s = shapeDef.box.size ?? [1, 1, 1];
+        return { type: 'box', halfExtents: new pc.Vec3(Math.abs(s[0]*sx)/2, Math.abs(s[1]*sy)/2, Math.abs(s[2]*sz)/2) };
+    }
+    if (shapeDef.capsule) {
+        const r = ((shapeDef.capsule.radiusTop ?? shapeDef.capsule.radius ?? 0.5) +
+                   (shapeDef.capsule.radiusBottom ?? shapeDef.capsule.radius ?? 0.5)) / 2 * Math.max(sx, sz);
+        return { type: 'capsule', radius: r, height: (shapeDef.capsule.height ?? 1.0) * sy + 2 * r, axis: 1 };
+    }
+    if (shapeDef.cylinder) {
+        const r = Math.max(shapeDef.cylinder.radiusTop ?? shapeDef.cylinder.radius ?? 0.5,
+                           shapeDef.cylinder.radiusBottom ?? shapeDef.cylinder.radius ?? 0.5) * Math.max(sx, sz);
+        return { type: 'cylinder', radius: r, height: (shapeDef.cylinder.height ?? 1.0) * sy, axis: 1 };
+    }
+    return null;
+}
+
+// --- Constraint helpers ---
+
+// Apply KHR joint limits and drives to a btGeneric6DofSpringConstraint.
+// Convention: lower > upper = FREE, lower == upper = LOCKED, lower < upper = LIMITED.
+function applyJointLimits(constraint, jointDef) {
+    // Default: all axes FREE.
+    const linLo = [1, 1, 1], linHi = [-1, -1, -1];
+    const angLo = [1, 1, 1], angHi = [-1, -1, -1];
+
+    for (const limit of (jointDef.limits ?? [])) {
+        const axes     = limit.linearAxes ?? limit.angularAxes ?? [];
+        const isLinear = !!limit.linearAxes;
+        const lo = limit.min ?? 0;
+        const hi = limit.max ?? 0;
+        const lo_arr = isLinear ? linLo : angLo;
+        const hi_arr = isLinear ? linHi : angHi;
+        for (const axis of axes) {
+            if (axis < 0 || axis > 2) continue;
+            lo_arr[axis] = lo;
+            hi_arr[axis] = hi;
+        }
+    }
+
+    const llV = new Ammo.btVector3(linLo[0], linLo[1], linLo[2]);
+    const luV = new Ammo.btVector3(linHi[0], linHi[1], linHi[2]);
+    const alV = new Ammo.btVector3(angLo[0], angLo[1], angLo[2]);
+    const auV = new Ammo.btVector3(angHi[0], angHi[1], angHi[2]);
+    constraint.setLinearLowerLimit(llV);
+    constraint.setLinearUpperLimit(luV);
+    constraint.setAngularLowerLimit(alV);
+    constraint.setAngularUpperLimit(auV);
+    Ammo.destroy(llV); Ammo.destroy(luV); Ammo.destroy(alV); Ammo.destroy(auV);
+
+    // Spring stiffness/damping from limits.
+    for (const limit of (jointDef.limits ?? [])) {
+        if (limit.stiffness === undefined && limit.damping === undefined) continue;
+        const axes     = limit.linearAxes ?? limit.angularAxes ?? [];
+        const isLinear = !!limit.linearAxes;
+        for (const axis of axes) {
+            const dofIdx = isLinear ? axis : 3 + axis;
+            if (limit.stiffness !== undefined) {
+                constraint.enableSpring(dofIdx, true);
+                constraint.setStiffness(dofIdx, limit.stiffness);
+            }
+            if (limit.damping !== undefined) constraint.setDamping(dofIdx, limit.damping);
+        }
+    }
+
+    // Drives (velocity motors / spring position motors).
+    for (const drive of (jointDef.drives ?? [])) {
+        const isAngular = drive.type === 'angular';
+        const axisIdx   = drive.axis ?? 0;
+        const dofIdx    = isAngular ? 3 + axisIdx : axisIdx;
+
+        const hasVelTarget = drive.velocityTarget !== undefined && drive.velocityTarget !== 0;
+        const hasSpring    = drive.stiffness !== undefined && drive.stiffness > 0;
+        const hasDamping   = drive.damping   !== undefined && drive.damping   > 0;
+
+        if (hasSpring || (drive.positionTarget !== undefined)) {
+            // Spring / position motor via btGeneric6DofSpringConstraint spring DOF.
+            constraint.enableSpring(dofIdx, true);
+            if (drive.stiffness !== undefined) constraint.setStiffness(dofIdx, drive.stiffness);
+            if (drive.damping   !== undefined) constraint.setDamping(dofIdx, drive.damping);
+            if (typeof constraint.setEquilibriumPoint === 'function' && drive.positionTarget !== undefined) {
+                constraint.setEquilibriumPoint(dofIdx, drive.positionTarget);
+            }
+        }
+
+        if (hasVelTarget || hasDamping) {
+            // Velocity motor via rotational/translational limit motor.
+            // Wrapped in try/catch: ammo.js builds expose motor fields inconsistently
+            // (some use set_m_X() setters, others expose direct properties).
+            // Failure here must not prevent the constraint from being added to the world.
+            try {
+                if (isAngular) {
+                    const motor = constraint.getRotationalLimitMotor(axisIdx);
+                    if (motor) {
+                        if (typeof motor.set_m_enableMotor === 'function') {
+                            motor.set_m_enableMotor(true);
+                            motor.set_m_targetVelocity(drive.velocityTarget ?? 0);
+                            motor.set_m_maxMotorForce(Math.max(Math.abs(drive.damping ?? 1) * 500, 100));
+                        } else {
+                            motor.m_enableMotor  = true;
+                            motor.m_targetVelocity = drive.velocityTarget ?? 0;
+                            motor.m_maxMotorForce  = Math.max(Math.abs(drive.damping ?? 1) * 500, 100);
+                        }
+                    }
+                } else {
+                    const motor = constraint.getTranslationalLimitMotor();
+                    if (motor) {
+                        const vel = drive.velocityTarget ?? 0;
+                        if (typeof motor.set_m_enableMotor === 'function') {
+                            motor.set_m_enableMotor(axisIdx, true);
+                            const tv = new Ammo.btVector3(
+                                axisIdx === 0 ? vel : 0,
+                                axisIdx === 1 ? vel : 0,
+                                axisIdx === 2 ? vel : 0
+                            );
+                            motor.set_m_targetVelocity(tv); Ammo.destroy(tv);
+                            const mf = new Ammo.btVector3(
+                                axisIdx === 0 ? 500 : 0,
+                                axisIdx === 1 ? 500 : 0,
+                                axisIdx === 2 ? 500 : 0
+                            );
+                            motor.set_m_maxMotorForce(mf); Ammo.destroy(mf);
+                        } else if (Array.isArray(motor.m_enableMotor)) {
+                            motor.m_enableMotor[axisIdx] = true;
+                        }
+                    }
+                }
+            } catch (_e) {
+                // Motor setup failed — constraint limits still apply
+            }
+        }
+    }
+}
+
+// Create a btTransform representing the joint anchor in body-local space.
+// jointWorldPos/Rot: world-space position and orientation of the joint node.
+// bodyWorldPos/Rot: world-space position and orientation of the body.
+function makeFrameInBody(jointWorldPos, jointWorldRot, bodyWorldPos, bodyWorldRot) {
+    const bodyRotInv = new pc.Quat(-bodyWorldRot.x, -bodyWorldRot.y, -bodyWorldRot.z, bodyWorldRot.w);
+
+    // Pivot in body-local space.
+    const delta = new pc.Vec3(
+        jointWorldPos.x - bodyWorldPos.x,
+        jointWorldPos.y - bodyWorldPos.y,
+        jointWorldPos.z - bodyWorldPos.z
+    );
+    const pivotLocal = new pc.Vec3();
+    bodyRotInv.transformVector(delta, pivotLocal);
+
+    // Joint orientation in body-local space.
+    const rotLocal = new pc.Quat().mul2(bodyRotInv, jointWorldRot);
+
+    const frame = new Ammo.btTransform();
+    frame.setIdentity();
+    frame.setOrigin(new Ammo.btVector3(pivotLocal.x, pivotLocal.y, pivotLocal.z));
+    frame.setRotation(new Ammo.btQuaternion(rotLocal.x, rotLocal.y, rotLocal.z, rotLocal.w));
+    return frame;
+}
+
+function createConstraint(jointEntity, bodyA, bodyB, jointDef, enableCollision, dynamicsWorld) {
+    const btBodyA = bodyA.rigidbody?.body;
+    const btBodyB = bodyB.rigidbody?.body;
+    if (!btBodyA || !btBodyB) return;
+
+    const jointPos = jointEntity.getPosition();
+    const jointRot = jointEntity.getRotation();
+    const posA     = bodyA.getPosition(), rotA = bodyA.getRotation();
+    const posB     = bodyB.getPosition(), rotB = bodyB.getRotation();
+
+    const frameA = makeFrameInBody(jointPos, jointRot, posA, rotA);
+    const frameB = makeFrameInBody(jointPos, jointRot, posB, rotB);
+
+    const constraint = new Ammo.btGeneric6DofSpringConstraint(btBodyA, btBodyB, frameA, frameB, true);
+    Ammo.destroy(frameA);
+    Ammo.destroy(frameB);
+
+    // Apply limits BEFORE adding to world so Bullet reads the correct state.
+    // applyJointLimits wraps motor code in try/catch internally; other errors bubble up
+    // to the outer try/catch in initPhysics.
+    applyJointLimits(constraint, jointDef);
+
+    // disableCollisionsBetweenLinkedBodies = !enableCollision
+    dynamicsWorld.addConstraint(constraint, !enableCollision);
+}
+
+// ---
+
+function initPhysics(gltfJson, binary, entityMap, dynamicsWorld) {
+    const matDefs      = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsMaterials ?? [];
+    const shapeDefs    = gltfJson.extensions?.KHR_implicit_shapes?.shapes ?? [];
+    const physicsJoints = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsJoints ?? [];
+    const nodes        = gltfJson.nodes ?? [];
+
+    const parentOf = new Array(nodes.length).fill(-1);
+    for (let i = 0; i < nodes.length; i++)
+        for (const c of nodes[i].children ?? []) parentOf[c] = i;
+
+    const hasMotion = i => !!nodes[i]?.extensions?.KHR_physics_rigid_bodies?.motion;
+    function findBodyOwner(idx) {
+        let cur = idx;
+        while (cur >= 0) { if (hasMotion(cur)) return cur; cur = parentOf[cur]; }
+        return -1;
+    }
+
+    // Pass 1: compound collision components for body-owners.
+    const bodyOwnerNodes = [];
+    for (let i = 0; i < nodes.length; i++) {
+        if (!hasMotion(i)) continue;
+        const e = entityMap[i]; if (!e) continue;
+        e.addComponent('collision', { type: 'compound' });
+        bodyOwnerNodes.push(i);
+    }
+
+    const standaloneStatics = []; // { entity, collider, nodeIdx }
+
+    for (let i = 0; i < nodes.length; i++) {
+        const physExt = nodes[i].extensions?.KHR_physics_rigid_bodies;
+        if (!physExt?.collider?.geometry) continue;
+        const geom     = physExt.collider.geometry;
+        const ownerIdx = findBodyOwner(i);
+
+        if (ownerIdx === i) {
+            if (geom.shape === undefined) continue;
+            const parent   = entityMap[i]; if (!parent) continue;
+            const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+            const child = new pc.Entity('__khrCollider');
+            parent.addChild(child);
+            const cd = getCollisionDataFromImplicit(shapeDef, parent.getWorldTransform().getScale());
+            if (cd) child.addComponent('collision', cd);
+        } else if (geom.shape !== undefined) {
+            const e = entityMap[i]; if (!e) continue;
+            const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+            const cd = getCollisionDataFromImplicit(shapeDef, e.getWorldTransform().getScale());
+            if (!cd) continue;
+            e.addComponent('collision', cd);
+            if (ownerIdx < 0) standaloneStatics.push({ entity: e, collider: physExt.collider, nodeIdx: i });
+        }
+    }
+
+    // Pass 2: rigidbody components.
+    const dynamicInfos = [];
+    const staticInfos  = [];
+
+    for (const i of bodyOwnerNodes) {
+        const e = entityMap[i];
+        const m = nodes[i].extensions.KHR_physics_rigid_bodies.motion;
+        const isK = !!m?.isKinematic;
+        const cfg = { type: isK ? 'kinematic' : 'dynamic' };
+        if (!isK) cfg.mass = m?.mass ?? 1;
+        e.addComponent('rigidbody', cfg);
+        const ownC = nodes[i].extensions.KHR_physics_rigid_bodies.collider;
+        const mat  = ownC?.physicsMaterial !== undefined ? (matDefs[ownC.physicsMaterial] ?? {}) : {};
+        (isK ? staticInfos : dynamicInfos).push({ entity: e, mat });
+    }
+    for (const { entity, collider } of standaloneStatics) {
+        entity.addComponent('rigidbody', { type: 'static' });
+        const mat = collider.physicsMaterial !== undefined ? (matDefs[collider.physicsMaterial] ?? {}) : {};
+        staticInfos.push({ entity, mat });
+    }
+
+    for (const info of dynamicInfos) {
+        if (info.mat.dynamicFriction !== undefined) info.entity.rigidbody.friction    = info.mat.dynamicFriction;
+        if (info.mat.restitution     !== undefined) info.entity.rigidbody.restitution = info.mat.restitution;
+    }
+
+    // Build bodyNodeSet: all nodes that have a physics body (motion-owners + standalone statics).
+    // Used for joint body lookup — includes static bodies that may serve as joint anchors.
+    const bodyNodeSet = new Set(bodyOwnerNodes);
+    for (const { nodeIdx } of standaloneStatics) bodyNodeSet.add(nodeIdx);
+
+    // Find nearest ancestor node that has a body (start from parent of idx).
+    function findAncestorBodyNode(idx) {
+        let cur = parentOf[idx];
+        while (cur >= 0) { if (bodyNodeSet.has(cur)) return cur; cur = parentOf[cur]; }
+        return -1;
+    }
+    // Resolve body node: check idx itself, then climb ancestors.
+    function resolveBodyNode(idx) {
+        let cur = idx;
+        while (cur >= 0) { if (bodyNodeSet.has(cur)) return cur; cur = parentOf[cur]; }
+        return -1;
+    }
+
+    // Pass 3: joints — connect bodies using btGeneric6DofSpringConstraint.
+    let jointsFound = 0, jointsCreated = 0;
+    for (let i = 0; i < nodes.length; i++) {
+        const physExt = nodes[i].extensions?.KHR_physics_rigid_bodies;
+        if (!physExt?.joint) continue;
+        jointsFound++;
+
+        const jointExt  = physExt.joint;
+        const jointDef  = physicsJoints[jointExt.joint];
+        if (!jointDef) { console.warn('[JointTypes] physicsJoints[' + jointExt.joint + '] missing'); continue; }
+
+        // The joint node's ancestor owns body A.
+        const ownerAIdx = findAncestorBodyNode(i);
+        if (ownerAIdx < 0) { console.warn('[JointTypes] joint node', i, 'has no ancestor body'); continue; }
+        const entityA   = entityMap[ownerAIdx];
+        if (!entityA?.rigidbody) { console.warn('[JointTypes] body A entity missing rigidbody'); continue; }
+
+        // The connectedNode (or its ancestor) owns body B.
+        const connIdx   = jointExt.connectedNode;
+        const ownerBIdx = resolveBodyNode(connIdx);
+        if (ownerBIdx < 0) { console.warn('[JointTypes] connectedNode', connIdx, 'has no body'); continue; }
+        const entityB   = entityMap[ownerBIdx];
+        if (!entityB?.rigidbody) { console.warn('[JointTypes] body B entity missing rigidbody'); continue; }
+
+        const jointEntity = entityMap[i];
+        if (!jointEntity) { console.warn('[JointTypes] joint entity', i, 'not in entityMap'); continue; }
+
+        try {
+            createConstraint(jointEntity, entityA, entityB, jointDef,
+                jointExt.enableCollision === true, dynamicsWorld);
+            jointsCreated++;
+        } catch (e) {
+            console.warn('[JointTypes] createConstraint failed for node', i, ':', e.message);
+        }
+    }
+    if (jointsFound > 0) console.log('[JointTypes] joints:', jointsCreated + '/' + jointsFound + ' created');
+
+    const debugEntities = [];
+    const visitDebug = e => {
+        if (e.collision?.type && e.collision.type !== 'compound') debugEntities.push(e);
+        for (const c of e.children) visitDebug(c);
+    };
+    for (const info of dynamicInfos) visitDebug(info.entity);
+    for (const info of staticInfos)  visitDebug(info.entity);
+
+    return {
+        dynamicBodies: dynamicInfos.map(info => ({
+            entity: info.entity,
+            initialPosition: info.entity.getPosition().clone(),
+            initialRotation: info.entity.getRotation().clone()
+        })),
+        debugEntities
+    };
+}
+
+// --- Debug wireframe ---
+
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+
+function _ringPoints(axis, radius, segs, out, mat) {
+    const tmp = new pc.Vec3(); let prev = null;
+    for (let i = 0; i <= segs; i++) {
+        const t=(i/segs)*Math.PI*2, c=Math.cos(t)*radius, s=Math.sin(t)*radius;
+        if(axis===0)tmp.set(0,c,s);else if(axis===1)tmp.set(c,0,s);else tmp.set(c,s,0);
+        const cur=new pc.Vec3(); mat.transformPoint(tmp,cur);
+        if(prev){out.push(prev);out.push(cur);} prev=cur;
+    }
+}
+function _getPosRotMat(e) { return new pc.Mat4().setTRS(e.getPosition(), e.getRotation(), pc.Vec3.ONE); }
+function _drawWireSphereLocal(app, mat, r, color) {
+    const pts=[]; _ringPoints(0,r,16,pts,mat); _ringPoints(1,r,16,pts,mat); _ringPoints(2,r,16,pts,mat);
+    app.drawLines(pts,pts.map(()=>color),false);
+}
+function _drawWireBoxLocal(app, mat, hx, hy, hz, color) {
+    app.drawWireAlignedBox(new pc.Vec3(-hx,-hy,-hz),new pc.Vec3(hx,hy,hz),color,false,undefined,mat);
+}
+function _drawWireCylinderLocal(app, mat, radius, halfH, axis, color) {
+    const pts=[],segs=16,oA=new pc.Vec3(),oB=new pc.Vec3();
+    if(axis===0){oA.set(-halfH,0,0);oB.set(halfH,0,0);}
+    else if(axis===1){oA.set(0,-halfH,0);oB.set(0,halfH,0);}
+    else{oA.set(0,0,-halfH);oB.set(0,0,halfH);}
+    const tmp=new pc.Vec3(),rings=[];
+    for(const off of [oA,oB]){
+        const ring=[];
+        for(let i=0;i<=segs;i++){
+            const t=(i/segs)*Math.PI*2,c=Math.cos(t)*radius,s=Math.sin(t)*radius;
+            if(axis===0)tmp.set(off.x,c,s);else if(axis===1)tmp.set(c,off.y,s);else tmp.set(c,s,off.z);
+            const v=new pc.Vec3();mat.transformPoint(tmp,v);ring.push(v);
+        }
+        rings.push(ring);
+        for(let i=0;i<segs;i++){pts.push(ring[i]);pts.push(ring[i+1]);}
+    }
+    const step=Math.floor(segs/4);
+    for(let k=0;k<4;k++){pts.push(rings[0][k*step]);pts.push(rings[1][k*step]);}
+    app.drawLines(pts,pts.map(()=>color),false);
+}
+function _drawWireCapsuleLocal(app, mat, r, cylHalf, axis, color) {
+    _drawWireCylinderLocal(app, mat, r, cylHalf, axis, color);
+    const off=new pc.Vec3();
+    for(const sign of[-1,1]){
+        if(axis===0)off.set(sign*cylHalf,0,0);else if(axis===1)off.set(0,sign*cylHalf,0);else off.set(0,0,sign*cylHalf);
+        _drawWireSphereLocal(app, new pc.Mat4().mul2(mat, new pc.Mat4().setTranslate(off.x,off.y,off.z)), r, color);
+    }
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision; if (!col?.type) continue;
+        let rb = entity; while(rb && !rb.rigidbody) rb = rb.parent;
+        const color = rb?.rigidbody?.type === pc.BODYTYPE_DYNAMIC ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = _getPosRotMat(entity);
+        switch(col.type) {
+            case 'box':      _drawWireBoxLocal(app,mat,col.halfExtents.x,col.halfExtents.y,col.halfExtents.z,color); break;
+            case 'sphere':   _drawWireSphereLocal(app,mat,col.radius,color); break;
+            case 'capsule':  _drawWireCapsuleLocal(app,mat,col.radius,Math.max(0,(col.height-2*col.radius)*0.5),col.axis??1,color); break;
+            case 'cylinder': _drawWireCylinderLocal(app,mat,col.radius,col.height*0.5,col.axis??1,color); break;
+        }
+    }
+}
+
+// ---
+
+function enableShadows(e) {
+    if (e.render) { e.render.castShadows = true; e.render.receiveShadows = true; }
+    if (e.model)  { e.model.castShadows  = true; e.model.receiveShadows  = true; }
+    for (const c of e.children) enableShadows(c);
+}
+
+function computeBodyBounds(dynamicBodies) {
+    if (!dynamicBodies.length) return { center: new pc.Vec3(0, 2, 0), radius: 15 };
+    let minX=Infinity,minY=Infinity,minZ=Infinity,maxX=-Infinity,maxY=-Infinity,maxZ=-Infinity;
+    for (const b of dynamicBodies) {
+        const p = b.initialPosition;
+        minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);
+        minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);
+        minZ=Math.min(minZ,p.z);maxZ=Math.max(maxZ,p.z);
+    }
+    const center = new pc.Vec3((minX+maxX)*0.5,(minY+maxY)*0.5,(minZ+maxZ)*0.5);
+    const d = Math.sqrt((maxX-minX)**2+(maxY-minY)**2+(maxZ-minZ)**2);
+    return { center, radius: Math.max(d+10, 15) };
+}
+
+let showWireframe = true;
+
+function init() {
+    const canvas = document.getElementById('c');
+    const app = new pc.Application(canvas, {
+        mouse: new pc.Mouse(canvas),
+        touch: new pc.TouchDevice(canvas)
+    });
+    if (typeof Ammo !== 'undefined' && app.systems.rigidbody) {
+        app.systems.rigidbody.gravity.set(0, -9.81, 0);
+        app.systems.rigidbody.onLibraryLoaded();
+    }
+    app.start();
+    app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+    app.setCanvasResolution(pc.RESOLUTION_AUTO);
+    window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
+    window.addEventListener('keydown', event => {
+        if ((event.code === 'KeyW' || event.key === 'w' || event.key === 'W') && !event.repeat) {
+            showWireframe = !showWireframe;
+            const hint = document.getElementById('hint');
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        }
+    });
+
+    app.scene.ambientLight = new pc.Color(0.4, 0.45, 0.5);
+
+    const light = new pc.Entity('light');
+    light.addComponent('light', { type: 'directional', color: new pc.Color(1, 0.95, 0.85),
+        intensity: 1.0, castShadows: true, shadowResolution: 2048, shadowBias: 0.3, normalOffsetBias: 0.02 });
+    light.setLocalEulerAngles(45, 45, 0);
+    app.root.addChild(light);
+
+    const fillLight = new pc.Entity('fillLight');
+    fillLight.addComponent('light', { type: 'directional', color: new pc.Color(0.45, 0.6, 1.0),
+        intensity: 0.5, castShadows: false });
+    fillLight.setLocalEulerAngles(-30, 180, 0);
+    app.root.addChild(fillLight);
+
+    const camera = new pc.Entity('camera');
+    camera.addComponent('camera', { clearColor: new pc.Color(0.96,0.97,0.99), nearClip: 0.05, farClip: 1000, fov: 45 });
+    camera.addComponent('script');
+    camera.setPosition(0, 2, 20);
+    app.root.addChild(camera);
+    const controls = camera.script.create(CameraControls, { properties: { enableFly: false } });
+
+    let dynamicBodies = [];
+    let debugEntities = [];
+
+    Promise.all([
+        fetchGlbData(MODEL_URL),
+        new Promise((resolve, reject) => {
+            app.assets.loadFromUrlAndFilename(MODEL_URL, MODEL_URL.split('/').pop(), 'container',
+                (err, asset) => err ? reject(err) : resolve(asset));
+        })
+    ]).then(([glbData, asset]) => {
+        const { json: gltfJson, binary } = glbData;
+        const res  = asset.resource;
+        const root = res.instantiateRenderEntity ? res.instantiateRenderEntity() : res.instantiateModelEntity();
+        app.root.addChild(root);
+        enableShadows(root);
+
+        const entityMap = buildEntityMap(gltfJson, root);
+        const result    = initPhysics(gltfJson, binary, entityMap, app.systems.rigidbody.dynamicsWorld);
+        dynamicBodies = result.dynamicBodies;
+        debugEntities = result.debugEntities;
+
+        const { center, radius } = computeBodyBounds(dynamicBodies);
+        const startPos = new pc.Vec3(center.x, center.y + 2, center.z + radius);
+        controls.reset(center, startPos);
+
+        app.on('update', () => {
+            if (showWireframe) drawPhysicsDebug(app, debugEntities);
+
+            for (const body of dynamicBodies) {
+                if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) continue;
+                body.entity.setPosition(body.initialPosition);
+                body.entity.setRotation(body.initialRotation);
+                body.entity.rigidbody.linearVelocity  = pc.Vec3.ZERO;
+                body.entity.rigidbody.angularVelocity = pc.Vec3.ZERO;
+                body.entity.rigidbody.syncEntityToBody();
+            }
+        });
+    }).catch(console.error);
+}

--- a/examples/playcanvas/ammo/gltf_physics_JointTypes/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_JointTypes/style.css
@@ -1,0 +1,26 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/playcanvas/ammo/gltf_physics_Triggers/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Triggers/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>[WIP] PlayCanvas + ammo.js Triggers (glTF Physics extension)</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+  <script type="importmap">
+  {
+    "imports": {
+      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
+      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+    }
+  }
+  </script>
+</head>
+<body>
+<canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
+
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/playcanvas/ammo/gltf_physics_Triggers/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Triggers/index.js
@@ -1,0 +1,524 @@
+import * as pc from 'playcanvas';
+import { CameraControls } from 'camera-controls';
+
+const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
+const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Triggers/Triggers.glb';
+const RESET_Y_THRESHOLD = -20;
+
+pc.WasmModule.setConfig('Ammo', {
+    glueUrl:     PC_ROOT + '/ammo/ammo.wasm.js',
+    wasmUrl:     PC_ROOT + '/ammo/ammo.wasm.wasm',
+    fallbackUrl: PC_ROOT + '/ammo/ammo.js'
+});
+pc.WasmModule.getInstance('Ammo', init);
+
+async function fetchGlbData(url) {
+    const data = await fetch(url).then(r => r.arrayBuffer());
+    if (new Uint32Array(data, 0, 1)[0] !== 0x46546c67) throw new Error('Invalid GLB header.');
+    let json = null, binary = null;
+    let offset = 12;
+    while (offset < data.byteLength) {
+        const view = new DataView(data, offset, 8);
+        const len  = view.getUint32(0, true);
+        const type = view.getUint32(4, true);
+        if      (type === 0x4e4f534a) json   = JSON.parse(new TextDecoder().decode(data.slice(offset + 8, offset + 8 + len)).replace(/\0+$/, ''));
+        else if (type === 0x004e4942) binary = data.slice(offset + 8, offset + 8 + len);
+        offset += 8 + len;
+    }
+    if (!json) throw new Error('GLB JSON chunk missing.');
+    return { json, binary };
+}
+
+function buildEntityMap(gltfJson, clonedRoot) {
+    const nodes = gltfJson.nodes ?? [];
+    const map = new Array(nodes.length).fill(null);
+
+    function nameMap(children) {
+        const m = new Map();
+        for (const child of children) {
+            const n = child.name ?? '';
+            if (!m.has(n)) m.set(n, []);
+            m.get(n).push(child);
+        }
+        return m;
+    }
+
+    function walk(nodeIndex, entity) {
+        if (!entity || nodeIndex < 0) return;
+        map[nodeIndex] = entity;
+        const childIndices = nodes[nodeIndex].children ?? [];
+        if (!childIndices.length) return;
+        const byName = nameMap(entity.children);
+        for (const ci of childIndices) {
+            const cName = nodes[ci]?.name ?? '';
+            const candidates = byName.get(cName);
+            if (candidates?.length) walk(ci, candidates.shift());
+        }
+    }
+
+    const scenes = gltfJson.scenes ?? [];
+    const sceneRoots = scenes.length === 1 ? [clonedRoot] : clonedRoot.children;
+    for (let s = 0; s < scenes.length; s++) {
+        const sceneRoot = sceneRoots[s];
+        if (!sceneRoot) continue;
+        const rootIndices = scenes[s].nodes ?? [];
+        if (rootIndices.length === 1 && sceneRoot.name === (nodes[rootIndices[0]]?.name ?? '')) {
+            walk(rootIndices[0], sceneRoot);
+            continue;
+        }
+        const byName = nameMap(sceneRoot.children);
+        for (const ri of rootIndices) {
+            const candidates = byName.get(nodes[ri]?.name ?? '');
+            if (candidates?.length) walk(ri, candidates.shift());
+        }
+    }
+    return map;
+}
+
+function getCollisionDataFromImplicit(shapeDef, worldScale) {
+    const sx = Math.abs(worldScale.x), sy = Math.abs(worldScale.y), sz = Math.abs(worldScale.z);
+    if (shapeDef.sphere) return { type: 'sphere', radius: (shapeDef.sphere.radius ?? 0.5) * Math.max(sx, sy, sz) };
+    if (shapeDef.box) {
+        const s = shapeDef.box.size ?? [1, 1, 1];
+        return { type: 'box', halfExtents: new pc.Vec3(Math.abs(s[0]*sx)/2, Math.abs(s[1]*sy)/2, Math.abs(s[2]*sz)/2) };
+    }
+    if (shapeDef.capsule) {
+        const r = ((shapeDef.capsule.radiusTop ?? shapeDef.capsule.radius ?? 0.5) +
+                   (shapeDef.capsule.radiusBottom ?? shapeDef.capsule.radius ?? 0.5)) / 2 * Math.max(sx, sz);
+        return { type: 'capsule', radius: r, height: (shapeDef.capsule.height ?? 1.0) * sy + 2 * r, axis: 1 };
+    }
+    if (shapeDef.cylinder) {
+        const r = Math.max(shapeDef.cylinder.radiusTop ?? shapeDef.cylinder.radius ?? 0.5,
+                           shapeDef.cylinder.radiusBottom ?? shapeDef.cylinder.radius ?? 0.5) * Math.max(sx, sz);
+        return { type: 'cylinder', radius: r, height: (shapeDef.cylinder.height ?? 1.0) * sy, axis: 1 };
+    }
+    return null;
+}
+
+// Build an Ammo btCollisionShape from an implicit shape definition (for ghost objects).
+function buildAmmoShapeFromImplicit(shapeDef, worldScale) {
+    const sx = Math.abs(worldScale.x), sy = Math.abs(worldScale.y), sz = Math.abs(worldScale.z);
+    if (shapeDef.sphere) {
+        const r = (shapeDef.sphere.radius ?? 0.5) * Math.max(sx, sy, sz);
+        return new Ammo.btSphereShape(r);
+    }
+    if (shapeDef.box) {
+        const s = shapeDef.box.size ?? [1, 1, 1];
+        const hx = Math.abs(s[0]*sx)/2, hy = Math.abs(s[1]*sy)/2, hz = Math.abs(s[2]*sz)/2;
+        return new Ammo.btBoxShape(new Ammo.btVector3(hx, hy, hz));
+    }
+    if (shapeDef.capsule) {
+        const r = ((shapeDef.capsule.radiusTop ?? shapeDef.capsule.radius ?? 0.5) +
+                   (shapeDef.capsule.radiusBottom ?? shapeDef.capsule.radius ?? 0.5)) / 2 * Math.max(sx, sz);
+        const cylHalf = Math.max(0, (shapeDef.capsule.height ?? 1.0) * sy * 0.5);
+        return new Ammo.btCapsuleShape(r, cylHalf * 2);
+    }
+    if (shapeDef.cylinder) {
+        const r = Math.max(shapeDef.cylinder.radiusTop ?? shapeDef.cylinder.radius ?? 0.5,
+                           shapeDef.cylinder.radiusBottom ?? shapeDef.cylinder.radius ?? 0.5) * Math.max(sx, sz);
+        const halfH = (shapeDef.cylinder.height ?? 1.0) * sy * 0.5;
+        return new Ammo.btCylinderShape(new Ammo.btVector3(r, halfH, r));
+    }
+    return null;
+}
+
+// Create a btGhostObject acting as a trigger volume.
+// Returns the ghost object (caller must track for overlap queries).
+function createTriggerGhostObject(shape, entity, dynamicsWorld) {
+    const ghost = new Ammo.btGhostObject();
+    ghost.setCollisionShape(shape);
+
+    const p = entity.getPosition(), q = entity.getRotation();
+    const xform = new Ammo.btTransform();
+    xform.setIdentity();
+    xform.setOrigin(new Ammo.btVector3(p.x, p.y, p.z));
+    xform.setRotation(new Ammo.btQuaternion(q.x, q.y, q.z, q.w));
+    ghost.setWorldTransform(xform);
+    Ammo.destroy(xform);
+
+    // CF_NO_CONTACT_RESPONSE = 4: no collision response, but still broadphase detects overlap
+    ghost.setCollisionFlags(ghost.getCollisionFlags() | 4);
+
+    // SensorTrigger group = 16, AllFilter = -1
+    dynamicsWorld.addCollisionObject(ghost, 16, -1);
+    return ghost;
+}
+
+// Make trigger entity visually semi-transparent so it looks like a ghost volume.
+function applyTriggerMaterial(entity) {
+    const visit = e => {
+        if (e.render) {
+            for (const mi of e.render.meshInstances) {
+                const mat = mi.material;
+                if (mat) {
+                    mat.opacity = 0.3;
+                    mat.blendType = pc.BLEND_NORMAL;
+                    mat.depthWrite = false;
+                    mat.update();
+                }
+            }
+        }
+        for (const c of e.children) visit(c);
+    };
+    visit(entity);
+}
+
+function setTriggerHighlight(entity, active) {
+    const visit = e => {
+        if (e.render) {
+            for (const mi of e.render.meshInstances) {
+                const mat = mi.material;
+                if (mat) {
+                    if (active) {
+                        mat.emissive = new pc.Color(0.4, 0.4, 0.0);
+                        mat.opacity  = 0.7;
+                    } else {
+                        mat.emissive = new pc.Color(0, 0, 0);
+                        mat.opacity  = 0.3;
+                    }
+                    mat.update();
+                }
+            }
+        }
+        for (const c of e.children) setTriggerHighlight(c, active);
+    };
+    visit(entity);
+}
+
+function initPhysics(gltfJson, binary, entityMap, dynamicsWorld) {
+    const matDefs   = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsMaterials ?? [];
+    const shapeDefs = gltfJson.extensions?.KHR_implicit_shapes?.shapes ?? [];
+    const nodes     = gltfJson.nodes ?? [];
+
+    // Register ghost pair callback so btGhostObject overlaps are detected.
+    // Must be done before adding any ghost objects.
+    if (typeof Ammo.btGhostPairCallback === 'function') {
+        const ghostPairCallback = new Ammo.btGhostPairCallback();
+        dynamicsWorld.getBroadphase().getOverlappingPairCache()
+            .setInternalGhostPairCallback(ghostPairCallback);
+    }
+
+    const parentOf = new Array(nodes.length).fill(-1);
+    for (let i = 0; i < nodes.length; i++)
+        for (const c of nodes[i].children ?? []) parentOf[c] = i;
+
+    const hasMotion = i => !!nodes[i]?.extensions?.KHR_physics_rigid_bodies?.motion;
+    function findBodyOwner(idx) {
+        let cur = idx;
+        while (cur >= 0) { if (hasMotion(cur)) return cur; cur = parentOf[cur]; }
+        return -1;
+    }
+
+    // Pass 1: compound collision for body-owners.
+    const bodyOwnerNodes = [];
+    for (let i = 0; i < nodes.length; i++) {
+        if (!hasMotion(i)) continue;
+        const e = entityMap[i]; if (!e) continue;
+        e.addComponent('collision', { type: 'compound' });
+        bodyOwnerNodes.push(i);
+    }
+
+    const standaloneStatics = [];
+    const triggerEntries    = []; // { entity, ghostObj, ghostShape }
+
+    for (let i = 0; i < nodes.length; i++) {
+        const physExt = nodes[i].extensions?.KHR_physics_rigid_bodies;
+        if (!physExt) continue;
+
+        const e = entityMap[i]; if (!e) continue;
+
+        // Trigger node: create ghost object instead of rigid body.
+        if (physExt.trigger?.geometry) {
+            const geomDef = physExt.trigger.geometry;
+            const ws      = e.getWorldTransform().getScale();
+            let shape = null;
+            if (geomDef.shape !== undefined) {
+                const sd = shapeDefs[geomDef.shape];
+                if (sd) shape = buildAmmoShapeFromImplicit(sd, ws);
+            }
+            if (!shape) {
+                // Fallback: box from render AABB
+                if (e.render && e.render.meshInstances.length > 0) {
+                    const h = e.render.meshInstances[0].aabb.halfExtents;
+                    shape = new Ammo.btBoxShape(new Ammo.btVector3(h.x, h.y, h.z));
+                }
+            }
+            if (shape) {
+                const ghostObj = createTriggerGhostObject(shape, e, dynamicsWorld);
+                applyTriggerMaterial(e);
+                triggerEntries.push({ entity: e, ghostObj, ghostShape: shape });
+            }
+            continue;
+        }
+
+        if (!physExt.collider?.geometry) continue;
+        const geom     = physExt.collider.geometry;
+        const ownerIdx = findBodyOwner(i);
+
+        if (ownerIdx === i) {
+            if (geom.shape === undefined) continue;
+            const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+            const child = new pc.Entity('__khrCollider');
+            e.addChild(child);
+            const cd = getCollisionDataFromImplicit(shapeDef, e.getWorldTransform().getScale());
+            if (cd) child.addComponent('collision', cd);
+        } else if (geom.shape !== undefined) {
+            const shapeDef = shapeDefs[geom.shape]; if (!shapeDef) continue;
+            const cd = getCollisionDataFromImplicit(shapeDef, e.getWorldTransform().getScale());
+            if (!cd) continue;
+            e.addComponent('collision', cd);
+            if (ownerIdx < 0) standaloneStatics.push({ entity: e, collider: physExt.collider });
+        }
+    }
+
+    // Pass 2: rigidbody components.
+    const dynamicInfos = [];
+    const staticInfos  = [];
+
+    for (const i of bodyOwnerNodes) {
+        const e = entityMap[i];
+        const m = nodes[i].extensions.KHR_physics_rigid_bodies.motion;
+        const isK = !!m?.isKinematic;
+        const cfg = { type: isK ? 'kinematic' : 'dynamic' };
+        if (!isK) cfg.mass = m?.mass ?? 1;
+        e.addComponent('rigidbody', cfg);
+        const ownC = nodes[i].extensions.KHR_physics_rigid_bodies.collider;
+        const mat  = ownC?.physicsMaterial !== undefined ? (matDefs[ownC.physicsMaterial] ?? {}) : {};
+        (isK ? staticInfos : dynamicInfos).push({ entity: e, mat });
+    }
+    for (const { entity, collider } of standaloneStatics) {
+        entity.addComponent('rigidbody', { type: 'static' });
+        const mat = collider.physicsMaterial !== undefined ? (matDefs[collider.physicsMaterial] ?? {}) : {};
+        staticInfos.push({ entity, mat });
+    }
+
+    for (const info of dynamicInfos) {
+        if (info.mat.dynamicFriction !== undefined) info.entity.rigidbody.friction    = info.mat.dynamicFriction;
+        if (info.mat.restitution     !== undefined) info.entity.rigidbody.restitution = info.mat.restitution;
+    }
+
+    const debugEntities = [];
+    const visitDebug = e => {
+        if (e.collision?.type && e.collision.type !== 'compound') debugEntities.push(e);
+        for (const c of e.children) visitDebug(c);
+    };
+    for (const info of dynamicInfos) visitDebug(info.entity);
+    for (const info of staticInfos)  visitDebug(info.entity);
+
+    return {
+        dynamicBodies: dynamicInfos.map(info => ({
+            entity: info.entity,
+            initialPosition: info.entity.getPosition().clone(),
+            initialRotation: info.entity.getRotation().clone()
+        })),
+        debugEntities,
+        triggerEntries
+    };
+}
+
+// Check trigger overlap by testing dynamic body positions against ghost object AABB.
+// btGhostObject.getNumOverlappingObjects() is the native overlap count.
+function checkTriggerOverlaps(triggerEntries, dynamicBodies) {
+    for (const entry of triggerEntries) {
+        const numOverlapping = entry.ghostObj.getNumOverlappingObjects();
+        const triggered = numOverlapping > 0;
+        setTriggerHighlight(entry.entity, triggered);
+    }
+}
+
+// --- Debug wireframe ---
+
+const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
+const _DBG_COLOR_STATIC  = new pc.Color(1, 1, 0, 1);
+const _DBG_COLOR_TRIGGER = new pc.Color(0, 0.6, 1, 1);
+
+function _ringPoints(axis, radius, segs, out, mat) {
+    const tmp = new pc.Vec3(); let prev = null;
+    for (let i = 0; i <= segs; i++) {
+        const t = (i/segs)*Math.PI*2, c = Math.cos(t)*radius, s = Math.sin(t)*radius;
+        if (axis===0) tmp.set(0,c,s); else if (axis===1) tmp.set(c,0,s); else tmp.set(c,s,0);
+        const cur = new pc.Vec3(); mat.transformPoint(tmp, cur);
+        if (prev) { out.push(prev); out.push(cur); }
+        prev = cur;
+    }
+}
+function _getPosRotMat(e) { return new pc.Mat4().setTRS(e.getPosition(), e.getRotation(), pc.Vec3.ONE); }
+function _drawWireSphereLocal(app, mat, r, color) {
+    const pts = []; _ringPoints(0,r,16,pts,mat); _ringPoints(1,r,16,pts,mat); _ringPoints(2,r,16,pts,mat);
+    app.drawLines(pts, pts.map(()=>color), false);
+}
+function _drawWireBoxLocal(app, mat, hx, hy, hz, color) {
+    app.drawWireAlignedBox(new pc.Vec3(-hx,-hy,-hz), new pc.Vec3(hx,hy,hz), color, false, undefined, mat);
+}
+function _drawWireCylinderLocal(app, mat, radius, halfH, axis, color) {
+    const pts=[], segs=16, oA=new pc.Vec3(), oB=new pc.Vec3();
+    if (axis===0){oA.set(-halfH,0,0);oB.set(halfH,0,0);}
+    else if(axis===1){oA.set(0,-halfH,0);oB.set(0,halfH,0);}
+    else{oA.set(0,0,-halfH);oB.set(0,0,halfH);}
+    const tmp=new pc.Vec3(), rings=[];
+    for (const off of [oA,oB]) {
+        const ring=[];
+        for (let i=0;i<=segs;i++) {
+            const t=(i/segs)*Math.PI*2,c=Math.cos(t)*radius,s=Math.sin(t)*radius;
+            if(axis===0)tmp.set(off.x,c,s);else if(axis===1)tmp.set(c,off.y,s);else tmp.set(c,s,off.z);
+            const v=new pc.Vec3(); mat.transformPoint(tmp,v); ring.push(v);
+        }
+        rings.push(ring);
+        for(let i=0;i<segs;i++){pts.push(ring[i]);pts.push(ring[i+1]);}
+    }
+    const step=Math.floor(segs/4);
+    for(let k=0;k<4;k++){pts.push(rings[0][k*step]);pts.push(rings[1][k*step]);}
+    app.drawLines(pts,pts.map(()=>color),false);
+}
+function _drawWireCapsuleLocal(app, mat, r, cylHalf, axis, color) {
+    _drawWireCylinderLocal(app, mat, r, cylHalf, axis, color);
+    const off=new pc.Vec3();
+    for (const sign of [-1,1]) {
+        if(axis===0)off.set(sign*cylHalf,0,0);else if(axis===1)off.set(0,sign*cylHalf,0);else off.set(0,0,sign*cylHalf);
+        _drawWireSphereLocal(app, new pc.Mat4().mul2(mat, new pc.Mat4().setTranslate(off.x,off.y,off.z)), r, color);
+    }
+}
+
+function drawPhysicsDebug(app, entities) {
+    for (const entity of entities) {
+        const col = entity.collision; if (!col?.type) continue;
+        let rb = entity; while(rb && !rb.rigidbody) rb = rb.parent;
+        const color = rb?.rigidbody?.type === pc.BODYTYPE_DYNAMIC ? _DBG_COLOR_DYNAMIC : _DBG_COLOR_STATIC;
+        const mat = _getPosRotMat(entity);
+        switch(col.type) {
+            case 'box':      _drawWireBoxLocal(app,mat,col.halfExtents.x,col.halfExtents.y,col.halfExtents.z,color); break;
+            case 'sphere':   _drawWireSphereLocal(app,mat,col.radius,color); break;
+            case 'capsule':  _drawWireCapsuleLocal(app,mat,col.radius,Math.max(0,(col.height-2*col.radius)*0.5),col.axis??1,color); break;
+            case 'cylinder': _drawWireCylinderLocal(app,mat,col.radius,col.height*0.5,col.axis??1,color); break;
+        }
+    }
+}
+
+// Draw trigger AABB outlines using ghost object world transform.
+function drawTriggerDebug(app, triggerEntries) {
+    const tmpT = new Ammo.btTransform();
+    for (const entry of triggerEntries) {
+        const mat = _getPosRotMat(entry.entity);
+        if (entry.entity.render) {
+            for (const mi of entry.entity.render.meshInstances) {
+                const h = mi.aabb.halfExtents;
+                _drawWireBoxLocal(app, mat, h.x, h.y, h.z, _DBG_COLOR_TRIGGER);
+            }
+        }
+    }
+    Ammo.destroy(tmpT);
+}
+
+// ---
+
+function enableShadows(e) {
+    if (e.render) { e.render.castShadows = true; e.render.receiveShadows = true; }
+    if (e.model)  { e.model.castShadows  = true; e.model.receiveShadows  = true; }
+    for (const c of e.children) enableShadows(c);
+}
+
+function computeBodyBounds(dynamicBodies) {
+    if (!dynamicBodies.length) return { center: new pc.Vec3(0, 2, 0), radius: 10 };
+    let minX=Infinity,minY=Infinity,minZ=Infinity,maxX=-Infinity,maxY=-Infinity,maxZ=-Infinity;
+    for (const b of dynamicBodies) {
+        const p = b.initialPosition;
+        minX=Math.min(minX,p.x);maxX=Math.max(maxX,p.x);
+        minY=Math.min(minY,p.y);maxY=Math.max(maxY,p.y);
+        minZ=Math.min(minZ,p.z);maxZ=Math.max(maxZ,p.z);
+    }
+    const center = new pc.Vec3((minX+maxX)*0.5,(minY+maxY)*0.5,(minZ+maxZ)*0.5);
+    const d = Math.sqrt((maxX-minX)**2+(maxY-minY)**2+(maxZ-minZ)**2);
+    return { center, radius: Math.max(d+8, 10) };
+}
+
+let showWireframe = true;
+
+function init() {
+    const canvas = document.getElementById('c');
+    const app = new pc.Application(canvas, {
+        mouse: new pc.Mouse(canvas),
+        touch: new pc.TouchDevice(canvas)
+    });
+    if (typeof Ammo !== 'undefined' && app.systems.rigidbody) {
+        app.systems.rigidbody.gravity.set(0, -9.81, 0);
+        app.systems.rigidbody.onLibraryLoaded();
+    }
+    app.start();
+    app.setCanvasFillMode(pc.FILLMODE_FILL_WINDOW);
+    app.setCanvasResolution(pc.RESOLUTION_AUTO);
+    window.addEventListener('resize', () => app.resizeCanvas(canvas.width, canvas.height));
+    window.addEventListener('keydown', event => {
+        if ((event.code === 'KeyW' || event.key === 'w' || event.key === 'W') && !event.repeat) {
+            showWireframe = !showWireframe;
+            const hint = document.getElementById('hint');
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        }
+    });
+
+    app.scene.ambientLight = new pc.Color(0.4, 0.45, 0.5);
+
+    const light = new pc.Entity('light');
+    light.addComponent('light', { type: 'directional', color: new pc.Color(1, 0.95, 0.85),
+        intensity: 1.0, castShadows: true, shadowResolution: 2048, shadowBias: 0.3, normalOffsetBias: 0.02 });
+    light.setLocalEulerAngles(45, 45, 0);
+    app.root.addChild(light);
+
+    const fillLight = new pc.Entity('fillLight');
+    fillLight.addComponent('light', { type: 'directional', color: new pc.Color(0.45, 0.6, 1.0),
+        intensity: 0.5, castShadows: false });
+    fillLight.setLocalEulerAngles(-30, 180, 0);
+    app.root.addChild(fillLight);
+
+    const camera = new pc.Entity('camera');
+    camera.addComponent('camera', { clearColor: new pc.Color(0.96,0.97,0.99), nearClip: 0.05, farClip: 1000, fov: 45 });
+    camera.addComponent('script');
+    camera.setPosition(0, 2, 12);
+    app.root.addChild(camera);
+    const controls = camera.script.create(CameraControls, { properties: { enableFly: false } });
+
+    let dynamicBodies  = [];
+    let debugEntities  = [];
+    let triggerEntries = [];
+
+    Promise.all([
+        fetchGlbData(MODEL_URL),
+        new Promise((resolve, reject) => {
+            app.assets.loadFromUrlAndFilename(MODEL_URL, MODEL_URL.split('/').pop(), 'container',
+                (err, asset) => err ? reject(err) : resolve(asset));
+        })
+    ]).then(([glbData, asset]) => {
+        const { json: gltfJson, binary } = glbData;
+        const res  = asset.resource;
+        const root = res.instantiateRenderEntity ? res.instantiateRenderEntity() : res.instantiateModelEntity();
+        app.root.addChild(root);
+        enableShadows(root);
+
+        const entityMap = buildEntityMap(gltfJson, root);
+        const result    = initPhysics(gltfJson, binary, entityMap, app.systems.rigidbody.dynamicsWorld);
+        dynamicBodies  = result.dynamicBodies;
+        debugEntities  = result.debugEntities;
+        triggerEntries = result.triggerEntries;
+
+        const { center, radius } = computeBodyBounds(dynamicBodies);
+        const startPos = new pc.Vec3(center.x, center.y + 1.5, center.z + radius);
+        controls.reset(center, startPos);
+
+        app.on('update', () => {
+            checkTriggerOverlaps(triggerEntries, dynamicBodies);
+
+            if (showWireframe) {
+                drawPhysicsDebug(app, debugEntities);
+                drawTriggerDebug(app, triggerEntries);
+            }
+
+            for (const body of dynamicBodies) {
+                if (body.entity.getPosition().y >= RESET_Y_THRESHOLD) continue;
+                body.entity.setPosition(body.initialPosition);
+                body.entity.setRotation(body.initialRotation);
+                body.entity.rigidbody.linearVelocity  = pc.Vec3.ZERO;
+                body.entity.rigidbody.angularVelocity = pc.Vec3.ZERO;
+                body.entity.rigidbody.syncEntityToBody();
+            }
+        });
+    }).catch(console.error);
+}

--- a/examples/playcanvas/ammo/gltf_physics_Triggers/style.css
+++ b/examples/playcanvas/ammo/gltf_physics_Triggers/style.css
@@ -1,0 +1,26 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- **gltf_physics_Filtering**: Collision filtering via `KHR_physics_rigid_bodies.collisionFilters`. Maps `collisionSystems`/`collideWithSystems` to Bullet group/mask bitmasks and re-adds each body with `addRigidBody(body, group, mask)`.
- **gltf_physics_Triggers**: Ghost objects via `btGhostObject` (`CF_NO_CONTACT_RESPONSE`). Registers `btGhostPairCallback`, detects overlaps each frame via `getNumOverlappingObjects()`, and highlights triggered entities with emissive/opacity change.
- **gltf_physics_JointTypes**: Constraints via `btGeneric6DofSpringConstraint`. Maps `physicsJoints` limits (lower>upper=FREE, ==LOCKED, <LIMITED). Builds `bodyNodeSet` from both motion-owner and standalone-static nodes so collider-only anchor bodies are correctly resolved. Motor drives wrapped in try/catch for ammo.js compatibility.

## Known issues

- JointTypes: drive motors (velocity/position targets) may not animate as intended depending on the ammo.js build's motor API availability
- JointTypes: kinematic body angular velocities from the GLB are not applied (kinematic bodies remain stationary)
- Triggers: trigger highlight relies on `getNumOverlappingObjects()`; no per-body enter/exit events

## Test plan

- [ ] Open `gltf_physics_Filtering/index.html` — objects with different collision groups pass through some walls but not others
- [ ] Open `gltf_physics_Triggers/index.html` — trigger volumes highlight when dynamic objects enter them
- [ ] Open `gltf_physics_JointTypes/index.html` — pendulums, hinges, sliders, spring, and fixed joints all hold bodies in place (no falling)
- [ ] Press W in each example to toggle wireframe debug overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)