### PR TITLE
Add W-key collider wireframe toggle to Babylon.js + Havok coins

### DIFF
--- a/examples/babylonjs/havok/coins/index.html
+++ b/examples/babylonjs/havok/coins/index.html
@@ -10,6 +10,7 @@
 <body>
 
 <canvas id="c" width="465" height="465"></canvas>
+<div id="hint">W: wireframe ON</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/coins/index.js
+++ b/examples/babylonjs/havok/coins/index.js
@@ -10,6 +10,82 @@ let engine;
 let scene;
 let canvas;
 
+let showWireframe = true;
+let physicsViewer = null;
+const trackedBodies = [];
+const trackedImpostors = [];
+
+function setupPhysicsDebugWireframe(scene) {
+    if (!BABYLON.Debug || !BABYLON.Debug.PhysicsViewer) {
+        return;
+    }
+
+    physicsViewer = new BABYLON.Debug.PhysicsViewer(scene);
+    const seenImpostors = new WeakSet();
+    const seenBodies = new WeakSet();
+
+    scene.registerBeforeRender(function () {
+        scene.meshes.forEach(function (mesh) {
+            if (!mesh) {
+                return;
+            }
+
+            if (mesh.physicsImpostor && !seenImpostors.has(mesh.physicsImpostor) && physicsViewer.showImpostor) {
+                seenImpostors.add(mesh.physicsImpostor);
+                trackedImpostors.push({ impostor: mesh.physicsImpostor, mesh: mesh });
+                if (showWireframe) {
+                    physicsViewer.showImpostor(mesh.physicsImpostor, mesh);
+                }
+            }
+
+            if (mesh.physicsBody && !seenBodies.has(mesh.physicsBody) && physicsViewer.showBody) {
+                seenBodies.add(mesh.physicsBody);
+                trackedBodies.push(mesh.physicsBody);
+                if (showWireframe) {
+                    physicsViewer.showBody(mesh.physicsBody);
+                }
+            }
+        });
+    });
+}
+
+function setWireframeVisible(visible) {
+    if (showWireframe === visible) {
+        return;
+    }
+    showWireframe = visible;
+    if (physicsViewer) {
+        if (visible) {
+            for (const body of trackedBodies) {
+                physicsViewer.showBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.showImpostor(entry.impostor, entry.mesh);
+            }
+        } else {
+            for (const body of trackedBodies) {
+                physicsViewer.hideBody(body);
+            }
+            for (const entry of trackedImpostors) {
+                physicsViewer.hideImpostor(entry.impostor);
+            }
+        }
+    }
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', function (e) {
+    if (e.repeat) {
+        return;
+    }
+    if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 const randomNumber = (min, max) => {
     if (min == max) {
         return min;
@@ -67,6 +143,7 @@ const createScene = async function() {
     });
     const havokPlugin = new BABYLON.HavokPlugin(true, havokInstance);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.81, 0), havokPlugin);
+    setupPhysicsDebugWireframe(scene);
 
     const ground = BABYLON.MeshBuilder.CreateGround('ground', { width: 20, height: 20 }, scene);
     ground.position.y = -10;

--- a/examples/babylonjs/havok/coins/style.css
+++ b/examples/babylonjs/havok/coins/style.css
@@ -11,3 +11,18 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds a wireframe view of the physics collision shapes to the Babylon.js + Havok falling-coins example (`examples/babylonjs/havok/coins`), toggled with the **W** key, matching the convention used by the other Babylon.js examples.

## Details

- Uses `BABYLON.Debug.PhysicsViewer` to draw each coin's sphere collider as a wireframe.
- A `registerBeforeRender` scan registers newly created physics bodies and shows them; `setWireframeVisible` toggles all of them on/off.
- Adds the W `keydown` handler and a `W: wireframe ON/OFF` hint (with matching `#hint` style), reusing the same pattern as the `babylonjs/ammo/*` examples.

## Test

Open `examples/babylonjs/havok/coins/index.html`. Coins fall and their spherical colliders are drawn as green wireframes; press `W` to toggle the wireframes off/on.

Note: this scene has many coins, so the viewer defaults to ON for consistency with the other examples; press W to turn it off if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)