### PR TITLE
Align WebGPU + WGSL Falling Shogi with the Havok samples

### DIFF
--- a/examples/webgpu/wgsl_compute/shogi/index.html
+++ b/examples/webgpu/wgsl_compute/shogi/index.html
@@ -29,12 +29,14 @@ struct PieceState {
 }
 struct SimParams { dt : f32, gravity : f32, elapsedTime : f32, pad : f32, }
 
-const COUNT : u32 = 200u;
+const COUNT : u32 = __COUNT__;
 // Half-extents matching SHOGI_PHYSICS_SIZE = [pw, ph*1.2, pd*1.4] (pw=ph=1.6, pd=0.32).
 const SHE : vec3<f32> = vec3<f32>(0.80, 0.96, 0.224);
 // Static floor OBB (thin plate, top surface at y = -9.95).
-const GROUND_C : vec3<f32> = vec3<f32>(0.0, -10.0, 0.0);
-const GROUND_HE : vec3<f32> = vec3<f32>(6.5, 0.05, 6.5);
+// Thick floor OBB so fast pieces cannot tunnel through (a too-thin slab lets a piece sink past
+// the box centre, flipping the SAT push-out normal downward). The top surface stays at -9.95.
+const GROUND_C : vec3<f32> = vec3<f32>(0.0, -11.45, 0.0);
+const GROUND_HE : vec3<f32> = vec3<f32>(6.5, 1.5, 6.5);
 
 const ANG_SCALE : f32 = 0.18;
 const PEN_SLOP  : f32 = 0.006;
@@ -43,7 +45,12 @@ const MAX_PUSH  : f32 = 0.06;
 const WAKE_LIN  : f32 = 0.15;
 const WAKE_ANG  : f32 = 0.6;
 const SLEEP_TIME : f32 = 0.4;
-const GTIP : f32 = 2.5;
+// Gravity torque about the average contact tips a piece flat quickly (fast, like real
+// toppling). Only applied while a piece is still moving (see below).
+const GTIP : f32 = 4.5;
+// Small extra bias toward lying flat, so a piece balanced perfectly on edge (where the gravity
+// torque vanishes) still starts to topple instead of freezing upright.
+const GTIP_FLAT : f32 = 1.5;
 const PUSH_REST : f32 = 0.03;
 const POKE_SPEED : f32 = 0.3;
 
@@ -209,13 +216,23 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     if (speed > 18.0) { vel *= 18.0 / speed; }
     if (length(angVel) > 8.0) { angVel *= 8.0 / length(angVel); }
 
