### PR TITLE
Rework WebGPU + WGSL shogi physics on the eraser solver

### DIFF
--- a/examples/webgpu/wgsl_compute/shogi/index.html
+++ b/examples/webgpu/wgsl_compute/shogi/index.html
@@ -7,12 +7,18 @@
 <body>
 
 <!-- ================================================================
-  Compute Shader
+  Compute Shader (ported from the Babylon.js + WGSL eraser solver)
   State per piece (16 floats = 4 × vec4<f32>):
-    position  : xyz=pos,    w=seed(uint bits)
-    velocity  : xyz=vel,    w=pad
+    position  : xyz=pos,    w=seed (float 0..1)
+    velocity  : xyz=vel,    w=sleep timer
     rotation  : xyzw quaternion
     angularVel: xyz=angVel, w=pad
+
+  Every piece is an oriented bounding box resolved by a single shared collide()
+  routine against the floor and every other piece, using only the six face
+  normals as separating axes (stable contact normal), a clamped Baumgarte
+  push-out, a gravity-tip torque about the average contact, and a per-body sleep
+  timer that only engages on a stable support once the push-out has converged.
 ================================================================ -->
 <script id="cs" type="x-shader/x-compute">
 struct PieceState {
@@ -21,41 +27,29 @@ struct PieceState {
     rotation   : vec4<f32>,
     angularVel : vec4<f32>,
 }
+struct SimParams { dt : f32, gravity : f32, elapsedTime : f32, pad : f32, }
 
-struct SimParams {
-    dt          : f32,
-    gravity     : f32,
-    groundY     : f32,
-    damping     : f32,
-    angDamping  : f32,
-    restitution : f32,
-    friction    : f32,
-    spawnRange  : f32,
-}
+const COUNT : u32 = 200u;
+// Half-extents matching SHOGI_PHYSICS_SIZE = [pw, ph*1.2, pd*1.4] (pw=ph=1.6, pd=0.32).
+const SHE : vec3<f32> = vec3<f32>(0.80, 0.96, 0.224);
+// Static floor OBB (thin plate, top surface at y = -9.95).
+const GROUND_C : vec3<f32> = vec3<f32>(0.0, -10.0, 0.0);
+const GROUND_HE : vec3<f32> = vec3<f32>(6.5, 0.05, 6.5);
 
-const COUNT : u32 = 300u;
-// Half-extents matching SHOGI_PHYSICS_SIZE = [pw, ph*1.2, pd*1.4]
-// pw=1.6, ph=1.6, pd=0.32  →  halves: [0.8, 0.96, 0.224]
-const HW : f32 = 0.80;
-const HH : f32 = 0.96;
-const HD : f32 = 0.224;
+const ANG_SCALE : f32 = 0.18;
+const PEN_SLOP  : f32 = 0.006;
+const BAUMGARTE : f32 = 0.4;
+const MAX_PUSH  : f32 = 0.06;
+const WAKE_LIN  : f32 = 0.15;
+const WAKE_ANG  : f32 = 0.6;
+const SLEEP_TIME : f32 = 0.4;
+const GTIP : f32 = 2.5;
+const PUSH_REST : f32 = 0.03;
+const POKE_SPEED : f32 = 0.3;
 
 @group(0) @binding(0) var<storage, read>       srcStates : array<PieceState>;
 @group(0) @binding(1) var<storage, read_write> dstStates : array<PieceState>;
 @group(0) @binding(2) var<uniform>             params    : SimParams;
-
-fn hash(n : u32) -> u32 {
-    var x = n ^ (n >> 17u);
-    x = x * 0xbf324c81u;
-    x ^= x >> 11u;
-    x = x * 0x68b665e5u;
-    x ^= x >> 16u;
-    return x;
-}
-
-fn hashF(n : u32) -> f32 {
-    return f32(hash(n) & 0xffffffu) * (1.0 / f32(0xffffffu));
-}
 
 fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
     return vec4<f32>(
@@ -65,18 +59,10 @@ fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
         a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z,
     );
 }
