### PR TITLE
Match Babylon.js + WGSL cone shape to the Havok cone

### DIFF
--- a/examples/babylonjs/wgsl_compute/cone/index.js
+++ b/examples/babylonjs/wgsl_compute/cone/index.js
@@ -169,13 +169,17 @@ function createInitialStates() {
     return states;
 }
 
+// Cone proportions match the Babylon.js + Havok cone (from the three.js carrot: radiusBottom 12.5,
+// height 50 -> base radius = height/4). The base radius is therefore derived from the height with
+// the same 0.25 ratio, so the WGSL cones are the same slender shape rather than squat/fat.
+const CONE_RADIUS_RATIO = 0.25;
 function createConeInfos() {
     const infos = new Float32Array(CONE_COUNT * INFO_FLOATS);
     for (let i = 0; i < CONE_COUNT; i++) {
-        const seed = ((i * 37) % 101) / 101;
         const base = i * INFO_FLOATS;
-        infos[base + 0] = 0.45 + seed * 0.3;
-        infos[base + 1] = 1.2 + (((i * 17) % 101) / 101) * 1.0;
+        const height = 1.2 + (((i * 17) % 101) / 101) * 1.0;
+        infos[base + 0] = height * CONE_RADIUS_RATIO;   // base radius (1/4 of height, like Havok)
+        infos[base + 1] = height;
         infos[base + 2] = 0.1;
         infos[base + 3] = 0.055;
     }


### PR DESCRIPTION
## Discrepancy
The **Babylon.js + WGSL** cones were noticeably squat compared to the **Babylon.js + Havok** cones.

- **Havok** (reference, from the three.js carrot `radiusBottom=12.5, height=50`): base radius is **1/4 of the height** (0.25 ratio) — a slender carrot.
- **WGSL** (before): the per-instance base radius (`0.45..0.75`) was set *independently* of the height (`1.2..2.2`), so the radius was ~1/3 of the height — too wide.

The render shader scales the unit cone by `vec3(radius, height, radius)`, so `radius` is the base radius directly; the larger ratio made the cones fat.

## Fix
Derive the WGSL base radius from the height using the same `0.25` ratio as the Havok/three.js cone, so the cones are the same slender shape. Per-cone height variation is preserved. Physics is unaffected (the bounding-sphere approximation already uses `height/2`, which still dominates).

Verified on a real GPU: the WGSL cones now match the slender carrot proportions of the Havok version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
