### PR TITLE
Rework WGSL Football physics on the Marbles spatial-grid solver

### DIFF
--- a/examples/webgpu/wgsl_compute/football/index.html
+++ b/examples/webgpu/wgsl_compute/football/index.html
@@ -30,10 +30,33 @@ struct SimParams {
 }
 
 const COUNT : u32 = 256u;
+// Uniform spatial grid for broad-phase collision (see cs-build / cs-clear). CELL_SIZE is
+// injected from JS so it always covers the ball diameter.
+const GRID_X : u32 = 64u;
+const GRID_Y : u32 = 64u;
+const GRID_Z : u32 = 64u;
+const CELL_CAPACITY : u32 = 12u;
+const CELL_SIZE : f32 = __CELL_SIZE__;
+const FLOOR_Y_C : f32 = -3.0;
 
 @group(0) @binding(0) var<storage, read> srcStates : array<BallState>;
 @group(0) @binding(1) var<storage, read_write> dstStates : array<BallState>;
 @group(0) @binding(2) var<uniform> params : SimParams;
+@group(0) @binding(3) var<storage, read> grid : array<u32>;
+
+fn cellCoord(p : vec3<f32>) -> vec3<i32> {
+    return vec3<i32>(
+        i32(floor(p.x / CELL_SIZE + f32(GRID_X) * 0.5)),
+        i32(floor((p.y - FLOOR_Y_C) / CELL_SIZE)),
+        i32(floor(p.z / CELL_SIZE + f32(GRID_Z) * 0.5)),
+    );
+}
+fn cellHash(c : vec3<i32>) -> i32 {
+    if (c.x < 0 || c.x >= i32(GRID_X)) { return -1; }
+    if (c.y < 0 || c.y >= i32(GRID_Y)) { return -1; }
+    if (c.z < 0 || c.z >= i32(GRID_Z)) { return -1; }
+    return c.x + c.y * i32(GRID_X) + c.z * i32(GRID_X) * i32(GRID_Y);
+}
 
 fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
     return vec4<f32>(
@@ -51,72 +74,91 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         return;
     }
 
+    let r = params.radius;
+    let restitution = params.restitution;
+    let friction = params.friction;
+    let minDist = r * 2.0;
+    let seed = srcStates[i].position.w;
+
     var pos = srcStates[i].position.xyz;
     var vel = srcStates[i].velocity.xyz;
     var rot = srcStates[i].rotation;
     var angVel = srcStates[i].angularVel.xyz;
-    let seed = srcStates[i].position.w;
-    let r = params.radius;
-    let minDist = r * 2.0;
 
     vel.y -= params.gravity * params.dt;
     vel *= params.damping;
     pos += vel * params.dt;
     angVel *= 0.995;
 
-    let onGroundPlane = abs(pos.x) < params.groundHalf && abs(pos.z) < params.groundHalf;
+    let onGroundPlane = abs(pos.x) + r < params.groundHalf && abs(pos.z) + r < params.groundHalf;
     if (onGroundPlane && pos.y - r < params.groundY) {
         let impactSpeed = max(-vel.y, 0.0);
         pos.y = params.groundY + r;
         if (impactSpeed > 0.0) {
-            let bounceSpeed = impactSpeed * params.restitution;
+            let bounceSpeed = impactSpeed * restitution;
             vel.y = select(bounceSpeed, max(bounceSpeed, 0.22), impactSpeed > 0.55);
         }
-        let tangentDecay = max(1.0 - params.friction, 0.0);
+
+        let tangentDecay = max(1.0 - friction, 0.0);
         vel.x *= tangentDecay;
         vel.z *= tangentDecay;
-
-        let rolling = vec3<f32>(-vel.z / max(r, 0.001), angVel.y * 0.8, vel.x / max(r, 0.001));
-        angVel = mix(angVel, rolling, 0.18);
+        // Roll without slipping: the zero-velocity contact point gives omega_x = vz/r and
+        // omega_z = -vx/r, so the surface rolls forward in the travel direction (the sign of
+        // these two terms is what makes it look like rolling rather than skidding).
+        let rollingAngVel = vec3<f32>(vel.z / r, angVel.y * 0.96, -vel.x / r);
+        angVel = mix(angVel, rollingAngVel, 0.5);
 
         if (abs(vel.y) < 0.03) {
             vel.y = 0.0;
         }
     }
 
