### PR TITLE
Fix black balls in PlayCanvas + Havok balls example (directional light orientation)

### DIFF
--- a/examples/playcanvas/havok/balls/index.js
+++ b/examples/playcanvas/havok/balls/index.js
@@ -186,7 +186,10 @@ async function main() {
 
     const light = new pc.Entity('light');
     light.addComponent('light', { type: 'directional', color: new pc.Color(1, 1, 1), castShadows: true, shadowResolution: 2048 });
-    light.setPosition(30, 100, 50);
+    // A directional light's direction comes from its rotation, not its position;
+    // setPosition() leaves it pointing the default way, so most balls only got the dim
+    // ambient light and looked black. Orient it like the other examples instead.
+    light.setLocalEulerAngles(45, 45, 45);
     app.root.addChild(light);
 
     camera = new pc.Entity('camera');


### PR DESCRIPTION
## Summary

In the PlayCanvas + Havok **balls** example, many balls rendered pure black (see the reported screenshot) instead of showing their textures.

### Root cause

The directional light was oriented with `light.setPosition(30, 100, 50)`. A directional light's direction comes from its **rotation**, not its position, so `setPosition` had no effect on lighting — the light kept its default orientation and most balls received only the dim ambient light (~0.24), making them look black. The textures themselves were loading fine (the setup is identical to the working `playcanvas/ammo/balls`).

This was a Phase-1 anomaly: every other PlayCanvas + Havok example orients its light with `setLocalEulerAngles(...)`, and only `balls` used `setPosition`.

### Fix

Orient the light with `light.setLocalEulerAngles(45, 45, 45)`, matching the other examples and the `ammo.js` version.

## Test plan

- [ ] Open `balls` and confirm the balls are evenly lit and show their textures (basketball, beach ball, football, softball, tennis ball) instead of appearing black
- [ ] Confirm no console errors

> Note: this environment's network allowlist blocks `cdn.babylonjs.com` (Havok WASM), so in-browser verification was not performed here. The fix was confirmed by comparing against the working `playcanvas/ammo/balls` and the other Havok examples, all of which orient the light by rotation. Please confirm on GitHub Pages.

https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp)_