### PR TITLE
Fix distorted ball textures in PlayCanvas + Havok balls example

### DIFF
--- a/examples/playcanvas/havok/balls/index.js
+++ b/examples/playcanvas/havok/balls/index.js
@@ -46,17 +46,21 @@ function drawDebug() {
     }
 }
 
-function getTexture(file, w, h) {
-    const tex = new pc.Texture(app.graphicsDevice, { width: w, height: h });
-    const img = new Image();
-    img.onload = () => {
-        tex.minFilter = pc.FILTER_LINEAR; tex.magFilter = pc.FILTER_LINEAR;
-        tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE; tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
-        tex.setSource(img);
-    };
-    img.crossOrigin = 'anonymous';
-    img.src = BASE_URL + file;
-    return tex;
+function createBallMaterial(file) {
+    // Load via the asset system so the texture keeps its native (non-square,
+    // equirectangular) size/aspect; pre-allocating a square texture and calling
+    // setSource() rescaled these 2:1 ball maps to 1:1 and distorted the mapping.
+    const m = new pc.StandardMaterial();
+    m.update();
+    app.assets.loadFromUrl(BASE_URL + file, 'texture', (err, asset) => {
+        if (err) { console.error('Failed to load texture', file, err); return; }
+        const tex = asset.resource;
+        tex.addressU = pc.ADDRESS_CLAMP_TO_EDGE;
+        tex.addressV = pc.ADDRESS_CLAMP_TO_EDGE;
+        m.diffuseMap = tex;
+        m.update();
+    });
+    return m;
 }
 
 function createStaticBox(hw, pos) {
@@ -116,14 +120,8 @@ function initPhysics() {
         app.root.addChild(we);
     }
 
-    // Preload textures and create materials
-    const textures = dataSet.map(d => getTexture(d.file, 512, 512));
-    const materials = dataSet.map((d, i) => {
-        const m = new pc.StandardMaterial();
-        m.diffuseMap = textures[i];
-        m.update();
-        return m;
-    });
+    // Create one material per ball type, loading each texture via the asset system.
+    const materials = dataSet.map(d => createBallMaterial(d.file));
 
     for (let i = 0; i < 200; i++) {
         const x = -5 + Math.random() * 10;


### PR DESCRIPTION
## Summary

Follow-up to the lighting fix (#338). With the balls now lit, the ball textures are visibly **distorted** — the mapping doesn't wrap the spheres correctly.

### Root cause

The ball textures are **non-square, equirectangular-style sphere maps**:

| Texture | Pixel size |
|---|---|
| Basketball.jpg | 450×271 |
| BeachBall.jpg | 400×200 |
| Football.jpg | 200×100 (grayscale) |
| Softball.jpg | 400×200 |
| TennisBall.jpg | 400×200 |

But `getTexture()` pre-allocated a **square 512×512** `pc.Texture` and then called `setSource()`. The 2:1 images were rescaled to 1:1, so the equirectangular maps no longer lined up with the sphere's UVs and looked wrong.

### Fix

Load each texture via the asset system (`app.assets.loadFromUrl(url, 'texture', …)`) and assign it to the material in the callback (re-`update()`ing the material). The asset loader keeps each image's native size and aspect ratio, so the equirectangular textures wrap the spheres correctly. This is the same approach already used by the `cone`, `eraser`, `coins`, and `marbles` examples.

## Test plan

- [ ] Open `balls` and confirm each ball type (basketball, beach ball, football, softball, tennis ball) shows its texture wrapped correctly, without vertical stretching/distortion
- [ ] Confirm no console errors

> Note: this environment's network allowlist blocks `cdn.babylonjs.com` (Havok WASM), so in-browser verification was not performed here. The fix mirrors the asset-loading approach used by the other (correctly-textured) examples and the threejs/havok balls reference. Please confirm on GitHub Pages.

https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSXuG47uTLw69gVWKjoWPp)_