### PR TITLE
Align three.js / PlayCanvas / Filament + Havok Shogi with the other samples

### DIFF
--- a/examples/filament/havok/shogi/index.js
+++ b/examples/filament/havok/shogi/index.js
@@ -20,25 +20,22 @@ const IBL_URL = 'https://cx20.github.io/gltf-test/textures/ktx/papermill/papermi
 const GRASS_URL = '../../../../assets/textures/grass.jpg';
 const SHOGI_URL = '../../../../assets/textures/shogi_001/shogi.png';
 
-const PIECE_COUNT = 220;
+const PIECE_COUNT = 300;
 const PIECE_W = 1.6;
 const PIECE_H = 1.6;
-const PIECE_D = 0.45;
-const COLLIDER_SIZE = [PIECE_W, PIECE_H, PIECE_D * 1.4]; // box fallback only
+const PIECE_D = 0.32;
+// Matches the other Havok samples' SHOGI_PHYSICS_SIZE = [w, h*1.2, d*1.4].
+const COLLIDER_SIZE = [PIECE_W, PIECE_H * 1.2, PIECE_D * 1.4];
 const PIECE_ROUGHNESS = 0.65; // lacquered-wood look
 const WIREFRAME_OUTSET = 1.005;
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
-const RESET_Y_THRESHOLD = -10;
-const GROUND = { size: [40, 4, 40], pos: [0, -2, 0] };
-const GROUND_TILES = 16;
-const WALLS = [
-  { size: [10, 10, 1], pos: [0, 5, -5] },
-  { size: [10, 10, 1], pos: [0, 5, 5] },
-  { size: [1, 10, 10], pos: [-5, 5, 0] },
-  { size: [1, 10, 10], pos: [5, 5, 0] },
-];
+const RESET_Y_THRESHOLD = -15;
+// Small, low floor (no walls), matching the WebGL/WebGPU + Havok shogi samples.
+const GROUND = { size: [13, 0.1, 13], pos: [0, -10, 0] };
+const GROUND_TILES = 5;
+const WALLS = [];
 
 const COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
 const COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
