### PR TITLE
Increase ball sizes and pull back camera in PlayCanvas + Havok balls example

### DIFF
--- a/examples/playcanvas/havok/balls/index.js
+++ b/examples/playcanvas/havok/balls/index.js
@@ -2,11 +2,11 @@ import * as pc from 'playcanvas';
 import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const dataSet = [
-    { file: 'Basketball.jpg',  scale: 1.0, restitution: 0.6 },
-    { file: 'BeachBall.jpg',   scale: 0.9, restitution: 0.7 },
-    { file: 'Football.jpg',    scale: 1.0, restitution: 0.55 },
-    { file: 'Softball.jpg',    scale: 0.3, restitution: 0.4 },
-    { file: 'TennisBall.jpg',  scale: 0.3, restitution: 0.75 },
+    { file: 'Basketball.jpg',  scale: 2.0, restitution: 0.6 },
+    { file: 'BeachBall.jpg',   scale: 1.8, restitution: 0.7 },
+    { file: 'Football.jpg',    scale: 2.0, restitution: 0.55 },
+    { file: 'Softball.jpg',    scale: 0.6, restitution: 0.4 },
+    { file: 'TennisBall.jpg',  scale: 0.6, restitution: 0.75 },
 ];
 
 const FIXED_TIMESTEP = 1 / 60;
@@ -197,7 +197,7 @@ async function main() {
     app.root.addChild(camera);
     const cc = camera.script.create(CameraControls);
     cc.enableFly = false;
-    cc.reset(new pc.Vec3(0, 1.5, 0), new pc.Vec3(0, 8, 12));
+    cc.reset(new pc.Vec3(0, 1.5, 0), new pc.Vec3(0, 20, 36));
 
     initPhysics();
     setInterval(updatePhysics, 1000 / 60);


### PR DESCRIPTION
## Summary

- Double ball sizes (scale ×2 for all ball types; physics radius updates automatically)
- Pull camera back from `(0, 8, 12)` to `(0, 20, 36)` for a wider view of the scene

## Test plan

- [ ] Verify balls appear roughly twice as large as before
- [ ] Verify camera starts with a wider view showing the full pen
- [ ] Verify physics colliders still match visual size (wireframe toggle W key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)