### PR TITLE
Add AGENTS.md guides (repo root and examples/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+Guidance for AI coding agents working with the **cx20/webgl-physics-examples** repository.
+
+## Repository Overview
+
+**Purpose**: a gallery that reproduces the *same* physics scenes across many **renderers** and
+many **physics engines**, so they can be compared side by side. Scenes include *Falling Marbles*,
+*Falling Football*, *Falling Shogi*, *Falling Eraser*, *Domino*, *Coins*, glTF physics samples,
+and more. Each sample is a self-contained static web page (open `index.html` in a WebGL/WebGPU
+browser — no build step).
+
+**Top-level layout**:
+
+- `examples/` — every sample, as a **renderer × engine** matrix (see `examples/AGENTS.md`).
+- `assets/` — shared textures, models, HDR/env maps used by the samples.
+- `docs/` — technical references. Start with
+  [`docs/physics-implementation-notes.md`](docs/physics-implementation-notes.md).
+- `README.md` — the index tables of all samples.
+
+## Key Patterns and Conventions
+
+### Directory structure
+
+```
+examples/<renderer>/<engine>/<scene>/   →  index.html, index.js, style.css
+```
+
+- **Renderers** (15): `ashes`, `babylonjs`, `claygl`, `czpg`, `filament`, `glboost`,
+  `grimoirejs`, `hilo3d`, `playcanvas`, `rhodonite`, `threejs`, `webgl1`, `webgl2`, `webgpu`,
+  `xenogl`.
+- **Engines** (10): `ammo`, `ammo_legacy`, `cannon`, `cannon-es`, `havok`, `oimo`,
+  `oimophysics`, `physx`, `rapier`, and the bespoke GPU solver `wgsl_compute`.
+
+### The golden rule
+
+> **A scene is the constant; only the renderer + engine vary.** When the same scene exists in
+> several cells, every implementation must use the **same scene parameters** — body count, spawn
+> region, floor size/position, gravity, collider sizes, camera. A divergence reads as a bug in
+> one of them. The full checklist is in `docs/physics-implementation-notes.md` §6.
+
+## Guidelines for AI Agents
+
+### When adding or porting a sample
+
+1. **Copy the closest existing sample** for the same scene (another engine, or the same engine on
+   another renderer) and adapt it — do not invent a new structure.
+2. **Match the renderer's existing idioms** (its module imports, camera, render loop). Look at
+   sibling samples under the same `examples/<renderer>/` first.
+3. **Match the engine's existing idioms** (its world setup, body creation, stepping). Look at
+   sibling samples under `examples/<*>/<engine>/`.
+4. **Keep the scene parameters identical** to the other implementations of that scene.
+5. **No build step.** Samples are plain ES modules / scripts loaded by `index.html`. Keep
+   dependencies CDN- or vendor-based as the sibling samples do.
+
+### When modifying physics behaviour
+
+- Read [`docs/physics-implementation-notes.md`](docs/physics-implementation-notes.md) first — it
+  records the gotchas (Havok full-vs-half box extents, thin-floor tunnelling, rolling-spin sign,
+  GPU sleeping/settling, gravity-vs-world-scale, body-teleport velocity inference, …).
+- Tune one parameter at a time and re-check; physics feel is sensitive.
+
+### Commit / PR conventions
+
+- **Commit messages and PR titles/descriptions are always in English.**
+- Branch off `master`; one logical change per PR. Stage only the files for that change (do not
+  sweep in unrelated work-in-progress).
+- Verify JavaScript with `node --check <file>` before committing (these samples have no test
+  suite; in-browser verification is manual).
+
+## Testing and Validation
+
+1. `node --check` the changed `index.js` (and any embedded shader logic you can lint).
+2. Open the sample in a WebGL/WebGPU-capable browser and confirm it runs.
+3. For WebGPU compute-physics samples, compare against the engine-backed version of the same
+   scene — the layout and camera should match.
+4. The primary environment is Windows 11 with a recent Chrome/Edge (WebGPU enabled).
+
+## Documentation
+
+- **`docs/physics-implementation-notes.md`** — libraries, the WGSL compute physics, and the
+  cross-implementation consistency checklist. Update it when you discover a new gotcha.
+- **`README.md`** — keep the sample tables current when adding a sample.
+- **`examples/AGENTS.md`** — focused guidance for working inside the example matrix.
+
+## Additional Resources
+
+- Live site: <https://cx20.github.io/webgl-physics-examples/>.
+- When unsure, study the same scene in another cell of the matrix before writing new code.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,108 @@
+# Examples — Agent Guide
+
+Focused guidance for working inside the **renderer × engine** example matrix. Read the root
+[`AGENTS.md`](../AGENTS.md) and [`docs/physics-implementation-notes.md`](../docs/physics-implementation-notes.md)
+first.
+
+## Folder Overview
+
+Every sample is a self-contained static page (`index.html` + `index.js` + `style.css`) with **no
+build step**. The same scene is reproduced in many cells so they can be compared:
+
+```
+examples/<renderer>/<engine>/<scene>/
+```
+
+- `<renderer>` draws the scene (Babylon.js, three.js, Filament, PlayCanvas, raw WebGL1/2/WebGPU, …).
+- `<engine>` simulates it (Havok, ammo.js, cannon-es, Oimo, PhysX, Rapier, or `wgsl_compute`).
+- `<scene>` is the shared scenario (`marbles`, `football`, `shogi`, `eraser`, `domino`, `coins`, …).
+
+## The two physics approaches
+
+### A. Library-backed (`<renderer>/<engine != wgsl_compute>/`)
+
+A CPU engine owns the simulation; the renderer only draws. The universal shape:
+
+```text
+init:   create world + gravity; create static colliders (floor/walls); create dynamic bodies
+frame:  world.step(FIXED_DT)                      // fixed timestep, e.g. 1/60 or 1/200
+        for each body: read transform → mesh/node
+        recycle bodies that fell below the reset threshold
+```
+
+### B. GPU compute (`<renderer>/wgsl_compute/`)
+
+The entire simulation runs in a **WGSL compute shader**; bodies are drawn with an instanced render
+pass. State lives in ping-pong storage buffers; collisions are spheres (distance test, often with a
+uniform spatial grid) or oriented boxes (face-normal SAT) with a per-body sleep timer. The custom
+solver will never exactly match an engine — aim for the *same scene parameters* and a *plausible*
+result. Full details and gotchas are in `docs/physics-implementation-notes.md` §3.
+
+## Adding / porting a sample
+
+1. **Start from the nearest sibling.** For a new engine of an existing scene, copy that scene from
+   another engine on the same renderer. For a new renderer, copy the same engine+scene from a
+   renderer with a similar API.
+2. **Keep the scene parameters identical** to the other implementations (see the checklist below).
+3. **Adapt only the renderer glue and engine calls**, not the scenario.
+4. Update the relevant table in the root `README.md`.
+
+## Cross-implementation consistency checklist
+
+When the same scene exists in several cells, line them up against these (values shown for *Falling
+Shogi*; the principle is general):
+
+- [ ] **World scale + gravity.** If a sample models at `1/10` scale, scale **gravity** too
+      (`g → g·0.1`) — otherwise it falls `~√10×` too fast.
+- [ ] **Gravity magnitude** consistent (`-9.8`, not a mix of `-9.8/-9.81/-10`).
+- [ ] **Body count / spawn region / recycle threshold** identical (300 pieces, `x,z ∈ ±7.5`,
+      `y ∈ 15..30`, reset `y < -15`).
+- [ ] **Floor** same footprint, level and surface height (`13 × 0.1 × 13` slab, top `≈ -9.95`).
+- [ ] **Collider size = mesh size.** Mind the **box convention**: most engines use *half-extents*,
+      **Havok `HP_Shape_CreateBox` uses full lengths**.
+- [ ] **Thin static floors tunnel.** Make the *physics* floor thick (the *rendered* plate may stay
+      thin) with aligned top surfaces.
+- [ ] **Camera** same eye/target/FOV (`(0,0,40)` → origin, 45°), no auto-rotation.
+
+## Renderer notes
+
+| Renderer | API entry | Camera idiom |
+| --- | --- | --- |
+| `babylonjs` | `BABYLON.*`, `ArcRotateCamera`; WGSL variants share `engine._device` and composite via `RenderTargetTexture` + `Layer` (note the **clip-space Y flip**). | `setPosition` / `setTarget` |
+| `threejs` | `THREE.*`, ES module imports, `OrbitControls` | `camera.position.set` + `controls` |
+| `playcanvas` | `pc.*`, `CameraControls` script | `cc.reset(focus, pos)` |
+| `filament` | low-level `Filament.*`, manual `camera.lookAt`, glTF authored in JS | manual orbit math |
+| `webgl1/2` | raw GL + hand-written matrices | hand-written `lookAt` |
+| `webgpu` | raw WebGPU; `wgsl_compute` here is the reference GPU solver | hand-written view matrix |
+
+## Engine notes
+
+| Engine | Box extents | Notable gotchas |
+| --- | --- | --- |
+| `havok` | **full** lengths | teleport must zero velocity and not re-orient (Babylon: see physics notes §5.1); default material friction/restitution. |
+| `ammo` / `ammo_legacy` | half-extents | Bullet port; PlayCanvas texture/winding quirks. |
+| `cannon` / `cannon-es` | half-extents | friction over-grips slopes; `ContactMaterial` ignored if per-`Material` friction is set. |
+| `oimo` / `oimophysics` | half-extents | pure-JS; two API generations. |
+| `physx` / `rapier` | half-extents | WASM; modern APIs. |
+| `wgsl_compute` | half-extents (`SHE`) | inject `COUNT` from JS; thick physics floor; sleep from the bottom up. |
+
+## Debugging
+
+- **Library samples**: log a few body transforms; toggle the collider wireframe (most samples bind
+  `W`).
+- **GPU compute samples**: you cannot log from a shader — read the state buffer back to the CPU
+  every N frames and aggregate (counts of airborne/settled/asleep, tilt distribution, max speed).
+  Remove the readback (and `COPY_SRC`) before committing. See physics notes §4.
+
+## Troubleshooting
+
+- *Sample looks different from its siblings* → run the consistency checklist above.
+- *Pieces fall through the floor* → thicken the **physics** floor collider.
+- *Collider wireframe larger than the mesh* → box half-vs-full-extents mismatch.
+- *GPU pile never settles / bottom squirms* → sleep gating; don't keep torquing settled bodies.
+- *Recycled body spins up (Babylon + Havok)* → don't re-orient on teleport; zero the velocities.
+
+## Resources
+
+- `docs/physics-implementation-notes.md` — the in-depth reference this guide summarises.
+- Sibling samples — the best template is always the same scene in another cell.

--- a/examples/babylonjs/AGENTS.md
+++ b/examples/babylonjs/AGENTS.md
@@ -1,0 +1,70 @@
+# Babylon.js — Agent Guide
+
+Renderer-specific guidance for `examples/babylonjs/`. Read the root [`AGENTS.md`](../../AGENTS.md),
+[`examples/AGENTS.md`](../AGENTS.md), and
+[`docs/physics-implementation-notes.md`](../../docs/physics-implementation-notes.md) first.
+
+## Folder Overview
+
+Babylon.js samples (`BABYLON.*`, loaded from a CDN). Physics engines present here:
+
+```
+examples/babylonjs/{ammo,cannon,havok,oimo,wgsl_compute}/<scene>/
+```
+
+`havok` is the reference engine; `wgsl_compute` runs the physics on Babylon's own WebGPU device.
+
+## Code Style & Idioms
+
+- A `createScene(engine)` builds a `BABYLON.Scene`; `engine.runRenderLoop(() => scene.render())`.
+- Camera is usually `ArcRotateCamera`; set the view with `camera.setPosition(...)` +
+  `camera.setTarget(...)` and `camera.fov` (radians). For comparison scenes use the fixed
+  head-on view (eye `(0,0,40)`, target origin, `fov = 45°`) and **no auto-rotation**.
+- Lights + `ShadowGenerator`, `StandardMaterial`/`PBRMaterial`, `MeshBuilder.CreateBox` etc.
+
+## Engine notes
+
+### Havok (`scene.enablePhysics(gravity, new BABYLON.HavokPlugin())`)
+
+- **`PhysicsAggregate` collider size**: pass `{ extents: new BABYLON.Vector3(w,h,d) }` to override
+  the mesh bounding box. `extents` are **full** dimensions. (Match the other samples'
+  `SHOGI_PHYSICS_SIZE` etc.)
+- **Teleporting / recycling a body** (the big gotcha):
+  ```js
+  body.disablePreStep = false;
+  body.transformNode.position.copyFrom(spawn);
+  body.setLinearVelocity(BABYLON.Vector3.Zero());
+  body.setAngularVelocity(BABYLON.Vector3.Zero());
+  ```
+  Do **not** also re-assign `transformNode.rotationQuaternion` to a new random orientation while
+  teleporting — Havok derives a huge angular velocity from the orientation jump and the body
+  **spins up**. Re-enabling `disablePreStep = true` afterwards can also leave a dynamic body
+  "animated" so it **falls slowly / not at all**. The proven pattern across these samples is to
+  leave `disablePreStep = false` and not re-orient on recycle.
+- **World scale**: if a sample uses a `PHYSICS_SCALE` (e.g. `1/10`), scale **gravity** too
+  (`-9.8 * PHYSICS_SCALE`) or pieces fall `~√10×` too fast. Prefer modelling in the same units as
+  the other samples (no scaling) so parameters can be copied directly.
+
+### ammo / cannon / oimo
+
+Standard Babylon physics-plugin usage. Mind each engine's **half-extents** box convention (unlike
+Havok's full lengths).
+
+### WGSL compute (`wgsl_compute`)
+
+- Shares Babylon's WebGPU device via `engine._device`; shaders are JS template literals (constants
+  like `COUNT`, `SHE`, `GROUND_*` interpolated in).
+- Output is drawn into a `RenderTargetTexture` and composited with a `BABYLON.Layer`.
+- **Clip-space Y flip**: emit `vec4(clip.x, -clip.y, clip.z, clip.w)` from the WGSL vertex shaders.
+- Same GPU-physics rules as `docs/physics-implementation-notes.md` §3 (thick physics floor,
+  sleep-from-the-bottom, etc.).
+
+## Build / Run
+
+No build step — open `index.html` in a WebGPU/WebGL browser. `node --check index.js` to lint.
+
+## Troubleshooting
+
+- *Recycled piece spins fast / won't fall* → see the Havok teleport note above.
+- *Collider wireframe ≠ mesh* → `extents` are full dimensions; don't pass half.
+- *Falls too fast at small scale* → scale gravity by `PHYSICS_SCALE`.

