### PR TITLE
Add mouse camera controls to all Filament + Havok examples

### DIFF
--- a/examples/filament/havok/balls/index.js
+++ b/examples/filament/havok/balls/index.js
@@ -513,9 +513,10 @@ async function main() {
   }
   console.log('[Filament+Havok] balls ready:', balls.length, 'static wires:', staticWireframeEntities.length);
 
-  const center = [0, 0, 0];
-  const orbitDist = 18;
-  const orbitHeight = 10;
+  const camTarget = [0, 0, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.51;   // elevation (rad)
+  let camRadius = 20.6;
 
   let aspect = 1;
   function resize() {
@@ -530,12 +531,26 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
   // Camera orbit driven directly by wall time (matches the raw WebGL2 sample) — pure function of
   // `now`, no accumulator drift when requestAnimationFrame's frame interval jitters.
-  const ORBIT_SPEED = 0.24; // rad/s
-  const ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
 
@@ -543,10 +558,10 @@ async function main() {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
 
     renderer.render(swapChain, view);
   }

--- a/examples/filament/havok/box/index.js
+++ b/examples/filament/havok/box/index.js
@@ -381,9 +381,10 @@ async function main() {
     }
   }
 
-  const center = [0, 4, 0];
-  const orbitDist = 28;
-  const orbitHeight = 12;
+  const camTarget = [0, 4, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.28;   // elevation (rad)
+  let camRadius = 29.1;
 
   let aspect = 1;
   function resize() {
@@ -398,19 +399,33 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/coins/index.js
+++ b/examples/filament/havok/coins/index.js
@@ -540,9 +540,10 @@ async function main() {
   if (groundWire) staticWireframeEntities.push(groundWire);
   console.log('[Filament+Havok] coins ready:', coins.length);
 
-  const center = [0, 6, 0];
-  const orbitDist = 32;
-  const orbitHeight = 18;
+  const camTarget = [0, 6, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.36;   // elevation (rad)
+  let camRadius = 34.2;
 
   let aspect = 1;
   function resize() {
@@ -557,11 +558,24 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time — pure function of `now`, no accumulator drift.
-  const ORBIT_SPEED = 0.24; // rad/s
-  const ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
 
@@ -569,10 +583,10 @@ async function main() {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
 
     renderer.render(swapChain, view);
   }

--- a/examples/filament/havok/cone/index.js
+++ b/examples/filament/havok/cone/index.js
@@ -404,9 +404,10 @@ async function main() {
     addCone(scene, coneVB, coneIB, coneInst, coneShape, randomDrop(3.5), coneWireVB, coneWireIB, wireMatInstance);
   }
 
-  const center = [0, 2, 0];
-  const orbitDist = 26;
-  const orbitHeight = 16;
+  const camTarget = [0, 2, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.49;   // elevation (rad)
+  let camRadius = 29.5;
 
   let aspect = 1;
   function resize() {
@@ -421,20 +422,33 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
-  const ORBIT_SPEED = 0.24; // rad/s
-  const ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/domino/index.js
+++ b/examples/filament/havok/domino/index.js
@@ -441,9 +441,10 @@ async function main() {
       sphereWireVB, sphereWireIB, wireMatInstance);
   }
 
-  const center = [0, 2, 0];
-  const orbitDist = 30;
-  const orbitHeight = 12;
+  const camTarget = [0, 2, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.32;   // elevation (rad)
+  let camRadius = 31.6;
 
   let aspect = 1;
   function resize() {
@@ -458,19 +459,33 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/football/index.js
+++ b/examples/filament/havok/football/index.js
@@ -426,9 +426,10 @@ async function main() {
     }
   }
 
-  const center = [0, 4, 0];
-  const orbitDist = 28;
-  const orbitHeight = 10;
+  const camTarget = [0, 4, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.21;   // elevation (rad)
+  let camRadius = 28.6;
 
   let aspect = 1;
   function resize() {
@@ -443,19 +444,33 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.24, ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
     if (HK && worldId) {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/gltf/index.js
+++ b/examples/filament/havok/gltf/index.js
@@ -301,9 +301,10 @@ async function main() {
   wireAsset = await loadWireframeAsset();
 
   // Camera: auto-orbit framing the duck's fall onto the ground.
-  const center = [0, 4, 0];
-  const orbitDist = 26;
-  const orbitHeight = 12;
+  const camTarget = [0, 4, 0];
+  let camTheta  = 0.4;   // azimuth (rad)
+  let camPhi    = 0.30;   // elevation (rad)
+  let camRadius = 27.2;
 
   let aspect = 1;
   function resize() {
@@ -318,13 +319,28 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
   const root = asset.getRoot();
   const tcm = engine.getTransformManager();
   const offsetLocal = vec3.fromValues(0, -cubeSizeY, 0);
 
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.4;
   function render(now) {
     requestAnimationFrame(render);
 
@@ -355,10 +371,10 @@ async function main() {
       }
     }
 
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
 
     renderer.render(swapChain, view);
   }

--- a/examples/filament/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/filament/havok/gltf_physics_Basic_Shapes/index.js
@@ -958,8 +958,10 @@ async function main() {
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 1.5;
-  const orbitHeight = center[1] + radius * 0.35;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.35, radius * 1.5);   // ~0.23
+  let camRadius = Math.sqrt((radius * 1.5) ** 2 + (radius * 0.35) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -975,17 +977,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/gltf_physics_Filtering/index.js
+++ b/examples/filament/havok/gltf_physics_Filtering/index.js
@@ -957,8 +957,10 @@ async function main() {
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 1.5;
-  const orbitHeight = center[1] + radius * 0.35;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.35, radius * 1.5);   // ~0.23
+  let camRadius = Math.sqrt((radius * 1.5) ** 2 + (radius * 0.35) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -974,17 +976,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/filament/havok/gltf_physics_Materials_Friction/index.js
@@ -564,8 +564,10 @@ async function main() {
     1,
   );
   const radius = span * 0.5;
-  const orbitDist = radius * 1.6;
-  const orbitHeight = center[1] + radius * 0.4;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.4, radius * 1.6);   // ~0.24
+  let camRadius = Math.sqrt((radius * 1.6) ** 2 + (radius * 0.4) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -581,21 +583,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [
-      center[0] + Math.sin(angle) * orbitDist,
-      orbitHeight,
-      center[2] + Math.cos(angle) * orbitDist,
-    ];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/filament/havok/gltf_physics_Materials_Restitution/index.js
@@ -607,8 +607,10 @@ async function main() {
     1,
   );
   const radius = span * 0.5;
-  const orbitDist = radius * 1.6;
-  const orbitHeight = center[1] + radius * 0.4;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.4, radius * 1.6);   // ~0.24
+  let camRadius = Math.sqrt((radius * 1.6) ** 2 + (radius * 0.4) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -624,20 +626,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [
-      center[0] + Math.sin(angle) * orbitDist,
-      orbitHeight,
-      center[2] + Math.cos(angle) * orbitDist,
-    ];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/filament/havok/gltf_physics_Motion_Properties/index.js
@@ -818,8 +818,10 @@ async function main() {
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 1.5;
-  const orbitHeight = center[1] + radius * 0.35;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.35, radius * 1.5);   // ~0.23
+  let camRadius = Math.sqrt((radius * 1.5) ** 2 + (radius * 0.35) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -835,19 +837,33 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time — pure function of `now`, no drift.
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
 
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
 
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
 
     renderer.render(swapChain, view);
   }

--- a/examples/filament/havok/gltf_physics_Triggers/index.js
+++ b/examples/filament/havok/gltf_physics_Triggers/index.js
@@ -907,8 +907,10 @@ async function main() {
   const center = [(sceneMin[0] + sceneMax[0]) / 2, (sceneMin[1] + sceneMax[1]) / 2, (sceneMin[2] + sceneMax[2]) / 2];
   const span = Math.max(sceneMax[0] - sceneMin[0], sceneMax[1] - sceneMin[1], sceneMax[2] - sceneMin[2], 1);
   const radius = span * 0.5;
-  const orbitDist = radius * 1.5;
-  const orbitHeight = center[1] + radius * 0.35;
+  const camTarget = [...center];
+  let camTheta  = 0.6;   // azimuth (rad)
+  let camPhi    = Math.atan2(radius * 0.35, radius * 1.5);   // ~0.23
+  let camRadius = Math.sqrt((radius * 1.5) ** 2 + (radius * 0.35) ** 2);
   const far = Math.max(2000, radius * 60);
 
   let aspect = 1;
@@ -924,17 +926,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time.
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.6;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/marbles/index.js
+++ b/examples/filament/havok/marbles/index.js
@@ -464,9 +464,10 @@ async function main() {
 
   await loadWireframeAsset();
 
-  const center = [0, 3, 0];
-  const orbitDist = 26;
-  const orbitHeight = 16;
+  const camTarget = [0, 3, 0];
+  let camTheta  = 0.4;   // azimuth (rad)
+  let camPhi    = 0.46;   // elevation (rad)
+  let camRadius = 29.1;
 
   let aspect = 1;
   function resize() {
@@ -481,16 +482,31 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  const ORBIT_SPEED = 0.21, ORBIT_PHASE = 0.4;
   function render(now) {
     requestAnimationFrame(render);
     try { physicsStep(); } catch (e) { console.error('[physics] step error:', e); HK = null; }
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
     renderer.render(swapChain, view);
   }
   requestAnimationFrame(render);

--- a/examples/filament/havok/shogi/index.js
+++ b/examples/filament/havok/shogi/index.js
@@ -544,9 +544,10 @@ async function main() {
   }
   console.log('[Filament+Havok] pieces ready:', pieces.length, 'static wires:', staticWireframeEntities.length);
 
-  const center = [0, 2, 0];
-  const orbitDist = 30;
-  const orbitHeight = 18;
+  const camTarget = [0, 2, 0];
+  let camTheta  = 0.5;   // azimuth (rad)
+  let camPhi    = 0.49;   // elevation (rad)
+  let camRadius = 34.0;
 
   let aspect = 1;
   function resize() {
@@ -561,11 +562,24 @@ async function main() {
   window.addEventListener('resize', resize);
   resize();
 
+  // Mouse-drag orbit + scroll zoom.
+  let isDragging = false, lastX = 0, lastY = 0;
+  canvas.addEventListener('mousedown', e => { isDragging = true; lastX = e.clientX; lastY = e.clientY; });
+  window.addEventListener('mouseup',   () => { isDragging = false; });
+  window.addEventListener('mousemove', e => {
+    if (!isDragging) return;
+    camTheta -= (e.clientX - lastX) * 0.01;
+    camPhi   += (e.clientY - lastY) * 0.01;
+    camPhi = Math.max(-Math.PI / 2 + 0.05, Math.min(Math.PI / 2 - 0.05, camPhi));
+    lastX = e.clientX; lastY = e.clientY;
+  });
+  canvas.addEventListener('wheel', e => {
+    e.preventDefault();
+    camRadius *= 1 + e.deltaY * 0.001;
+    camRadius = Math.max(1.0, Math.min(500.0, camRadius));
+  }, { passive: false });
   setWireframeVisible(showWireframe);
 
-  // Camera orbit driven directly by wall time — pure function of `now`, no accumulator drift.
-  const ORBIT_SPEED = 0.24; // rad/s
-  const ORBIT_PHASE = 0.5;
   function render(now) {
     requestAnimationFrame(render);
 
@@ -573,10 +587,10 @@ async function main() {
       try { stepAndSync(); } catch (e) { console.error('[physics] error:', e); HK = null; }
     }
 
-    const angle = ORBIT_PHASE + now * 0.001 * ORBIT_SPEED;
-    const eye = [center[0] + Math.sin(angle) * orbitDist, orbitHeight, center[2] + Math.cos(angle) * orbitDist];
-    const up = [0, 1, 0];
-    camera.lookAt(eye, center, up);
+    const ex = camTarget[0] + camRadius * Math.cos(camPhi) * Math.sin(camTheta);
+    const ey = camTarget[1] + camRadius * Math.sin(camPhi);
+    const ez = camTarget[2] + camRadius * Math.cos(camPhi) * Math.cos(camTheta);
+    camera.lookAt([ex, ey, ez], camTarget, [0, 1, 0]);
 
     renderer.render(swapChain, view);
   }


### PR DESCRIPTION
## Summary

Replace time-based auto-orbit cameras with interactive mouse controls across all 15 Filament + Havok examples:

- **Left mouse drag**: orbit (azimuth θ, elevation φ)
- **Scroll wheel**: zoom in/out (radius)

### Non-gltf 9 examples
`balls`, `box`, `coins`, `cone`, `domino`, `football`, `gltf`, `marbles`, `shogi`

Hardcoded `center` / `orbitDist` / `orbitHeight` → `camTarget` / `camTheta` / `camPhi` / `camRadius` (pre-computed to match original camera position).

### gltf_physics 6 examples
`Basic_Shapes`, `Filtering`, `Materials_Friction`, `Materials_Restitution`, `Motion_Properties`, `Triggers`

Bounds-derived `orbitDist` / `orbitHeight` → cam* values computed from `radius` at runtime, so initial framing still adapts to each scene's bounds.

All 15 examples: `ORBIT_SPEED` / `ORBIT_PHASE` constants removed.

## Test plan

- [ ] Left mouse drag rotates camera in each example
- [ ] Scroll wheel zooms in/out
- [ ] Initial camera position matches the original orbit view
- [ ] Physics simulation and W-key wireframe toggle still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)