-    for (var j = 0u; j < COUNT; j++) {
-        if (j == i) {
-            continue;
-        }
+    // Sphere vs sphere using a uniform spatial grid: only the 3x3x3 neighbouring cells
+    // are scanned instead of every other ball, turning the broad phase from O(N^2) into
+    // roughly O(N).
+    let myCoord = cellCoord(pos);
+    for (var dz = -1; dz <= 1; dz = dz + 1) {
+    for (var dy = -1; dy <= 1; dy = dy + 1) {
+    for (var dx = -1; dx <= 1; dx = dx + 1) {
+        let cidx = cellHash(myCoord + vec3<i32>(dx, dy, dz));
+        if (cidx < 0) { continue; }
+        let cellBase = u32(cidx) * (CELL_CAPACITY + 1u);
+        let cellCount = min(grid[cellBase], CELL_CAPACITY);
+        for (var k = 0u; k < cellCount; k = k + 1u) {
+            let j = grid[cellBase + 1u + k];
+            if (j == i) { continue; }
 
-        let other = srcStates[j];
-        var delta = pos - other.position.xyz;
-        var dist = length(delta);
-        if (dist < 0.0001) {
-            let a = params.elapsedTime + seed * 6.28318;
-            delta = vec3<f32>(cos(a), 0.2, sin(a)) * 0.001;
-            dist = length(delta);
-        }
-
-        if (dist < minDist) {
-            let n = delta / dist;
-            let penetration = minDist - dist;
-            pos += n * penetration * 0.52;
-
-            let relVel = vel - other.velocity.xyz;
-            let vn = dot(relVel, n);
-            if (vn < 0.0) {
-                vel += n * (-(1.0 + params.restitution) * vn * 0.65);
+            let other = srcStates[j];
+            var delta = pos - other.position.xyz;
+            var dist = length(delta);
+            if (dist < 0.0001) {
+                let a = params.elapsedTime + seed * 6.28318;
+                delta = vec3<f32>(cos(a), 0.2, sin(a)) * 0.001;
+                dist = length(delta);
             }
 
-            let tangent = relVel - n * vn;
-            let tangentLen = length(tangent);
-            if (tangentLen > 0.0001) {
-                let t = tangent / tangentLen;
-                vel -= t * min(tangentLen * params.friction, 0.12);
-                angVel += cross(n, t) * tangentLen * 0.11;
+            if (dist < minDist) {
+                let n = delta / dist;
+                let penetration = minDist - dist;
+                pos += n * penetration * 0.52;
+
+                let relVel = vel - other.velocity.xyz;
+                let vn = dot(relVel, n);
+                if (vn < 0.0) {
+                    vel += n * (-(1.0 + restitution) * vn * 0.65);
+                }
+
+                let tangent = relVel - n * vn;
+                let tangentLen = length(tangent);
+                if (tangentLen > 0.0001) {
+                    let t = tangent / tangentLen;
+                    vel -= t * min(tangentLen * friction, 0.12);
+                    angVel += cross(n, t) * tangentLen * 0.11;
+                }
             }
         }
+    }
+    }
     }
 
     let speed = length(angVel);
@@ -140,6 +182,60 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     dstStates[i].velocity = vec4<f32>(vel, 0.0);
     dstStates[i].rotation = rot;
     dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+}
+</script>
+
+<!-- Clears the spatial grid (per sub-step, before it is rebuilt). -->
+<script id="cs-clear" type="x-shader/x-compute">
+@group(0) @binding(0) var<storage, read_write> grid : array<u32>;
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let i = id.x;
+    if (i < arrayLength(&grid)) { grid[i] = 0u; }
+}
+</script>
+
+<!-- Inserts each ball into its grid cell (atomic append, capacity-capped). -->
+<script id="cs-build" type="x-shader/x-compute">
+const COUNT : u32 = 256u;
+const GRID_X : u32 = 64u;
+const GRID_Y : u32 = 64u;
+const GRID_Z : u32 = 64u;
+const CELL_CAPACITY : u32 = 12u;
+const CELL_SIZE : f32 = __CELL_SIZE__;
+const FLOOR_Y_C : f32 = -3.0;
+struct BallState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+@group(0) @binding(0) var<storage, read> states : array<BallState>;
+@group(0) @binding(1) var<storage, read_write> grid : array<atomic<u32>>;
+fn cellCoord(p : vec3<f32>) -> vec3<i32> {
+    return vec3<i32>(
+        i32(floor(p.x / CELL_SIZE + f32(GRID_X) * 0.5)),
+        i32(floor((p.y - FLOOR_Y_C) / CELL_SIZE)),
+        i32(floor(p.z / CELL_SIZE + f32(GRID_Z) * 0.5)),
+    );
+}
+fn cellHash(c : vec3<i32>) -> i32 {
+    if (c.x < 0 || c.x >= i32(GRID_X)) { return -1; }
+    if (c.y < 0 || c.y >= i32(GRID_Y)) { return -1; }
+    if (c.z < 0 || c.z >= i32(GRID_Z)) { return -1; }
+    return c.x + c.y * i32(GRID_X) + c.z * i32(GRID_X) * i32(GRID_Y);
+}
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+    let i = id.x;
+    if (i >= COUNT) { return; }
+    let cidx = cellHash(cellCoord(states[i].position.xyz));
+    if (cidx < 0) { return; }
+    let base = u32(cidx) * (CELL_CAPACITY + 1u);
+    let slot = atomicAdd(&grid[base], 1u);
+    if (slot < CELL_CAPACITY) {
+        atomicStore(&grid[base + 1u + slot], i);
+    }
 }
 </script>
 

--- a/examples/webgpu/wgsl_compute/football/index.js
+++ b/examples/webgpu/wgsl_compute/football/index.js
@@ -1,4 +1,6 @@
 const computeShaderWGSL = document.getElementById('cs').textContent;
+const clearGridShaderWGSL = document.getElementById('cs-clear').textContent;
+const buildGridShaderWGSL = document.getElementById('cs-build').textContent;
 const vertexShaderWGSL = document.getElementById('vs').textContent;
 const fragmentShaderWGSL = document.getElementById('fs').textContent;
 
@@ -26,23 +28,37 @@ const ROWS = [
 const COUNT = 256;
 const INSTANCE_COUNT = COUNT + 1;
 const STATE_FLOATS = 16;
-const SUBSTEPS = 4;
+// The grid broad-phase keeps contacts stable. Restitution is kept moderate so dense piles
+// settle without exploding, while damping stays light (~0.995/frame after SUBSTEPS) so the
+// balls keep a lively bounce instead of feeling viscous.
+const SUBSTEPS = 5;
 const RADIUS = 0.5;
 const GROUND_Y = -2.0;
 const GROUND_HALF = 15.0;
 const SPAWN_Y_OFFSET = 4.0;
-const RESTITUTION = 0.82;
-const FRICTION = 0.035;
+const RESTITUTION = 0.68;
+// Moderate rolling resistance: low enough that balls keep horizontal velocity and visibly
+// roll after landing, high enough that they come to rest within the containment walls
+// instead of sloshing forever.
+const FRICTION = 0.02;
 const LINEAR_DAMPING = 0.999;
 
+// Uniform spatial grid for broad-phase collision (mirrors the WGSL constants in index.html;
+// CELL_SIZE is computed from the ball radius and injected into the shaders).
+const GRID_X = 64, GRID_Y = 64, GRID_Z = 64;
+const CELL_CAPACITY = 12;
+const GRID_SLOTS = GRID_X * GRID_Y * GRID_Z * (CELL_CAPACITY + 1);
+
 let device, context, format, depthTexture;
-let renderPipeline, computePipeline;
+let renderPipeline, computePipeline, clearGridPipeline, buildGridPipeline;
 let sphereMesh, groundMesh;
-let cameraBuffer, colorBuffer, simParamsBuffer;
+let cameraBuffer, colorBuffer, simParamsBuffer, gridBuffer;
 let sampler, textureView;
 let stateBuffers = [];
 let renderBindGroups = [];
 let computeBindGroups = [];
+let buildGridBindGroups = [];
+let clearGridBindGroup;
 let currentState = 0;
 let lastTime = -1;
 
@@ -257,11 +273,26 @@ function frame(timeMs) {
     ]));
 
     const encoder = device.createCommandEncoder();