--- a/examples/filament/AGENTS.md
+++ b/examples/filament/AGENTS.md
@@ -1,0 +1,48 @@
+# Filament — Agent Guide
+
+Renderer-specific guidance for `examples/filament/`. Read the root [`AGENTS.md`](../../AGENTS.md),
+[`examples/AGENTS.md`](../AGENTS.md), and
+[`docs/physics-implementation-notes.md`](../../docs/physics-implementation-notes.md) first.
+
+## Folder Overview
+
+Filament samples — the lowest-level renderer here (Google Filament via its JS/WASM bindings,
+`Filament.*`). Physics engine present:
+
+```
+examples/filament/havok/<scene>/
+```
+
+Everything is explicit: meshes are built as in-memory glTF (vertex buffers, accessors, materials),
+the camera is driven by hand, and the physics result is written onto Filament transform instances.
+
+## Code Style & Idioms
+
+- `Filament.init([...assets], () => main())`; create `engine`, `scene`, `view`, `renderer`,
+  `swapChain`, a `camera`, and a `TransformManager`.
+- **Camera** is manual: maintain `camTarget` + spherical `camTheta/camPhi/camRadius`, compute the
+  eye each frame and `camera.lookAt(eye, target, up)`; `camera.setProjectionFov(fovDeg, aspect,
+  near, far, fovAxis)`. For comparison scenes: target origin, `camRadius = 40`, `camTheta =
+  camPhi = 0` (head-on), `fov = 45`.
+- Static geometry is often a flat **quad** for the floor while the **physics** body is a thin box —
+  keep their top surfaces aligned.
+
+## Gotchas (see `reference_filament_havok_gltf_physics`)
+
+- **Skip punctual lights at feature level 1** (`engine.getSupportedFeatureLevel()`), or Filament
+  crashes building the froxel UBO. Light the scene with IBL / sunlight instead.
+- Remember `scene.remove` / `popRenderable` bookkeeping, colour grading, and the **node → entity**
+  map when syncing physics transforms back to renderables.
+- The wireframe collider overlay is drawn as its own line geometry; keep it in sync with the OBB
+  sizes.
+- **Havok** `HP_Shape_CreateBox` takes **full** side lengths.
+
+## Build / Run
+
+No build step — `index.html` loads the Filament WASM + JS. `node --check index.js`.
+
+## Troubleshooting
+
+- *Blank screen / crash on start* → a punctual light at FL1; remove it or use IBL.
+- *Pieces sink through the floor* → thicken the physics box; align its top with the visible quad.
+- *Pieces drift from their meshes* → node→entity index mapping is off.

