### PR TITLE
Fix sunken colliders in PlayCanvas + Havok examples

### DIFF
--- a/examples/playcanvas/havok/balls/index.js
+++ b/examples/playcanvas/havok/balls/index.js
@@ -60,7 +60,8 @@ function getTexture(file, w, h) {
 }
 
 function createStaticBox(hw, pos) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, hw)[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw[0] * 2, hw[1] * 2, hw[2] * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetMotionType(bodyId, HK.MotionType.STATIC);

--- a/examples/playcanvas/havok/box/index.js
+++ b/examples/playcanvas/havok/box/index.js
@@ -88,7 +88,8 @@ function initPhysics() {
     const grassTex = getTexture('grass.jpg', 512, 512);
 
     // Ground
-    const gsId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30, 0.4, 30])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const gsId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [30 * 2, 0.4 * 2, 30 * 2])[1];
     const gbId = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(gbId, gsId);
     HK.HP_Body_SetMotionType(gbId, HK.MotionType.STATIC);
@@ -107,7 +108,8 @@ function initPhysics() {
 
     // Shared box shape
     const hw = BOX_SIZE;
-    const boxShapeId  = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hw, hw])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const boxShapeId  = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hw * 2, hw * 2])[1];
     const boxMassProps = HK.HP_Shape_BuildMassProperties(boxShapeId)[1];
 
     for (let x = 0; x < 16; x++) {

--- a/examples/playcanvas/havok/coins/index.js
+++ b/examples/playcanvas/havok/coins/index.js
@@ -100,7 +100,8 @@ function initPhysics() {
     floorMat.gloss = 0.2;
     floorMat.update();
 
-    const floorShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [12, 1, 12])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const floorShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [12 * 2, 1 * 2, 12 * 2])[1];
     const floorBody  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(floorBody, floorShape);
     HK.HP_Body_SetMotionType(floorBody, HK.MotionType.STATIC);

--- a/examples/playcanvas/havok/cone/index.js
+++ b/examples/playcanvas/havok/cone/index.js
@@ -69,7 +69,8 @@ function getTexture(url, w, h, flipY) {
 }
 
 function createStaticBox(x, y, z, hw, hh, hd) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetMotionType(bodyId, HK.MotionType.STATIC);

--- a/examples/playcanvas/havok/domino/index.js
+++ b/examples/playcanvas/havok/domino/index.js
@@ -124,7 +124,8 @@ function initPhysics() {
 
     // Ground (static)
     const BOX_SIZE = 2;
-    const groundId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [100, 0.2, 100])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const groundId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [100 * 2, 0.2 * 2, 100 * 2])[1];
     const groundBodyId = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(groundBodyId, groundId);
     HK.HP_Body_SetMotionType(groundBodyId, HK.MotionType.STATIC);
@@ -141,7 +142,8 @@ function initPhysics() {
 
     // Domino shape (shared)
     const DOMINO_W = BOX_SIZE * 0.15, DOMINO_H = BOX_SIZE * 1.5, DOMINO_D = BOX_SIZE * 1.0;
-    const dominoShapeId  = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [DOMINO_W, DOMINO_H, DOMINO_D])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const dominoShapeId  = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [DOMINO_W * 2, DOMINO_H * 2, DOMINO_D * 2])[1];
     const dominoMassProps = HK.HP_Shape_BuildMassProperties(dominoShapeId)[1];
 
     // Ball shape (shared)

--- a/examples/playcanvas/havok/football/index.js
+++ b/examples/playcanvas/havok/football/index.js
@@ -105,7 +105,8 @@ function initPhysics() {
     const footballTex = getTexture('football.png', 1024, 512);
 
     // Ground
-    const gsId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [20, 0.4, 20])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const gsId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [20 * 2, 0.4 * 2, 20 * 2])[1];
     const gbId = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(gbId, gsId);
     HK.HP_Body_SetMotionType(gbId, HK.MotionType.STATIC);

--- a/examples/playcanvas/havok/gltf/index.js
+++ b/examples/playcanvas/havok/gltf/index.js
@@ -27,7 +27,8 @@ function drawDebug() {
 }
 
 function createBoxBody(x, y, z, hw, hh, hd, isDynamic) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetPosition(bodyId, [x, y, z]);