+    const ballWorkgroups = Math.ceil(COUNT / 64);
+    const gridWorkgroups = Math.ceil(GRID_SLOTS / 64);
     for (let s = 0; s < SUBSTEPS; s++) {
+        // Rebuild the spatial grid from the current (src) state, then step the physics.
+        const clearPass = encoder.beginComputePass();
+        clearPass.setPipeline(clearGridPipeline);
+        clearPass.setBindGroup(0, clearGridBindGroup);
+        clearPass.dispatchWorkgroups(gridWorkgroups);
+        clearPass.end();
+
+        const buildPass = encoder.beginComputePass();
+        buildPass.setPipeline(buildGridPipeline);
+        buildPass.setBindGroup(0, buildGridBindGroups[currentState]);
+        buildPass.dispatchWorkgroups(ballWorkgroups);
+        buildPass.end();
+
         const computePass = encoder.beginComputePass();
         computePass.setPipeline(computePipeline);
         computePass.setBindGroup(0, computeBindGroups[currentState]);
-        computePass.dispatchWorkgroups(Math.ceil(COUNT / 64));
+        computePass.dispatchWorkgroups(ballWorkgroups);
         computePass.end();
         currentState = 1 - currentState;
     }
@@ -324,6 +355,13 @@ async function init() {
 
     cameraBuffer = device.createBuffer({ size: 64, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
     simParamsBuffer = device.createBuffer({ size: 48, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    gridBuffer = device.createBuffer({ size: GRID_SLOTS * 4, usage: GPUBufferUsage.STORAGE });
+
+    // Grid cell size must cover the ball diameter so the 3x3x3 neighbour scan catches every
+    // overlapping pair; inject it into the compute and grid-build shaders.
+    const cellSize = Math.max(1.2, RADIUS * 2 * 1.15).toFixed(4);
+    const computeCode = computeShaderWGSL.replaceAll('__CELL_SIZE__', cellSize);
+    const buildGridCode = buildGridShaderWGSL.replaceAll('__CELL_SIZE__', cellSize);
 
     sampler = device.createSampler({
         addressModeU: 'repeat',
@@ -357,9 +395,21 @@ async function init() {
     computePipeline = device.createComputePipeline({
         layout: 'auto',
         compute: {
-            module: device.createShaderModule({ code: computeShaderWGSL }),
+            module: device.createShaderModule({ code: computeCode }),
             entryPoint: 'main',
         },
+    });
+    clearGridPipeline = device.createComputePipeline({
+        layout: 'auto',
+        compute: { module: device.createShaderModule({ code: clearGridShaderWGSL }), entryPoint: 'main' },
+    });
+    buildGridPipeline = device.createComputePipeline({
+        layout: 'auto',
+        compute: { module: device.createShaderModule({ code: buildGridCode }), entryPoint: 'main' },
+    });
+    clearGridBindGroup = device.createBindGroup({
+        layout: clearGridPipeline.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer: gridBuffer } }],
     });
 
     for (let i = 0; i < 2; i++) {
@@ -380,6 +430,15 @@ async function init() {
                 { binding: 0, resource: { buffer: stateBuffers[i] } },
                 { binding: 1, resource: { buffer: stateBuffers[1 - i] } },
                 { binding: 2, resource: { buffer: simParamsBuffer } },
+                { binding: 3, resource: { buffer: gridBuffer } },
+            ],
+        }));
+
+        buildGridBindGroups.push(device.createBindGroup({
+            layout: buildGridPipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: stateBuffers[i] } },
+                { binding: 1, resource: { buffer: gridBuffer } },
             ],
         }));
     }