--- a/examples/playcanvas/AGENTS.md
+++ b/examples/playcanvas/AGENTS.md
@@ -1,0 +1,46 @@
+# PlayCanvas — Agent Guide
+
+Renderer-specific guidance for `examples/playcanvas/`. Read the root [`AGENTS.md`](../../AGENTS.md),
+[`examples/AGENTS.md`](../AGENTS.md), and
+[`docs/physics-implementation-notes.md`](../../docs/physics-implementation-notes.md) first.
+
+## Folder Overview
+
+PlayCanvas samples (`pc.*`, ES modules). Physics engines present:
+
+```
+examples/playcanvas/{ammo,havok}/<scene>/
+```
+
+The physics is driven directly (Havok handle API, or ammo.js) rather than through PlayCanvas's
+built-in rigidbody component, and the result is copied onto `pc.Entity` transforms.
+
+## Code Style & Idioms
+
+- `new pc.Application(canvas, ...)`; entities via `new pc.Entity()` + `addComponent('render'|'model'|'camera', ...)`.
+- Camera + orbit: `import { CameraControls } from 'playcanvas/scripts/esm/camera-controls.mjs'`,
+  then `const cc = camera.script.create(CameraControls); cc.reset(focus, position)`. For comparison
+  scenes use the head-on view: `fov: 45`, `cc.reset(new pc.Vec3(0,0,0), new pc.Vec3(0,0,40))`.
+- Each frame: step the world, then `entity.setPosition(...)` / `entity.setRotation(new pc.Quat(...))`.
+
+## Engine notes
+
+- **Havok**: low-level `HK.HP_*`. `HP_Shape_CreateBox` takes **full** side lengths — these samples
+  often write `createStaticBox(x,y,z, hw,hh,hd)` and pass `[hw*2, hh*2, hd*2]`, i.e. they keep
+  half-extents in JS and double them for Havok. Keep that convention.
+- **ammo.js** gotchas (see `reference_playcanvas_ammo_gotchas`):
+  - Pre-allocate textures at the **exact** image dimensions.
+  - Use `flipY = false` for custom UVs; fix triangle/normal **winding**.
+  - `btConvexHullShape` jitters when stacked pieces interpenetrate — prefer primitive box/convex
+    shapes where possible.
+
+## Build / Run
+
+No build step — `index.html` loads the ESM. `node --check index.js`.
+
+## Troubleshooting
+
+- *Texture wrong size / blurry* → texture not pre-allocated at the image's exact dimensions.
+- *Texture flipped / mis-UV'd* → `flipY = false` and check winding.
+- *Stacked convex pieces jitter* → `btConvexHullShape` instability; use simpler colliders.
+- *Collider ≠ mesh* → Havok full-vs-half extents.