-    // Resting bodies: gravity torque about the average contact tips an edge-balanced piece flat
-    // (and vanishes once balanced). Sleep only on a stable support, when slow and once the
-    // push-out has converged, so jammed/penetrating pieces never freeze in mid-air.
+    // Resting bodies: gravity torque about the average contact topples a piece quickly, like
+    // real toppling. But once a piece is slow on a stable support it is left alone (no more
+    // tipping), so settled and buried pieces come to rest and stay put instead of being nudged
+    // forever. A small bias toward flat is kept only for near-upright pieces, to break the
+    // metastable on-edge balance. Pieces may sleep at whatever angle they wedge at (a jumble).
     if (contacts > 0.0) {
-        let rAvg = leverSum / contacts;
-        angVel += cross(-rAvg, vec3<f32>(0.0, -params.gravity, 0.0)) * (params.dt * GTIP);
-        angVel *= 0.9;
+        let zaxis = axA[2];
+        let settledSupport = stableSupport && length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG;
+        if (!settledSupport) {
+            let rAvg = leverSum / contacts;
+            angVel += cross(-rAvg, vec3<f32>(0.0, -params.gravity, 0.0)) * (params.dt * GTIP);
+        }
+        if (abs(zaxis.y) < 0.35) {   // near upright (tilt > ~70deg): nudge so it cannot balance
+            let upTarget = select(vec3<f32>(0.0, -1.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), zaxis.y >= 0.0);
+            angVel += cross(zaxis, upTarget) * (params.dt * GTIP_FLAT);
+        }
+        angVel *= 0.93;
         if (stableSupport && length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG && pushMag < PUSH_REST) {
             sleepTimer += params.dt;
         } else {
@@ -235,10 +252,11 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         let fx = f32((salt >> 0u) & 1023u) / 1023.0;
         let fy = f32((salt >> 10u) & 1023u) / 1023.0;
         let fz = f32((salt >> 20u) & 1023u) / 1023.0;
-        pos = vec3<f32>((fx - 0.5) * 8.0, (fy + 1.0) * 15.0, (fz - 0.5) * 8.0);
+        pos = vec3<f32>((fx - 0.5) * 15.0, (fy + 1.0) * 15.0, (fz - 0.5) * 15.0);
         vel = vec3<f32>(0.0, -0.3, 0.0);
+        // Respawn at a random orientation and tumble so recycled pieces land in a jumble too.
         rot = normalizeQ(vec4<f32>(fx - 0.5, fz - 0.5, seed - 0.5, 1.0));
-        angVel = vec3<f32>(0.0, 0.0, 0.0);
+        angVel = vec3<f32>((fx - 0.5) * 6.0, (fz - 0.5) * 2.0, (seed - 0.5) * 6.0);
         sleepTimer = 0.0;
     }
 

--- a/examples/webgpu/wgsl_compute/shogi/index.js
+++ b/examples/webgpu/wgsl_compute/shogi/index.js
@@ -9,9 +9,9 @@ const wireVertWGSL       = document.getElementById('wvs').textContent;
 const wireFragWGSL       = document.getElementById('wfs').textContent;
 
 // ------------------------------------------------------------------ constants
-// Keep the heap inside the open 13 x 13 plate; more pieces overflow the edges and the spilled
-// ones recycle forever (a "fountain" of pieces raining back down).
-const COUNT       = 150;
+// 300 pieces rain onto the 13 x 13 plate and overflow the edges; the spilled ones recycle from
+// the top (a "fountain"), matching the WebGL/WebGPU + Havok shogi samples.
+const COUNT       = 300;
 const STATE_FLOATS = 16;   // 4 × vec4<f32>
 const SUBSTEPS    = 5;
 
@@ -177,13 +177,13 @@ function createInitialStates() {
     for (let i = 0; i < COUNT; i++) {
         const base = i * STATE_FLOATS;
         const seed = hash32(i + 1);
-        states[base + 0] = (hashF(seed)     - 0.5) * 8;   // x (kept well inside the plate)
+        states[base + 0] = (hashF(seed)     - 0.5) * 15;  // x (matches the other Havok samples)
         states[base + 1] = (hashF(seed + 1) + 1.0) * 15;  // y (15..30)
-        states[base + 2] = (hashF(seed + 2) - 0.5) * 8;   // z
+        states[base + 2] = (hashF(seed + 2) - 0.5) * 15;  // z
         states[base + 3] = hashF(seed + 6);                // seed (float 0..1)
-        // rotation: identity (qw=1)
+        // rotation: identity (qw = 1). The strong random tumble below makes pieces rotate during
+        // the fall and land at varied angles, so the heap settles in a Havok-like jumble.
         states[base + 11] = 1.0;
-        // Initial angular velocity: random tumble so pieces tip on landing
         states[base + 12] = (hashF(seed + 3) - 0.5) * 6;
         states[base + 13] = (hashF(seed + 4) - 0.5) * 2;
         states[base + 14] = (hashF(seed + 5) - 0.5) * 6;
@@ -438,7 +438,9 @@ async function init() {
 
     computePipeline = device.createComputePipeline({
         layout: 'auto',
-        compute: { module: device.createShaderModule({ code: computeShaderWGSL }), entryPoint: 'main' }
+        // Inject COUNT so the shader's piece-piece loop never reads past the state buffer (a
+        // hardcoded mismatch would create phantom colliders at the origin).
+        compute: { module: device.createShaderModule({ code: computeShaderWGSL.replaceAll('__COUNT__', COUNT + 'u') }), entryPoint: 'main' }
     });
 
     computeBindGroupA = device.createBindGroup({


### PR DESCRIPTION
## Summary

Aligns the **WebGPU + WGSL** compute-shader Falling Shogi sample with the WebGL/WebGPU + Havok (and the other renderer + Havok) shogi samples for easy comparison, and fixes a collider bug found along the way.

## Changes

- **Phantom-collider bug fix**: the compute shader hardcoded `COUNT = 200u` while the buffers held 150 pieces, so the piece-piece loop read past the state buffer and created phantom colliders at the origin that disturbed falling pieces. `COUNT` is now injected from JS so the shader and buffers always agree.
- **Scene parity**: 300 pieces and spawn `x,z` in ±7.5, matching the other samples. The rendered floor (`13 x 0.1 x 13` at `y = -10`) and the fixed head-on camera (eye at `(0,0,40)`, 45° FOV) already matched.
- **No tunnelling**: thicken the static floor collider so fast pieces cannot sink past a too-thin slab (its top surface stays at `y = -9.95`).
- **Natural settling**: gravity torque about the contact topples a piece quickly, but it is not applied once the piece is slow on a stable support — so settled and buried pieces come to rest and stay put instead of being nudged forever. A small bias only nudges near-upright pieces so none freeze balanced on edge. Pieces sleep at whatever angle they wedge at, giving a Havok-like jumble rather than a tidy flat stack.

The development-only debug readback/overlay used while tuning this has been removed.

## Notes

This sample uses a bespoke WGSL OBB solver (not Havok), so the pile cannot match Havok exactly; the scene parameters match and the heap settles into a comparable jumble. Toppling speed may still get a follow-up tweak.

## Testing

Verify in a WebGPU browser alongside the Havok shogi samples: 300 textured pieces rain onto the small low floor, pile and overflow, recycle from the top, and settle into a jumble under a fixed head-on camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