@@ -371,7 +368,7 @@ function randomQuat() {
 }
 
 function randomDrop() {
-  return [(Math.random() - 0.5) * 8, 12 + Math.random() * 26, (Math.random() - 0.5) * 8];
+  return [(Math.random() - 0.5) * 15, (Math.random() + 1.0) * 15, (Math.random() - 0.5) * 15];
 }
 
 function addPieceBody(shapeId, entity, wireframeEntity, pos, rot) {
@@ -493,7 +490,7 @@ async function main() {
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
-  checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
+  checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
@@ -544,10 +541,11 @@ async function main() {
   }
   console.log('[Filament+Havok] pieces ready:', pieces.length, 'static wires:', staticWireframeEntities.length);
 
-  const camTarget = [0, 2, 0];
-  let camTheta  = 0.5;   // azimuth (rad)
-  let camPhi    = 0.49;   // elevation (rad)
-  let camRadius = 34.0;
+  // Head-on view matching the WebGL/WebGPU + Havok shogi samples (eye at (0,0,40), origin).
+  const camTarget = [0, 0, 0];
+  let camTheta  = 0.0;   // azimuth (rad)
+  let camPhi    = 0.0;   // elevation (rad)
+  let camRadius = 40.0;
 
   let aspect = 1;
   function resize() {
@@ -557,7 +555,7 @@ async function main() {
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
-    camera.setProjectionFov(75, aspect, 0.1, 1000.0, fovAxis);
+    camera.setProjectionFov(45, aspect, 0.1, 1000.0, fovAxis);
   }
   window.addEventListener('resize', resize);
   resize();

--- a/examples/playcanvas/havok/shogi/index.js
+++ b/examples/playcanvas/havok/shogi/index.js
@@ -8,8 +8,8 @@ import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs';
 
 const PIECE_W = 1.6;
 const PIECE_H = 1.6;
-const PIECE_D = 0.45;
-const PIECE_COUNT = 220;
+const PIECE_D = 0.32;
+const PIECE_COUNT = 300;
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
 const SHOGI_TEX = 'https://cx20.github.io/webgl-physics-examples/assets/textures/shogi_001/shogi.png';
@@ -139,47 +139,26 @@ function randomQuaternion() {
 
 function initPhysics() {
     worldId = HK.HP_World_Create()[1];
-    HK.HP_World_SetGravity(worldId, [0, -9.81, 0]);
+    HK.HP_World_SetGravity(worldId, [0, -9.8, 0]);
     HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP);
 
     const floorMat = new pc.StandardMaterial();
     floorMat.diffuseMap = getTexture(GRASS_TEX, 72, 72);
     floorMat.update();
 
-    const wallMat = new pc.StandardMaterial();
-    wallMat.diffuse = new pc.Color(1, 1, 1);
-    wallMat.opacity = 0.3;
-    wallMat.blendType = pc.BLEND_NORMAL;
-    wallMat.update();
-
     const shogiMat = new pc.StandardMaterial();
     shogiMat.diffuseMap = getTexture(SHOGI_TEX, 1024, 512, false);
     shogiMat.cull = pc.CULLFACE_NONE;
     shogiMat.update();
 
-    // Floor (static)
-    createStaticBox(0, -2, 0, 20, 2, 20);
+    // Small, low floor (no walls), matching the WebGL/WebGPU + Havok shogi samples: a
+    // 13 x 0.1 x 13 slab at y = -10 that the heap overflows.
+    createStaticBox(0, -10, 0, 6.5, 0.05, 6.5);
     const floor = new pc.Entity();
     floor.addComponent('model', { type: 'box', material: floorMat });
-    floor.setLocalScale(40, 4, 40);
-    floor.setPosition(0, -2, 0);
+    floor.setLocalScale(13, 0.1, 13);
+    floor.setPosition(0, -10, 0);
     app.root.addChild(floor);
-
-    // Walls (static)
-    const wallData = [
-        { size: [10, 10, 1], pos: [0, 5, -5] },
-        { size: [10, 10, 1], pos: [0, 5,  5] },
-        { size: [1, 10, 10], pos: [-5, 5, 0] },
-        { size: [1, 10, 10], pos: [5, 5,  0] }
-    ];
-    for (const w of wallData) {
-        createStaticBox(w.pos[0], w.pos[1], w.pos[2], w.size[0] / 2, w.size[1] / 2, w.size[2] / 2);
-        const wall = new pc.Entity();
-        wall.addComponent('model', { type: 'box', material: wallMat });
-        wall.setLocalScale(w.size[0], w.size[1], w.size[2]);
-        wall.setPosition(w.pos[0], w.pos[1], w.pos[2]);
-        app.root.addChild(wall);
-    }
 
     // Shared shogi mesh + box collider.
     const geo = buildShogiGeometry(PIECE_W, PIECE_H, PIECE_D);
@@ -190,13 +169,14 @@ function initPhysics() {
     shogiMesh.setIndices(geo.indices);
     shogiMesh.update();
 
-    const hw = PIECE_W / 2, hh = PIECE_H / 2, hd = PIECE_D * 0.7;
+    // Collider matches the other Havok samples' SHOGI_PHYSICS_SIZE = [w, h*1.2, d*1.4].
+    const hw = PIECE_W / 2, hh = PIECE_H * 0.6, hd = PIECE_D * 0.7;
     // HP_Shape_CreateBox takes full side lengths, so pass 2x the half-extents.
     const pieceShape = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [hw * 2, hh * 2, hd * 2])[1];
     const pieceMass  = HK.HP_Shape_BuildMassProperties(pieceShape)[1];
 
     for (let i = 0; i < PIECE_COUNT; i++) {
-        const spawn = [(Math.random() - 0.5) * 8, 2 + Math.random() * 36, (Math.random() - 0.5) * 8];
+        const spawn = [(Math.random() - 0.5) * 15, (Math.random() + 1.0) * 15, (Math.random() - 0.5) * 15];
 
         const bodyId = HK.HP_Body_Create()[1];
         HK.HP_Body_SetShape(bodyId, pieceShape);
@@ -222,8 +202,8 @@ function updatePhysics() {
         p.entity.setPosition(pos[0], pos[1], pos[2]);
         p.entity.setRotation(new pc.Quat(ori[0], ori[1], ori[2], ori[3]));
 
-        if (pos[1] < -10) {
-            HK.HP_Body_SetPosition(p.bodyId, [(Math.random() - 0.5) * 8, 12 + Math.random() * 26, (Math.random() - 0.5) * 8]);
+        if (pos[1] < -15) {
+            HK.HP_Body_SetPosition(p.bodyId, [(Math.random() - 0.5) * 15, (Math.random() + 1.0) * 15, (Math.random() - 0.5) * 15]);
             HK.HP_Body_SetOrientation(p.bodyId, randomQuaternion());
             HK.HP_Body_SetLinearVelocity(p.bodyId, [0, 0, 0]);
             HK.HP_Body_SetAngularVelocity(p.bodyId, [0, 0, 0]);
@@ -249,12 +229,13 @@ async function main() {
     app.root.addChild(light);
 
     camera = new pc.Entity('camera');
-    camera.addComponent('camera', { clearColor: new pc.Color(0.13, 0.14, 0.16), nearClip: 0.01, farClip: 1000, fov: 60 });
+    camera.addComponent('camera', { clearColor: new pc.Color(0.13, 0.14, 0.16), nearClip: 0.1, farClip: 1000, fov: 45 });
     camera.addComponent('script');
     app.root.addChild(camera);
     const cc = camera.script.create(CameraControls);
     cc.enableFly = false;
-    cc.reset(new pc.Vec3(0, 4, 0), new pc.Vec3(0, 14, 28));
+    // Head-on view matching the WebGL/WebGPU + Havok shogi samples (eye at (0,0,40), origin).
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 0, 40));
 
     initPhysics();
     setInterval(updatePhysics, 1000 / 60);

--- a/examples/threejs/havok/shogi/index.js
+++ b/examples/threejs/havok/shogi/index.js
@@ -3,7 +3,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
-const PIECE_COUNT = 220;
+const PIECE_COUNT = 300;
 
 let HK, worldId;
 let scene, camera, renderer, controls;
@@ -118,8 +118,10 @@ function initThree() {
   scene.add(new THREE.HemisphereLight(0xbfd6ff, 0x2a2a2a, 0.9));
   scene.add(new THREE.AmbientLight(0x666666, 1.3));
 
-  camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-  camera.position.set(18, 24, 34);
+  // Head-on camera matching the WebGL/WebGPU + Havok shogi samples (eye at (0,0,40) looking at
+  // the origin, 45 deg FOV).
+  camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+  camera.position.set(0, 0, 40);
 
   const light = new THREE.DirectionalLight(0xffffff, 2.1);
   light.position.set(30, 100, 50);
@@ -134,7 +136,7 @@ function initThree() {
   container.appendChild(renderer.domElement);
 
   controls = new OrbitControls(camera, renderer.domElement);
-  controls.autoRotate = true;
+  controls.autoRotate = false;
 
   window.addEventListener('resize', () => {
     camera.aspect = window.innerWidth / window.innerHeight;
@@ -147,7 +149,7 @@ function initPhysics() {
   const worldRes = HK.HP_World_Create();
   checkResult(worldRes[0], 'HP_World_Create');
   worldId = worldRes[1];
-  checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
+  checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
 
   const loader = new THREE.TextureLoader();
@@ -158,41 +160,26 @@ function initPhysics() {
 
   const shogiMat = new THREE.MeshLambertMaterial({ map: shogiTex, side: THREE.DoubleSide });
   const groundMat = new THREE.MeshLambertMaterial({ color: 0x3D4143 });
-  const wallMat = new THREE.MeshLambertMaterial({ color: 0x3D4143, transparent: true, opacity: 0.4 });
 
-  createStaticBox([40, 4, 40], [0, -2, 0], groundMat);
+  // Small, low floor (no walls), matching the WebGL/WebGPU + Havok shogi samples: a
+  // 13 x 0.1 x 13 slab at y = -10 that the heap overflows.
+  createStaticBox([13, 0.1, 13], [0, -10, 0], groundMat);
   const groundDbg = new THREE.LineSegments(
-    new THREE.EdgesGeometry(new THREE.BoxGeometry(40, 4, 40)),
+    new THREE.EdgesGeometry(new THREE.BoxGeometry(13, 0.1, 13)),
     new THREE.LineBasicMaterial({ color: 0x44ee88 })
   );
-  groundDbg.position.set(0, -2, 0);
+  groundDbg.position.set(0, -10, 0);
   groundDbg.visible = showWireframe;
   scene.add(groundDbg);
   staticDebugMeshes.push(groundDbg);
 
-  const wallData = [
-    { size: [10, 10,  1], pos: [ 0, 5, -5] },
-    { size: [10, 10,  1], pos: [ 0, 5,  5] },
-    { size: [ 1, 10, 10], pos: [-5, 5,  0] },
-    { size: [ 1, 10, 10], pos: [ 5, 5,  0] },
-  ];
-  for (const { size, pos } of wallData) {
-    createStaticBox(size, pos, wallMat);
-    const wallDbg = new THREE.LineSegments(
-      new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
-      new THREE.LineBasicMaterial({ color: 0x44ee88 })
-    );
-    wallDbg.position.set(pos[0], pos[1], pos[2]);
-    wallDbg.visible = showWireframe;
-    scene.add(wallDbg);
-    staticDebugMeshes.push(wallDbg);
-  }
-
   const pieceW = 1.6;
   const pieceH = 1.6;
-  const pieceD = 0.45;
+  const pieceD = 0.32;
+  // Collider matches the other Havok samples' SHOGI_PHYSICS_SIZE = [w, h*1.2, d*1.4].
+  const colliderSize = [pieceW, pieceH * 1.2, pieceD * 1.4];
 
-  const psRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, [pieceW, pieceH, pieceD * 1.4]);
+  const psRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, colliderSize);
   checkResult(psRes[0], 'HP_Shape_CreateBox shogi');
   const pieceShapeId = psRes[1];
   const pmRes = HK.HP_Shape_BuildMassProperties(pieceShapeId);
@@ -202,9 +189,9 @@ function initPhysics() {
   const pieceGeo = createShogiGeometry(pieceW, pieceH, pieceD);
 
   for (let i = 0; i < PIECE_COUNT; i++) {
-    const x = (Math.random() - 0.5) * 8;
-    const y = 12 + Math.random() * 26;
-    const z = (Math.random() - 0.5) * 8;
+    const x = (Math.random() - 0.5) * 15;
+    const y = (Math.random() + 1.0) * 15;
+    const z = (Math.random() - 0.5) * 15;
     const q = randomQuaternion();
 
     const bRes = HK.HP_Body_Create();
@@ -224,7 +211,7 @@ function initPhysics() {
     scene.add(mesh);
     meshes.push(mesh);
     const dbg = new THREE.LineSegments(
-      new THREE.EdgesGeometry(new THREE.BoxGeometry(pieceW, pieceH, pieceD * 1.4)),
+      new THREE.EdgesGeometry(new THREE.BoxGeometry(colliderSize[0], colliderSize[1], colliderSize[2])),
       new THREE.LineBasicMaterial({ color: 0xff8844 })
     );
     dbg.visible = showWireframe;
@@ -245,10 +232,10 @@ function updatePhysics() {
       debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
     }
 
-    if (pos[1] < -10) {
-      const x = (Math.random() - 0.5) * 8;
-      const y = 12 + Math.random() * 26;
-      const z = (Math.random() - 0.5) * 8;
+    if (pos[1] < -15) {
+      const x = (Math.random() - 0.5) * 15;
+      const y = (Math.random() + 1.0) * 15;
+      const z = (Math.random() - 0.5) * 15;
       const q = randomQuaternion();
       HK.HP_Body_SetPosition(bodyIds[i], [x, y, z]);
       HK.HP_Body_SetOrientation(bodyIds[i], [q.x, q.y, q.z, q.w]);


### PR DESCRIPTION
## Summary

Aligns the **three.js + Havok**, **PlayCanvas + Havok** and **Filament + Havok** Falling Shogi samples with the **WebGL1/2 + Havok** and **WebGPU + Havok** shogi samples (and the recently-updated **Babylon.js + Havok** one, #376), so all the Havok shogi implementations look the same and can be compared side by side.

## Changes (applied to all three samples)

- **Small floor, no walls**: remove the surrounding containment walls (the centre box) and replace the large `40 x 4 x 40` ground with a small `13 x 0.1 x 13` floor slab at `y = -10` that the heap overflows.
- **Same drop parameters**: 300 pieces, spawn `x,z` in ±7.5 / `y` in 15..30, recycle below `y = -15`.
- **Same physics**: gravity `-9.8`, and piece box colliders sized `[w, h*1.2, d*1.4] = [1.6, 1.92, 0.448]`, matching the other samples' `SHOGI_PHYSICS_SIZE`.
- **Fixed, head-on camera**: eye at `(0,0,40)` looking at the origin, 45° FOV. The three.js `OrbitControls.autoRotate` is turned off; PlayCanvas / Filament keep their mouse orbit but start from the head-on view.

## Testing

Syntax-checked all three. Verify in-browser that each renders 300 pieces raining onto the small low floor, piling and overflowing the edges, recycling from the top, under a fixed head-on camera — matching the WebGL/WebGPU + Havok shogi samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