--- a/examples/threejs/AGENTS.md
+++ b/examples/threejs/AGENTS.md
@@ -1,0 +1,54 @@
+# three.js — Agent Guide
+
+Renderer-specific guidance for `examples/threejs/`. Read the root [`AGENTS.md`](../../AGENTS.md),
+[`examples/AGENTS.md`](../AGENTS.md), and
+[`docs/physics-implementation-notes.md`](../../docs/physics-implementation-notes.md) first.
+
+## Folder Overview
+
+three.js samples (ES modules: `import * as THREE from 'three'`). This renderer has the **widest**
+engine coverage:
+
+```
+examples/threejs/{ammo,ammo_legacy,cannon,cannon-es,havok,oimo,oimophysics,physx,rapier}/<scene>/
+```
+
+It is the best place to compare engines against each other on a single renderer.
+
+## Code Style & Idioms
+
+- `import { OrbitControls } from 'three/addons/controls/OrbitControls.js'`.
+- `PerspectiveCamera`, `WebGLRenderer` (shadow maps, ACES tone mapping). For comparison scenes use
+  the fixed head-on view: `camera = new THREE.PerspectiveCamera(45, aspect, 0.1, 1000)`,
+  `camera.position.set(0, 0, 40)`, `controls.target` at origin, **`controls.autoRotate = false`**.
+- Each frame: `engine.step(FIXED_DT)`, then copy each body's transform onto its mesh
+  (`mesh.position.set(...)`, `mesh.quaternion.set(...)`); also update the debug wireframe mesh.
+
+## Engine notes
+
+- **Havok** uses the low-level handle API (`HK.HP_World_*`, `HK.HP_Body_*`,
+  `HK.HP_Shape_CreateBox`). Remember **`HP_Shape_CreateBox` takes full side lengths**, not
+  half-extents — a static floor box `[13, 0.1, 13]` is full size.
+- **cannon-es**: friction over-grips slopes; a `ContactMaterial`'s friction is ignored when the two
+  `Material`s already set per-material friction. Ramp scenes need a `FRICTION_SCALE` fudge to match
+  the other engines.
+- **ammo / ammo_legacy / oimo / oimophysics / physx / rapier**: half-extents box convention; pick
+  the matching sibling sample as the template.
+
+## Consistency
+
+Match the scene parameters to the other renderers' versions (count, spawn, floor, gravity,
+collider size, camera). For *Falling Shogi* the piece box collider is `[w, h*1.2, d*1.4]` =
+`[1.6, 1.92, 0.448]` and the floor is a `13 × 0.1 × 13` slab at `y = -10` — see
+`examples/AGENTS.md`.
+
+## Build / Run
+
+No build step — `index.html` loads the ES modules (import map / CDN). `node --check index.js`.
+
+## Troubleshooting
+
+- *Pieces fall through a thin floor* → thicken the **physics** box (the rendered slab can stay
+  thin), tops aligned.
+- *Boxes grip slopes too much (cannon-es)* → reduce friction / apply `FRICTION_SCALE`.
+- *Texture upside-down* → `texture.flipY` / UV convention for that loader.