### PR DESCRIPTION
## Summary

Reworks the **WebGPU + WGSL Falling Football** example so its physics is based on the **Falling Marbles (glTF)** sample's solver, while keeping the Football rendering (football texture, ground plane, orbit camera, colour layout) unchanged.

## Changes

- **Spatial-grid broad phase (O(N²) → O(N))**: replaces the old all-pairs collision loop with a uniform spatial grid that scans only the 3×3×3 neighbouring cells, mirroring the Marbles sample. Adds `cs-clear` / `cs-build` compute passes (clear grid → atomic-append balls → step), with `CELL_SIZE` injected from JS.
- **Correct rolling direction**: fixes the rolling angular-velocity sign so a ball spins forward in its travel direction (`ωx = vz/r`, `ωz = -vx/r`). Previously the sign was reversed, so textured balls looked like they were skidding rather than rolling.
- **Physics tuning** for stable but lively piling: `RESTITUTION = 0.68`, `SUBSTEPS = 5`, `LINEAR_DAMPING = 0.999`, `FRICTION = 0.02`.

Recycling behaviour (balls that roll off the ground respawn from the top) is preserved.

## Testing

Verified in a WebGPU browser. The balls fall, collide via the grid solver, roll across the ground in the correct direction, and recycle from the top — without the energy blow-ups seen during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
