### PR TITLE
Add mouse camera controls to all PlayCanvas + ammo.js examples

### DIFF
--- a/examples/playcanvas/ammo/balls/index.html
+++ b/examples/playcanvas/ammo/balls/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/balls/index.js
+++ b/examples/playcanvas/ammo/balls/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const dataSet = [
@@ -145,9 +146,11 @@ function init() {
         nearClip: 0.01,
         farClip: 1000
     });
-    camera.translate(18, 20, 30);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 10, 40));
 
     let boxDataSet = [
         { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
@@ -219,19 +222,15 @@ function init() {
         numBalls++;
     }
 
-    let angle = 0;
     let time = 0;
     let maxBalls = 200;
-    const EXCEPTED_FPS = 60;
     app.on("update", function (dt) {
-        let ADJUST_SPEED = dt / (1/EXCEPTED_FPS);
-        angle += 0.5 * ADJUST_SPEED;
         time += dt;
         if (time > 0.05 && numBalls < maxBalls) {
             spawnBall();
             time = 0;
         }
-        
+
         for (let i = 0; i < numBalls; i++ ) {
             let ball = balls[i];
             if (ball.localPosition.y < -10) {
@@ -244,9 +243,6 @@ function init() {
                 ball.rigidbody.syncEntityToBody();
             }
         }
-        
-        camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
-        camera.lookAt(0, 0, 0);
 
         if (showWireframe) {
             drawPhysicsDebug(app, staticDebugEntities);

--- a/examples/playcanvas/ammo/box/index.html
+++ b/examples/playcanvas/ammo/box/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/box/index.js
+++ b/examples/playcanvas/ammo/box/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 let DOT_SIZE = 0.3;
@@ -153,24 +154,17 @@ function init() {
 
     // Create camera entity
     function Camera() {
-      let cam = new pc.Entity();
+      let cam = new pc.Entity('camera');
       app.systems.camera.addComponent(cam, {
         clearColor: new pc.Color(0.1, 0.1, 0.1),
         farClip: 20
       });
+      cam.addComponent('script');
       app.root.addChild(cam);
+      const cc = cam.script.create(CameraControls);
+      cc.enableFly = false;
+      cc.reset(new pc.Vec3(0, 2, 0), new pc.Vec3(0, 5, 9));
       this.entity = cam;
-      this.timer = 0;
-    }
-
-    Camera.prototype.update = function (dt) {
-      this.timer += dt;
-      // Spin the camera around a center point
-      let x = Math.sin(this.timer * 0.25) * 9;
-      let z = Math.cos(this.timer * 0.25) * 6;
-      let e = this.entity;
-      e.setPosition(x, 5, z);
-      e.lookAt(0, 2, 0);
     }
 
     // Create spot light entity
@@ -300,9 +294,7 @@ function init() {
 
     const debugEntities = [ground.entity, ...wall.bricks, ball.entity];
 
-    // Register an update event to rotate the camera
     app.on("update", function (dt) {
-      camera.update(dt);
       if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 }

--- a/examples/playcanvas/ammo/coins/index.html
+++ b/examples/playcanvas/ammo/coins/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
       "imports": {
-          "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+          "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
       }
   }
   </script>

--- a/examples/playcanvas/ammo/coins/index.js
+++ b/examples/playcanvas/ammo/coins/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 // PlayCanvas + ammo.js — Falling Coins.
@@ -141,7 +142,11 @@ function init() {
         farClip: 1000,
         fov: 60
     });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 6, 0), new pc.Vec3(0, 18, 32));
 
     // Coin materials: PBR metalness + shared normal map (assigned once the texture arrives).
     const coinMaterials = COIN_TYPES.map(function (t) {
@@ -245,15 +250,7 @@ function init() {
         coins.push({ entity: body, rest: 0 });
     }
 
-    let angle = 0;
-    const EXPECTED_FPS = 60;
     app.on("update", function (dt) {
-        const adjustSpeed = dt / (1 / EXPECTED_FPS);
-        angle += 0.4 * adjustSpeed;
-
-        camera.setLocalPosition(Math.sin(Math.PI * angle / 180) * 32, 18, Math.cos(Math.PI * angle / 180) * 32);
-        camera.lookAt(0, 6, 0);
-
         if (showWireframe) {
             drawPhysicsDebug(app, [floor]);
             drawPhysicsDebug(app, coins.map(c => c.entity));

--- a/examples/playcanvas/ammo/cone/index.html
+++ b/examples/playcanvas/ammo/cone/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/cone/index.js
+++ b/examples/playcanvas/ammo/cone/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
@@ -134,9 +135,11 @@ function init() {
         nearClip: 0.01,
         farClip: 1000
     });
-    camera.translate(18, 20, 30);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 10, 40));
 
     let boxDataSet = [
         { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
@@ -202,19 +205,15 @@ function init() {
         numCarrots++;
     }
 
-    let angle = 0;
     let time = 0;
     let maxCarrots = 200;
-    const EXCEPTED_FPS = 60;
     app.on("update", function (dt) {
-        let ADJUST_SPEED = dt / (1/EXCEPTED_FPS);
-        angle += 0.5 * ADJUST_SPEED;
         time += dt;
         if (time > 0.01 && numCarrots < maxCarrots) {
             spawnCarrot();
             time = 0;
         }
-        
+
         for (let i = 0; i < numCarrots; i++ ) {
             let carrot = carrots[i];
             if (carrot.localPosition.y < -10) {
@@ -227,9 +226,6 @@ function init() {
                 carrot.rigidbody.syncEntityToBody();
             }
         }
-        
-        camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
-        camera.lookAt(0, 0, 0);
 
         if (showWireframe) {
             drawPhysicsDebug(app, staticDebugEntities);

--- a/examples/playcanvas/ammo/domino/index.html
+++ b/examples/playcanvas/ammo/domino/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/domino/index.js
+++ b/examples/playcanvas/ammo/domino/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
@@ -149,9 +150,11 @@ function init() {
         clearColor: new pc.Color(0.5, 0.5, 0.8),
         farClip: 50
     });
-    camera.translate(0, 10, 15);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 10, 15));
 
     let domino = new pc.Entity("domino");
     domino.setLocalPosition(0, 5, 0);

--- a/examples/playcanvas/ammo/eraser/index.html
+++ b/examples/playcanvas/ammo/eraser/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/eraser/index.js
+++ b/examples/playcanvas/ammo/eraser/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const w = 1.0;
@@ -212,9 +213,11 @@ function init() {
         nearClip: 0.01,
         farClip: 1000
     });
-    camera.translate(18, 20, 30);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 10, 40));
 
     let boxDataSet = [
         { size:[10, 10,  1], pos:[ 0, 5,-5], rot:[0,0,0] },
@@ -293,19 +296,15 @@ function init() {
         numErasers++;
     }
 
-    let angle = 0;
     let time = 0;
     let maxErasers = 200;
-    const EXCEPTED_FPS = 60;
     app.on("update", function (dt) {
-        let ADJUST_SPEED = dt / (1/EXCEPTED_FPS);
-        angle += 0.5 * ADJUST_SPEED;
         time += dt;
         if (time > 0.05 && numErasers < maxErasers) {
             spawnEraser();
             time = 0;
         }
-        
+
         for (let i = 0; i < numErasers; i++ ) {
             let eraser = erasers[i];
             if (eraser.localPosition.y < -10) {
@@ -318,9 +317,6 @@ function init() {
                 eraser.rigidbody.syncEntityToBody();
             }
         }
-        
-        camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 40, 10, Math.cos(Math.PI*angle/180) * 40);
-        camera.lookAt(0, 0, 0);
 
         if (showWireframe) {
             drawPhysicsDebug(app, staticDebugEntities);

--- a/examples/playcanvas/ammo/football/index.html
+++ b/examples/playcanvas/ammo/football/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/football/index.js
+++ b/examples/playcanvas/ammo/football/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 let DOT_SIZE = 0.3;
@@ -156,24 +157,17 @@ function init() {
 
     // Create camera entity
     function Camera() {
-      let cam = new pc.Entity();
+      let cam = new pc.Entity('camera');
       app.systems.camera.addComponent(cam, {
         clearColor: new pc.Color(0.1, 0.1, 0.1),
         farClip: 1000
       });
+      cam.addComponent('script');
       app.root.addChild(cam);
+      const cc = cam.script.create(CameraControls);
+      cc.enableFly = false;
+      cc.reset(new pc.Vec3(0, 2, 0), new pc.Vec3(0, 5, 6));
       this.entity = cam;
-      this.timer = 0;
-    }
-
-    Camera.prototype.update = function (dt) {
-      this.timer += dt;
-      // Spin the camera around a center point
-      let x = Math.sin(this.timer * 0.25) * 6;
-      let z = Math.cos(this.timer * 0.25) * 4;
-      let e = this.entity;
-      e.setPosition(x, 5, z);
-      e.lookAt(0, 2, 0);
     }
 
     // Create spot light entity
@@ -286,9 +280,7 @@ function init() {
 
     const debugEntities = [ground.entity, ...wall.balls.map(b => b.entity)];
 
-    // Register an update event to rotate the camera
     app.on("update", function (dt) {
-      camera.update(dt);
       if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 

--- a/examples/playcanvas/ammo/gltf/index.html
+++ b/examples/playcanvas/ammo/gltf/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/gltf/index.js
+++ b/examples/playcanvas/ammo/gltf/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const _DBG_COLOR_DYNAMIC = new pc.Color(0, 1, 0, 1);
@@ -105,9 +106,11 @@ function init() {
         clearColor: new pc.Color(0.5, 0.5, 0.8),
         farClip: 50
     });
-    camera.translate(0, 5, 10);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 3, 4));
 
     let duckBody = new pc.Entity("duckBody");
     let url =  'https://rawcdn.githack.com/cx20/gltf-test/5465cc37/sampleModels/Duck/glTF/Duck.gltf';
@@ -149,15 +152,7 @@ function init() {
 
     const debugEntities = [duckBody, floor];
 
-    let angle = 0;
-    let time = 0;
-    let maxErasers = 200;
-    const EXCEPTED_FPS = 60;
     app.on("update", function (dt) {
-        let ADJUST_SPEED = dt / (1/EXCEPTED_FPS);
-        angle += 0.5 * ADJUST_SPEED;
-        camera.setLocalPosition(Math.sin(Math.PI*angle/180) * 4, 3, Math.cos(Math.PI*angle/180) * 4);
-        camera.lookAt(0, 0, 0);
         if (showWireframe) drawPhysicsDebug(app, debugEntities);
     });
 }

--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Basic_Shapes/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from 'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js';
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/ShapeTypes/ShapeTypes.glb';
@@ -701,7 +702,10 @@ function init() {
 
     const camera = new pc.Entity('camera');
     camera.addComponent('camera', { clearColor: new pc.Color(0.96,0.97,0.99), nearClip: 0.05, farClip: 1000, fov: 45 });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
 
     let dynamicBodies      = [];
     let debugEntities      = [];
@@ -730,18 +734,9 @@ function init() {
         convexHullEntities = result.convexHullEntities;
 
         const { center, radius } = computeWorldBounds(root);
-        let angle = 0;
-        const expectedFps = 60;
+        cc.reset(center, new pc.Vec3(center.x, center.y + radius * 0.4, center.z + radius));
 
         app.on('update', dt => {
-            angle += 0.25 * dt / (1 / expectedFps);
-            camera.setLocalPosition(
-                center.x + Math.sin(Math.PI * angle / 180) * radius,
-                center.y + radius * 0.4,
-                center.z + Math.cos(Math.PI * angle / 180) * radius
-            );
-            camera.lookAt(center);
-
             if (showWireframe) {
                 drawPhysicsDebug(app, debugEntities);
                 drawMeshDebug(app, meshStaticEntities,  _DBG_COLOR_STATIC);   // btBvhTriangleMeshShape (yellow)

--- a/examples/playcanvas/ammo/gltf_physics_Filtering/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Filtering/index.html
@@ -6,8 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
-      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Filtering/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Filtering/index.js
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { CameraControls } from 'camera-controls';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Filtering/Filtering.glb';

--- a/examples/playcanvas/ammo/gltf_physics_JointTypes/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_JointTypes/index.html
@@ -6,8 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
-      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_JointTypes/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_JointTypes/index.js
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { CameraControls } from 'camera-controls';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/JointTypes/JointTypes.glb';

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Friction/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from 'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js';
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Friction/Materials_Friction.glb';
@@ -183,7 +184,10 @@ function init() {
         farClip: 1000,
         fov: 45
     });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
 
     const dynamicBodies = [];
 
@@ -299,21 +303,9 @@ function init() {
         const bounds = computeWorldBounds(root);
         const center = bounds.center;
         const radius = bounds.radius;
-
-        let angle = 0;
-        const expectedFps = 60;
+        cc.reset(center, new pc.Vec3(center.x, center.y + radius * 0.4, center.z + radius));
 
         app.on('update', function(dt) {
-            const adjustSpeed = dt / (1 / expectedFps);
-            angle += 0.25 * adjustSpeed;
-
-            const x = center.x + Math.sin(Math.PI * angle / 180) * radius;
-            const z = center.z + Math.cos(Math.PI * angle / 180) * radius;
-            const y = center.y + radius * 0.4;
-
-            camera.setLocalPosition(x, y, z);
-            camera.lookAt(center);
-
             if (showWireframe) drawPhysicsDebug(app, debugEntities);
 
             for (const body of dynamicBodies) {

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Materials_Restitution/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from 'https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js';
 
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Materials_Restitution/Materials_Restitution.glb';
@@ -366,7 +367,10 @@ function init() {
 
     const camera = new pc.Entity('camera');
     camera.addComponent('camera', { clearColor: new pc.Color(0.96,0.97,0.99), nearClip: 0.05, farClip: 1000, fov: 45 });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
 
     let dynamicBodies = [];
 
@@ -393,18 +397,9 @@ function init() {
         visitForDebug(root);
 
         const { center, radius } = computeWorldBounds(root);
-        let angle = 0;
-        const expectedFps = 60;
+        cc.reset(center, new pc.Vec3(center.x, center.y + radius * 0.4, center.z + radius));
 
         app.on('update', dt => {
-            angle += 0.25 * dt / (1 / expectedFps);
-            camera.setLocalPosition(
-                center.x + Math.sin(Math.PI * angle / 180) * radius,
-                center.y + radius * 0.4,
-                center.z + Math.cos(Math.PI * angle / 180) * radius
-            );
-            camera.lookAt(center);
-
             if (showWireframe) drawPhysicsDebug(app, debugEntities);
 
             for (const body of dynamicBodies) {

--- a/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.html
@@ -6,8 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
-      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Motion_Properties/index.js
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { CameraControls } from 'camera-controls';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/MotionProperties/MotionProperties.glb';

--- a/examples/playcanvas/ammo/gltf_physics_Triggers/index.html
+++ b/examples/playcanvas/ammo/gltf_physics_Triggers/index.html
@@ -6,8 +6,8 @@
   <script type="importmap">
   {
     "imports": {
-      "playcanvas": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/playcanvas.mjs",
-      "camera-controls": "https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2/camera-controls.mjs"
+      "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+      "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
     }
   }
   </script>

--- a/examples/playcanvas/ammo/gltf_physics_Triggers/index.js
+++ b/examples/playcanvas/ammo/gltf_physics_Triggers/index.js
@@ -1,5 +1,5 @@
 import * as pc from 'playcanvas';
-import { CameraControls } from 'camera-controls';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const PC_ROOT = 'https://cx20.github.io/gltf-test/libs/playcanvas/v2.14.2';
 const MODEL_URL = 'https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Triggers/Triggers.glb';

--- a/examples/playcanvas/ammo/marbles/index.html
+++ b/examples/playcanvas/ammo/marbles/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
       "imports": {
-          "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+          "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
       }
   }
   </script>

--- a/examples/playcanvas/ammo/marbles/index.js
+++ b/examples/playcanvas/ammo/marbles/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const BASE_URL = "https://cx20.github.io/gltf-test";
@@ -117,7 +118,11 @@ function init() {
         farClip: 1000,
         fov: 60
     });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 2, 0), new pc.Vec3(0, 9, 18));
 
     function createMaterial(color, opacity = 1.0) {
         const material = new pc.StandardMaterial();
@@ -269,17 +274,7 @@ function init() {
         }
     });
 
-    let angle = 0;
-    const EXPECTED_FPS = 60;
     app.on("update", function(dt) {
-        const adjustSpeed = dt / (1 / EXPECTED_FPS);
-        angle += 0.5 * adjustSpeed;
-
-        const x = Math.sin(Math.PI * angle / 180) * 18;
-        const z = Math.cos(Math.PI * angle / 180) * 18;
-        camera.setLocalPosition(x, 9, z);
-        camera.lookAt(0, 2, 0);
-
         if (showWireframe) {
             drawPhysicsDebug(app, staticDebugEntities);
             drawPhysicsDebug(app, marbles);

--- a/examples/playcanvas/ammo/minimum/index.html
+++ b/examples/playcanvas/ammo/minimum/index.html
@@ -6,7 +6,8 @@
     <script type="importmap">
     {
         "imports": {
-            "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+            "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+            "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
         }
     }
     </script>

--- a/examples/playcanvas/ammo/minimum/index.js
+++ b/examples/playcanvas/ammo/minimum/index.js
@@ -1,4 +1,5 @@
 ﻿import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
@@ -96,9 +97,11 @@ function init() {
         clearColor: new pc.Color(0.5, 0.5, 0.8),
         farClip: 50
     });
-    camera.translate(0, 5, 10);
-    camera.lookAt(0, 0, 0);
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 5, 10));
 
     let box = new pc.Entity("box");
     box.setLocalPosition(0, 10, 0);

--- a/examples/playcanvas/ammo/shogi/index.html
+++ b/examples/playcanvas/ammo/shogi/index.html
@@ -6,7 +6,8 @@
   <script type="importmap">
   {
       "imports": {
-          "playcanvas": "https://code.playcanvas.com/playcanvas-stable.mjs"
+          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas/build/playcanvas.mjs",
+          "playcanvas/scripts/esm/camera-controls.mjs": "https://cdn.jsdelivr.net/npm/playcanvas/scripts/esm/camera-controls.mjs"
       }
   }
   </script>

--- a/examples/playcanvas/ammo/shogi/index.js
+++ b/examples/playcanvas/ammo/shogi/index.js
@@ -1,4 +1,5 @@
 import * as pc from 'playcanvas';
+import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 import { loadWasmModuleAsync } from "https://rawcdn.githack.com/playcanvas/engine/f8e929634cf7b057f7c80ac206a4f3d2d11843dc/examples/src/wasm-loader.js";
 
 const PIECE_W     = 1.6;
@@ -217,7 +218,11 @@ function init() {
         farClip: 1000,
         fov: 60
     });
+    camera.addComponent('script');
     app.root.addChild(camera);
+    const cc = camera.script.create(CameraControls);
+    cc.enableFly = false;
+    cc.reset(new pc.Vec3(0, 4, 0), new pc.Vec3(0, 14, 28));
 
     const wallMat  = createTransparentMaterial(new pc.Color(1, 1, 1));
     const floorMat = createTextureMaterial("../../../../assets/textures/grass.jpg", 512, 512);
@@ -306,19 +311,7 @@ function init() {
         pieces.push(createPiece(x, y, z));
     }
 
-    let angle = 0;
-    const EXPECTED_FPS = 60;
     app.on("update", function (dt) {
-        const adj = dt / (1 / EXPECTED_FPS);
-        angle += 0.4 * adj;
-
-        camera.setLocalPosition(
-            Math.sin(Math.PI * angle / 180) * 28,
-            14,
-            Math.cos(Math.PI * angle / 180) * 28
-        );
-        camera.lookAt(0, 4, 0);
-
         for (const piece of pieces) {
             if (piece.getPosition().y < -10) {
                 const x = (Math.random() - 0.5) * 8;


### PR DESCRIPTION
## Summary

- **Group A — standard 11 examples** (minimum, domino, football, box, balls, cone, coins, shogi, eraser, marbles, gltf): replace static / auto-orbit cameras with interactive `CameraControls` (mouse drag to orbit, scroll to zoom); update PlayCanvas CDN URL to npm version to match importmap of CameraControls
- **Group A — gltf_physics 3 examples** (Basic_Shapes, Materials_Friction, Materials_Restitution): replace bounds-based orbit animation with `CameraControls`; initial position set from world bounds after model load
- **Group B — gltf_physics 4 examples** (Motion_Properties, Filtering, JointTypes, Triggers): already used CameraControls but from an external URL — migrated to playcanvas npm pattern for consistency with Havok examples

All examples now share the same camera interaction pattern as PlayCanvas + Havok examples (PR #340–#341).

## Test plan

- [ ] Verify mouse drag orbits camera in standard examples (minimum, balls, shogi, etc.)
- [ ] Verify scroll wheel zooms in/out
- [ ] Verify auto-orbit animation no longer runs
- [ ] Verify gltf_physics examples load and show correct initial camera framing
- [ ] Press W to confirm physics wireframe still toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)