--- a/examples/webgpu/AGENTS.md
+++ b/examples/webgpu/AGENTS.md
@@ -1,0 +1,65 @@
+# WebGPU — Agent Guide
+
+Renderer-specific guidance for `examples/webgpu/`. Read the root [`AGENTS.md`](../../AGENTS.md),
+[`examples/AGENTS.md`](../AGENTS.md), and
+[`docs/physics-implementation-notes.md`](../../docs/physics-implementation-notes.md) first.
+
+## Folder Overview
+
+Raw WebGPU samples (no engine/framework wrapper — direct `navigator.gpu`). Physics present:
+
+```
+examples/webgpu/{havok,oimo,wgsl_compute}/<scene>/
+```
+
+`wgsl_compute` here is the **reference implementation of the GPU compute physics** — the marbles /
+football / shogi / eraser solvers. The `havok` / `oimo` variants are CPU-engine-driven and just
+draw with WebGPU.
+
+## Code Style & Idioms
+
+- Manual everything: request adapter/device, configure the canvas context, build pipelines, write
+  uniform/storage buffers, hand-rolled `mat4` perspective/lookAt.
+- The camera is a fixed view matrix (e.g. eye `(0,0,40)` looking at the origin, `perspective(45,
+  …)`). No orbit controls in the compute samples.
+- Shaders are in `<script type="x-shader/...">` blocks in `index.html` (read via
+  `getElementById(...).textContent`) **or** JS template literals.
+
+## `wgsl_compute` rules (the important part)
+
+These run the whole simulation in a compute shader. Follow
+`docs/physics-implementation-notes.md` §3, in particular:
+
+- **Inject `COUNT` from JS** (replace a `__COUNT__` token or use a template literal). A hardcoded
+  shader `COUNT` that disagrees with the buffer length makes the inner loop read past the buffer →
+  **phantom colliders at the origin**.
+- **Ping-pong** two state buffers (`src` read, `dst` write, swap); run `SUBSTEPS` dispatches per
+  frame at `dt = frameDt / SUBSTEPS`.
+- **Broad phase**: brute-force O(N²) is fine for a few hundred bodies; use the uniform spatial grid
+  (`cs-clear` → `cs-build` → step) for thousands. `CELL_SIZE ≥ largest body diameter`.
+- **Narrow phase**: spheres (distance) or OBB face-normal SAT (stable contact normal).
+- **Static floor**: make the **physics** collider thick (rendered plate can be thin) so fast bodies
+  cannot tunnel; align top surfaces (`y ≈ -9.95`).
+- **Rolling spheres**: drive spin from the contact, `ω_x = vz/r`, `ω_z = -vx/r` — check the sign or
+  the ball looks like it is skidding.
+- **Settling boxes**: sleep from the bottom up; stop torquing a body once it is slow on a stable
+  support, so buried bodies stay put.
+
+## Debugging GPU physics
+
+You cannot log from a shader. Add `COPY_SRC` to the state buffers + a mappable readback buffer,
+`copyBufferToBuffer` after submit, `mapAsync(READ)` every N frames, and aggregate to an overlay
+(airborne/settled/asleep counts, tilt distribution, max speed). **Remove the readback and
+`COPY_SRC` before committing.** See physics notes §4.
+
+## Build / Run
+
+No build step — open `index.html` in a WebGPU browser (Chrome/Edge with WebGPU). `node --check
+index.js`.
+
+## Troubleshooting
+
+- *Bodies near the origin get shoved for no reason* → shader `COUNT` ≠ buffer length (phantoms).
+- *Bodies tunnel through the floor* → thin physics floor; thicken it.
+- *Sphere looks like it slides* → wrong rolling-spin sign.
+- *Pile never rests / bottom squirms* → keep torquing settled bodies; gate it on "still moving".


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` agent-instruction files following the [cx20/hello](https://github.com/cx20/hello) convention (a root guide, a guide for the `examples/` matrix, and per-major-renderer guides).

## Files

- **`AGENTS.md`** (root): repository overview, the renderer × engine matrix, the "keep the scene constant" golden rule, contribution/commit conventions (English commits, one logical change per PR, `node --check`), and pointers to `docs/physics-implementation-notes.md`.
- **`examples/AGENTS.md`**: working inside the matrix — the two physics approaches (library-backed vs WGSL compute), how to add/port a sample, the cross-implementation consistency checklist, per-renderer and per-engine notes tables, debugging, troubleshooting.
- **`examples/<renderer>/AGENTS.md`** for the five renderers covered in depth — **babylonjs, threejs, playcanvas, filament, webgpu** — each documenting that renderer's API/idioms, the engines present under it, the camera convention, build/run, and the renderer-specific gotchas (Babylon + Havok teleport, three.js engine coverage, PlayCanvas ammo texture/winding, Filament froxel/FL1 + quad-vs-box floor, WebGPU `wgsl_compute` rules + GPU readback debugging).

Distilled from building and cross-checking the shogi / marbles / football samples across the matrix. Per-renderer guides were limited to the five renderers with first-hand specifics; the remaining renderers are covered by the tables in `examples/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)