-
-fn rotateQ(q : vec4<f32>, v : vec3<f32>) -> vec3<f32> {
-    let t = 2.0 * cross(q.xyz, v);
-    return v + q.w * t + cross(q.xyz, t);
-}
-
 fn normalizeQ(q : vec4<f32>) -> vec4<f32> {
     let l = length(q);
     return select(vec4<f32>(0, 0, 0, 1), q / l, l > 0.0001);
 }
-
-// Build rotation matrix (column-major: axes[0]=local-X, axes[1]=local-Y, axes[2]=local-Z)
 fn quatToAxes(q : vec4<f32>) -> mat3x3<f32> {
     let x = q.x; let y = q.y; let z = q.z; let w = q.w;
     return mat3x3<f32>(
@@ -85,20 +71,63 @@ fn quatToAxes(q : vec4<f32>) -> mat3x3<f32> {
         vec3<f32>(  2.0*(x*z+w*y),   2.0*(y*z-w*x), 1.0-2.0*(x*x+y*y))
     );
 }
-
-// Project OBB half-extents onto a unit axis
-fn obbHalfProj(axes : mat3x3<f32>, L : vec3<f32>) -> f32 {
-    return abs(dot(axes[0], L)) * HW
-         + abs(dot(axes[1], L)) * HH
-         + abs(dot(axes[2], L)) * HD;
+fn obbProj(ax : mat3x3<f32>, he : vec3<f32>, L : vec3<f32>) -> f32 {
+    return abs(dot(ax[0], L))*he.x + abs(dot(ax[1], L))*he.y + abs(dot(ax[2], L))*he.z;
 }
-
-// SAT penetration along L: positive = overlapping, <=0 = separated
-fn satPen(T : vec3<f32>, axA : mat3x3<f32>, axB : mat3x3<f32>, L : vec3<f32>) -> f32 {
+fn satPen(T : vec3<f32>, axA : mat3x3<f32>, heA : vec3<f32>, axB : mat3x3<f32>, heB : vec3<f32>, L : vec3<f32>) -> f32 {
     let lenSq = dot(L, L);
     if (lenSq < 1e-8) { return 1e9; }
     let Ln = L * inverseSqrt(lenSq);
-    return obbHalfProj(axA, Ln) + obbHalfProj(axB, Ln) - abs(dot(T, Ln));
+    return obbProj(axA, heA, Ln) + obbProj(axB, heB, Ln) - abs(dot(T, Ln));
+}
+
+struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, lever:vec3<f32>, }
+
+// Collide this piece (A, half-extents SHE) against another OBB (B). Only the six face normals
+// are separating axes, so the contact normal is a stable face direction (no jitter/crawl).
+fn collide(pos:vec3<f32>, vel:vec3<f32>, axA:mat3x3<f32>,
+           cB:vec3<f32>, velB:vec3<f32>, axB:mat3x3<f32>, heB:vec3<f32>,
+           pushFactor:f32, impFactor:f32, restitution:f32, friction:f32) -> Resp {
+    var resp : Resp;
+    resp.dPos = vec3<f32>(0.0); resp.dVel = vec3<f32>(0.0); resp.dAng = vec3<f32>(0.0); resp.hit = 0.0; resp.lever = vec3<f32>(0.0);
+    let T = cB - pos;
+    let bsr = length(SHE) + length(heB);
+    if (dot(T,T) > bsr*bsr) { return resp; }
+
+    var minPen = 1e9;
+    var minAxis = vec3<f32>(0.0, 1.0, 0.0);
+    var sep = false;
+    for (var k=0; k<3; k++) { if (sep) { break; } let pen = satPen(T,axA,SHE,axB,heB,axA[k]); if (pen<=0.0){sep=true;break;} if (pen<minPen){minPen=pen;minAxis=axA[k];} }
+    for (var k=0; k<3; k++) { if (sep) { break; } let pen = satPen(T,axA,SHE,axB,heB,axB[k]); if (pen<=0.0){sep=true;break;} if (pen<minPen){minPen=pen;minAxis=axB[k];} }
+    if (sep) { return resp; }
+    resp.hit = 1.0;
+
+    var n = minAxis;
+    if (dot(n, -T) < 0.0) { n = -n; }   // n points from B toward this piece
+    resp.dPos = n * min(max(minPen - PEN_SLOP, 0.0) * pushFactor * BAUMGARTE, MAX_PUSH);
+
+    let cLx = clamp(dot(T, axA[0]), -SHE.x, SHE.x);
+    let cLy = clamp(dot(T, axA[1]), -SHE.y, SHE.y);
+    let cLz = clamp(dot(T, axA[2]), -SHE.z, SHE.z);
+    let r_i = axA[0]*cLx + axA[1]*cLy + axA[2]*cLz;
+    resp.lever = r_i;
+
+    let relV = vel - velB;
+    let relVn = dot(relV, n);
+    if (relVn < 0.0) {
+        let Jn = -(relVn * (1.0 + restitution) * impFactor);
+        resp.dVel += n * Jn;
+        resp.dAng += cross(r_i, n * Jn) * (impFactor * ANG_SCALE);
+        let relVt = relV - relVn * n;
+        let vtLen = length(relVt);
+        if (vtLen > 0.001) {
+            let tDir = relVt / vtLen;
+            let Jt = min(friction * abs(Jn), vtLen * impFactor);
+            resp.dVel -= tDir * Jt;
+            resp.dAng += cross(r_i, -tDir * Jt) * (impFactor * ANG_SCALE);
+        }
+    }
+    return resp;
 }
 
 @compute @workgroup_size(64)
@@ -106,157 +135,115 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let i = id.x;
     if (i >= COUNT) { return; }
 
-    var pos    = srcStates[i].position.xyz;
-    let seedW  = bitcast<u32>(srcStates[i].position.w);
-    var vel    = srcStates[i].velocity.xyz;
-    var rot    = srcStates[i].rotation;
+    var pos = srcStates[i].position.xyz;
+    var vel = srcStates[i].velocity.xyz;
+    var rot = srcStates[i].rotation;
     var angVel = srcStates[i].angularVel.xyz;
+    let seed = srcStates[i].position.w;
+    var sleepTimer = srcStates[i].velocity.w;
+    var asleep = sleepTimer >= SLEEP_TIME;
 
-    // Respawn when piece falls out of the play area
-    if (pos.y < -15.0 || abs(pos.x) > 30.0 || abs(pos.z) > 30.0) {
-        let s  = hash(seedW + 1u);
-        pos.x  = (hashF(s)      - 0.5) * params.spawnRange;
-        pos.y  = (hashF(s + 1u) + 1.0) * 15.0;
-        pos.z  = (hashF(s + 2u) - 0.5) * params.spawnRange;
-        // Random tumble on respawn
-        let av = vec3<f32>(
-            (hashF(s + 3u) - 0.5) * 6.0,
-            (hashF(s + 4u) - 0.5) * 2.0,
-            (hashF(s + 5u) - 0.5) * 6.0,
-        );
-        dstStates[i].position   = vec4<f32>(pos, bitcast<f32>(s));
-        dstStates[i].velocity   = vec4<f32>(0.0);
-        dstStates[i].rotation   = vec4<f32>(0.0, 0.0, 0.0, 1.0);
-        dstStates[i].angularVel = vec4<f32>(av, 0.0);
-        return;
-    }
-
-    // Gravity
-    vel.y -= params.gravity * params.dt;
-
-    // Integrate position
-    pos += vel * params.dt;
-
-    // Integrate rotation
-    let hw = angVel * 0.5 * params.dt;
-    let dq = quatMul(vec4<f32>(hw, 0.0), rot);
-    rot = normalizeQ(rot + dq);
-
-    // Ground collision: find lowest OBB corner and compute contact torque
-    var minY  = 1e9;
-    var cLocal = vec3<f32>(0.0, -HH, 0.0);  // contact local pos
-    for (var ix = 0; ix < 2; ix++) {
-        for (var iy = 0; iy < 2; iy++) {
-            for (var iz = 0; iz < 2; iz++) {
-                let lx = select(-HW, HW, ix == 1);
-                let ly = select(-HH, HH, iy == 1);
-                let lz = select(-HD, HD, iz == 1);
-                let local = vec3<f32>(lx, ly, lz);
-                let wy = pos.y + rotateQ(rot, local).y;
-                if (wy < minY) {
-                    minY   = wy;
-                    cLocal = local;
-                }
-            }
+    // Integrate only while awake; a sleeping piece holds its pose (still tested below to wake).
+    if (!asleep) {
+        vel.y -= params.gravity * params.dt;
+        vel *= 0.998;
+        angVel *= 0.96;
+        pos += vel * params.dt;
+        let sp = length(angVel);
+        if (sp > 0.0001) {
+            let axis = angVel / sp;
+            let half = sp * params.dt * 0.5;
+            rot = normalizeQ(quatMul(vec4<f32>(axis * sin(half), cos(half)), rot));
         }
     }
-    if (minY < params.groundY && abs(pos.x) < 6.5 && abs(pos.z) < 6.5) {
-        pos.y += params.groundY - minY;
-        if (vel.y < 0.0) {
-            let r  = rotateQ(rot, cLocal);
-            let jY = -vel.y * (1.0 + params.restitution);
-            // Torque from normal (vertical) impulse
-            angVel += cross(r, vec3<f32>(0.0, jY, 0.0)) * 0.20;
-            // Torque from friction (horizontal velocity removed by ground contact)
-            let dVelF = vec3<f32>(vel.x * (params.friction - 1.0), 0.0, vel.z * (params.friction - 1.0));
-            angVel += cross(r, dVelF) * 0.25;
 
-            vel.y  = -vel.y * params.restitution;
-            vel.x *= params.friction;
-            vel.z *= params.friction;
-        }
-        angVel *= 0.80;
+    let axA = quatToAxes(rot);
+    let identity = mat3x3<f32>(vec3<f32>(1,0,0), vec3<f32>(0,1,0), vec3<f32>(0,0,1));
+
+    var contacts = 0.0;
+    var leverSum = vec3<f32>(0.0);
+    var pushMag = 0.0;
+    var stableSupport = false;
+    var awakePoke = false;
+
+    // Floor (static, always a stable support).
+    var r = collide(pos, vel, axA, GROUND_C, vec3<f32>(0.0), identity, GROUND_HE, 1.0, 1.0, 0.0, 0.8);
+    if (r.hit > 0.0) {
+        pos += r.dPos; vel += r.dVel; angVel += r.dAng;
+        contacts += 1.0; leverSum += r.lever; pushMag += length(r.dPos);
+        stableSupport = true;
     }
 
-    // Piece-to-piece OBB collision (SAT)
-    let axA    = quatToAxes(rot);
-    let BSR2   = 6.76; // quick-reject: bounding sphere diameter^2 = (2*1.3)^2
+    // Piece-piece (read neighbours from the previous state). An already-sleeping neighbour acts
+    // like a static obstacle (full push-out) and counts as a stable support.
     for (var j = 0u; j < COUNT; j++) {
         if (j == i) { continue; }
-        let jPos = srcStates[j].position.xyz;
-        let T    = jPos - pos;
-        if (dot(T, T) > BSR2) { continue; }  // bounding-sphere early exit
-        let axB = quatToAxes(srcStates[j].rotation);
-
-        var minPen  = 1e9;
-        var minAxis = vec3<f32>(1.0, 0.0, 0.0);
-        var sep     = false;
-
-        // A face normals (3)
-        for (var k = 0; k < 3; k++) {
-            if (sep) { break; }
-            let pen = satPen(T, axA, axB, axA[k]);
-            if (pen <= 0.0) { sep = true; break; }
-            if (pen < minPen) { minPen = pen; minAxis = axA[k]; }
-        }
-        // B face normals (3)
-        for (var k = 0; k < 3; k++) {
-            if (sep) { break; }
-            let pen = satPen(T, axA, axB, axB[k]);
-            if (pen <= 0.0) { sep = true; break; }
-            if (pen < minPen) { minPen = pen; minAxis = axB[k]; }
-        }
-        // Edge cross products (9)
-        for (var a = 0; a < 3; a++) {
-            if (sep) { break; }
-            for (var b = 0; b < 3; b++) {
-                if (sep) { break; }
-                let L   = cross(axA[a], axB[b]);
-                let pen = satPen(T, axA, axB, L);
-                if (pen <= 0.0) { sep = true; break; }
-                if (pen < minPen) { minPen = pen; minAxis = L; }
-            }
-        }
-        if (sep) { continue; }
-
-        // Orient push-out normal from j toward i
-        var n = minAxis;
-        if (dot(n, pos - jPos) < 0.0) { n = -n; }
-
-        // Push-out (take half)
-        pos += n * (minPen * 0.5);
-
-        // Contact point on piece i: project direction-toward-j onto i's local axes, clamp to half-extents
-        let cLx = clamp(dot(T, axA[0]), -HW, HW);
-        let cLy = clamp(dot(T, axA[1]), -HH, HH);
-        let cLz = clamp(dot(T, axA[2]), -HD, HD);
-        let r_i = axA[0]*cLx + axA[1]*cLy + axA[2]*cLz;
-
-        let jVel  = srcStates[j].velocity.xyz;
-        let relV  = vel - jVel;
-        let relVn = dot(relV, n);
-        if (relVn < 0.0) {
-            let Jn = -(relVn * (1.0 + 0.2) * 0.5);
-            // Normal impulse: linear + angular
-            vel    += n * Jn;
-            angVel += cross(r_i, n * Jn) * 0.5;
-            // Tangential friction impulse: generates spin when pieces scrape
-            let relVt    = relV - relVn * n;
-            let relVtLen = length(relVt);
-            if (relVtLen > 0.001) {
-                let Jt   = min(0.4 * Jn, relVtLen * 0.5);
-                let tDir = relVt / relVtLen;
-                vel    -= tDir * Jt;
-                angVel += cross(r_i, -tDir * Jt) * 1.5;
-            }
+        let o = srcStates[j];
+        let oAsleep = o.velocity.w >= SLEEP_TIME;
+        let push = select(0.5, 1.0, oAsleep);
+        r = collide(pos, vel, axA, o.position.xyz, o.velocity.xyz, quatToAxes(o.rotation), SHE, push, 0.5, 0.0, 0.6);
+        if (r.hit > 0.0) {
+            pos += r.dPos; vel += r.dVel; angVel += r.dAng;
+            contacts += 1.0; leverSum += r.lever; pushMag += length(r.dPos);
+            if (oAsleep) { stableSupport = true; }
+            else if (length(o.velocity.xyz) > POKE_SPEED) { awakePoke = true; }
         }
     }
 
-    vel    *= params.damping;
-    angVel *= params.angDamping;
+    // A sleeping piece stays frozen unless a moving piece disturbs it or its support is gone.
+    if (asleep) {
+        if (awakePoke || !stableSupport) {
+            sleepTimer = 0.0;
+            asleep = false;
+        } else {
+            dstStates[i].position = vec4<f32>(pos, seed);
+            dstStates[i].velocity = vec4<f32>(0.0, 0.0, 0.0, sleepTimer);
+            dstStates[i].rotation = rot;
+            dstStates[i].angularVel = vec4<f32>(0.0);
+            return;
+        }
+    }
 
-    dstStates[i].position   = vec4<f32>(pos, bitcast<f32>(seedW));
-    dstStates[i].velocity   = vec4<f32>(vel, 0.0);
+    // Cap speeds so impacts into the dense pile stay gentle (no ejection fountain).
+    let speed = length(vel);
+    if (speed > 18.0) { vel *= 18.0 / speed; }
+    if (length(angVel) > 8.0) { angVel *= 8.0 / length(angVel); }
+
+    // Resting bodies: gravity torque about the average contact tips an edge-balanced piece flat
+    // (and vanishes once balanced). Sleep only on a stable support, when slow and once the
+    // push-out has converged, so jammed/penetrating pieces never freeze in mid-air.
+    if (contacts > 0.0) {
+        let rAvg = leverSum / contacts;
+        angVel += cross(-rAvg, vec3<f32>(0.0, -params.gravity, 0.0)) * (params.dt * GTIP);
+        angVel *= 0.9;
+        if (stableSupport && length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG && pushMag < PUSH_REST) {
+            sleepTimer += params.dt;
+        } else {
+            sleepTimer = 0.0;
+        }
+        if (sleepTimer >= SLEEP_TIME) {
+            vel = vec3<f32>(0.0);
+            angVel = vec3<f32>(0.0);
+        }
+    } else {
+        sleepTimer = 0.0;   // airborne -> never sleeps
+    }
+
+    // Recycle pieces that fall off the plate edge.
+    if (pos.y < -15.0) {
+        let salt = i * 2654435761u + u32(params.elapsedTime * 60.0) * 40503u;
+        let fx = f32((salt >> 0u) & 1023u) / 1023.0;
+        let fy = f32((salt >> 10u) & 1023u) / 1023.0;
+        let fz = f32((salt >> 20u) & 1023u) / 1023.0;
+        pos = vec3<f32>((fx - 0.5) * 8.0, (fy + 1.0) * 15.0, (fz - 0.5) * 8.0);
+        vel = vec3<f32>(0.0, -0.3, 0.0);
+        rot = normalizeQ(vec4<f32>(fx - 0.5, fz - 0.5, seed - 0.5, 1.0));
+        angVel = vec3<f32>(0.0, 0.0, 0.0);
+        sleepTimer = 0.0;
+    }
+
+    dstStates[i].position   = vec4<f32>(pos, seed);
+    dstStates[i].velocity   = vec4<f32>(vel, sleepTimer);
     dstStates[i].rotation   = rot;
     dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
 }

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -9,9 +9,11 @@ const wireVertWGSL       = document.getElementById('wvs').textContent;
 const wireFragWGSL       = document.getElementById('wfs').textContent;
 
 // ------------------------------------------------------------------ constants
-const COUNT       = 300;
+// Keep the heap inside the open 13 x 13 plate; more pieces overflow the edges and the spilled
+// ones recycle forever (a "fountain" of pieces raining back down).
+const COUNT       = 150;
 const STATE_FLOATS = 16;   // 4 × vec4<f32>
-const SUBSTEPS    = 4;
+const SUBSTEPS    = 5;
 
 // Piece geometry dimensions (identical to Havok version)
 const DOT_SIZE = 2;
@@ -169,16 +171,16 @@ function hash32(n) {
 }
 function hashF(n) { return (hash32(n) & 0xffffff) / 0xffffff; }
 
+// State layout (matches the eraser solver): position.w = seed (float), velocity.w = sleep timer.
 function createInitialStates() {
     const states = new Float32Array(COUNT * STATE_FLOATS);
-    const statesU = new Uint32Array(states.buffer);
     for (let i = 0; i < COUNT; i++) {
         const base = i * STATE_FLOATS;
         const seed = hash32(i + 1);
-        states[base + 0] = (hashF(seed)     - 0.5) * 15;  // x
+        states[base + 0] = (hashF(seed)     - 0.5) * 8;   // x (kept well inside the plate)
         states[base + 1] = (hashF(seed + 1) + 1.0) * 15;  // y (15..30)
-        states[base + 2] = (hashF(seed + 2) - 0.5) * 15;  // z
-        statesU[base + 3] = seed;                          // seed as uint32 bits
+        states[base + 2] = (hashF(seed + 2) - 0.5) * 8;   // z
+        states[base + 3] = hashF(seed + 6);                // seed (float 0..1)
         // rotation: identity (qw=1)
         states[base + 11] = 1.0;
         // Initial angular velocity: random tumble so pieces tip on landing
@@ -266,6 +268,7 @@ let computePipeline, computeBindGroupA, computeBindGroupB;
 let simParamsBuffer;
 let currentPMatrix = null;
 let ping = 0;
+let startTime = 0;
 
 // ------------------------------------------------------------------ resize
 function resize() {
@@ -281,6 +284,10 @@ function resize() {
 
 // ------------------------------------------------------------------ render loop
 function render() {
+    // Update sim params (elapsedTime drives the recycle salt).
+    const time = (performance.now() - startTime) / 1000;
+    device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([1 / (60 * SUBSTEPS), 9.8, time, 0]));
+
     const encoder = device.createCommandEncoder();
 
     // --- Compute substeps (ping-pong) ---
@@ -397,7 +404,7 @@ async function init() {
     });
 
     // State buffers (ping-pong)
-    simParamsBuffer = device.createBuffer({ size: 32, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    simParamsBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
 
     const stateBufSize = COUNT * STATE_FLOATS * 4;
     srcBuffer = device.createBuffer({
@@ -433,18 +440,6 @@ async function init() {
         layout: 'auto',
         compute: { module: device.createShaderModule({ code: computeShaderWGSL }), entryPoint: 'main' }
     });
-
-    // Sim params: dt, gravity, groundY (top of floor = -10+0.1), damping, angDamping, restitution, friction, spawnRange
-    device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([
-        1 / (60 * SUBSTEPS),  // dt per substep (placeholder, fixed at 60fps)
-        9.8,                  // gravity
-        -9.9,                 // groundY  (floor top surface)
-        0.9992,               // linear damping
-        0.992,                // angular damping
-        0.35,                 // restitution
-        0.82,                 // friction
-        15.0,                 // spawnRange (x/z)
-    ]));
 
     computeBindGroupA = device.createBindGroup({
         layout: computePipeline.getBindGroupLayout(0),
@@ -571,6 +566,7 @@ async function init() {
         document.getElementById('hint').textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
     });
 
+    startTime = performance.now();
     requestAnimationFrame(render);
 }
 


### PR DESCRIPTION
Fixes the **WebGPU + WGSL falling shogi** sample, where pieces could settle in unstable poses and freeze in mid-air.

## Change
Replaces the compute shader's physics with the same stable solver now used by the Babylon.js + WGSL eraser/shogi samples:

- Every piece is an oriented bounding box resolved by **one shared `collide()` routine** against the floor and every other piece, using **only the six face normals** as separating axes (stable contact normal — no jitter/crawl), a clamped Baumgarte push-out, and a **gravity-tip torque** about the average contact that flattens an edge-balanced piece.
- A **sleep timer** that only engages on a *stable support* (the floor or an already-sleeping piece) once the push-out has converged, and **wakes** a piece when a moving neighbour pushes into it or its support disappears — so pieces no longer freeze while still penetrating/unsupported (the mid-air "floating" heap).
- Energy is capped (fall speed, push-out `MAX_PUSH`, angular impulse, gravity-tip) so dense multi-contact impacts don't eject pieces; the count is reduced to 150 with spawns kept inside the plate so nothing spills off the open edge and recycles forever as a rain of pieces.

State layout matches the eraser solver (`position.w` = seed, `velocity.w` = sleep timer); `SimParams` reduced to `{dt, gravity, elapsedTime}`. **Rendering is unchanged** (pentagon-prism mesh, shogi texture, ground plate, `W` wireframe toggle).

Verified on a real GPU (Playwright headful Chromium): pieces fall and settle into a compact heap that fits the plate, fully at rest with no floating/ejected pieces by ~26 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