--- a/examples/playcanvas/havok/marbles/index.js
+++ b/examples/playcanvas/havok/marbles/index.js
@@ -52,7 +52,8 @@ function drawDebug() {
 }
 
 function createStaticBox(x, y, z, hw, hh, hd) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetMotionType(bodyId, HK.MotionType.STATIC);

--- a/examples/playcanvas/havok/minimum/index.js
+++ b/examples/playcanvas/havok/minimum/index.js
@@ -38,7 +38,8 @@ function getTexture(file, w, h) {
 }
 
 function createBoxBody(x, y, z, hw, hh, hd, isDynamic) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetPosition(bodyId, [x, y, z]);

--- a/examples/playcanvas/havok/shogi/index.js
+++ b/examples/playcanvas/havok/shogi/index.js
@@ -117,7 +117,8 @@ function getTexture(url, w, h, flipY) {
 }
 
 function createStaticBox(x, y, z, hw, hh, hd) {
-    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const shapeId = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const bodyId  = HK.HP_Body_Create()[1];
     HK.HP_Body_SetShape(bodyId, shapeId);
     HK.HP_Body_SetMotionType(bodyId, HK.MotionType.STATIC);
@@ -189,7 +190,8 @@ function initPhysics() {
     shogiMesh.update();
 
     const hw = PIECE_W / 2, hh = PIECE_H / 2, hd = PIECE_D * 0.7;
-    const pieceShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw, hh, hd])[1];
+    // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
+    const pieceShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const pieceMass  = HK.HP_Shape_BuildMassProperties(pieceShape)[1];
 
     for (let i = 0; i < PIECE_COUNT; i++) {


### PR DESCRIPTION
## Summary

All PlayCanvas + Havok examples (both Phase 1 and Phase 2) rendered objects partially **sunk into the floor**. See the reported screenshot of `minimum`: the green collider wireframe (the intended size) and the textured cube are buried up to the floor surface.

### Root cause

`HP_Shape_CreateBox(center, rotation, extents)` takes the **full side lengths**, but every PlayCanvas + Havok example passed **half-extents**. As a result each box collider was only half its intended size:

- The floor collider's top surface sat *below* the visible floor mesh, so everything came to rest sunk into the floor.
- Dynamic boxes (cube, dominoes, shogi pieces, the glTF duck's AABB box) were half-size too, so their visuals extended below the contact point.

This was confirmed against the three other Havok ports in this repo — `threejs/havok`, `webgpu/havok`, and `filament/havok` — which all pass **full side lengths** to `HP_Shape_CreateBox` (e.g. `BoxGeometry(4, 0.1, 4)` ↔ `HP_Shape_CreateBox(..., [4, 0.1, 4])`).

### Fix

Pass `2×` the half-extents to every `HP_Shape_CreateBox` call (13 call sites across 10 examples): floors, walls, stacked boxes, dominoes, shogi pieces, and the glTF duck box.

- **Sphere** colliders are unaffected — `HP_Shape_CreateSphere` already takes a radius, which matches the visuals.
- The **cone**'s convex hull is built from explicit vertex coordinates, so it was already the correct size.
- Debug wireframes and visual meshes were already correct (they use the half-extents / full scale respectively) and are left untouched.

### Files changed

`minimum`, `domino`, `football`, `box`, `balls` (Phase 1) and `gltf`, `marbles`, `coins`, `shogi`, `cone` (Phase 2).

## Test plan

- [ ] Open each `index.html` and confirm objects now rest **on** the floor surface (not sunk into it)
- [ ] Toggle wireframe with `W` and confirm the collider wireframe aligns with the visual mesh and the floor top
- [ ] Confirm there are no console errors

> Note: this environment's network allowlist blocks `cdn.babylonjs.com` (Havok WASM), so in-browser verification was not performed here. Syntax was checked with `node --check`, and the fix was validated by cross-referencing the threejs/webgpu/filament Havok examples and the reported screenshot. Please confirm on GitHub Pages.

https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp)_