### PR TITLE
Align three.js/PlayCanvas/Filament/Rhodonite + Havok Eraser with the reference

### DIFF
--- a/examples/filament/havok/eraser/index.js
+++ b/examples/filament/havok/eraser/index.js
@@ -37,15 +37,11 @@ const WIREFRAME_OUTSET = 1.01;
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
-const RESET_Y_THRESHOLD = -10;
-const GROUND = { size: [40, 4, 40], pos: [0, -2, 0] };
-const GROUND_TILES = 16;
-const WALLS = [
-  { size: [10, 10, 1], pos: [0, 5, -5] },
-  { size: [10, 10, 1], pos: [0, 5, 5] },
-  { size: [1, 10, 10], pos: [-5, 5, 0] },
-  { size: [1, 10, 10], pos: [5, 5, 0] },
-];
+const RESET_Y_THRESHOLD = -15;
+// Small low floor (no walls), matching the other Havok eraser samples.
+const GROUND = { size: [20, 0.1, 20], pos: [0, -10, 0] };
+const GROUND_TILES = 8;
+const WALLS = [];
 
 const COLOR_DYNAMIC = [1.0, 0.5, 0.2, 1.0];
 const COLOR_STATIC = [0.2, 1.0, 0.4, 1.0];
@@ -343,7 +339,7 @@ function randomQuat() {
 }
 
 function randomDrop() {
-  return [(Math.random() - 0.5) * 8, 12 + Math.random() * 26, (Math.random() - 0.5) * 8];
+  return [(Math.random() - 0.5) * 12, 14 + Math.random() * 14, (Math.random() - 0.5) * 12];
 }
 
 function addEraserBody(shapeId, entity, wireframeEntity, pos, rot) {
@@ -483,7 +479,7 @@ async function main() {
   HK = await HavokPhysics();
   const w = HK.HP_World_Create();
   worldId = w[1];
-  checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
+  checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
   createStaticBox(GROUND.size, GROUND.pos);
   for (const wd of WALLS) createStaticBox(wd.size, wd.pos);
@@ -534,10 +530,11 @@ async function main() {
   }
   console.log('[Filament+Havok] erasers ready:', erasers.length, 'static wires:', staticWireframeEntities.length);
 
-  const camTarget = [0, 2, 0];
-  let camTheta = 0.5;   // azimuth (rad)
-  let camPhi = 0.49;    // elevation (rad)
-  let camRadius = 34.0;
+  // Head-on view matching the WebGL/WebGPU + Havok eraser samples (eye at (0,0,40), origin).
+  const camTarget = [0, 0, 0];
+  let camTheta = 0.0;   // azimuth (rad)
+  let camPhi = 0.0;     // elevation (rad)
+  let camRadius = 40.0;
 
   let aspect = 1;
   function resize() {
@@ -547,7 +544,7 @@ async function main() {
     aspect = width / height;
     view.setViewport([0, 0, width, height]);
     const fovAxis = aspect < 1 ? Fov.HORIZONTAL : Fov.VERTICAL;
-    camera.setProjectionFov(75, aspect, 0.1, 1000.0, fovAxis);
+    camera.setProjectionFov(45, aspect, 0.1, 1000.0, fovAxis);
   }
   window.addEventListener('resize', resize);
   resize();

--- a/examples/playcanvas/havok/eraser/index.js
+++ b/examples/playcanvas/havok/eraser/index.js
@@ -108,7 +108,7 @@ function randomQuaternion() {
 }
 
 function spawnPosition() {
-    return [randomRange(-5, 5), randomRange(20, 30), randomRange(-5, 5)];
+    return [randomRange(-6, 6), randomRange(14, 28), randomRange(-6, 6)];
 }
 
 function spawnEraser() {
@@ -132,18 +132,12 @@ function spawnEraser() {
 
 function initPhysics() {
     worldId = HK.HP_World_Create()[1];
-    HK.HP_World_SetGravity(worldId, [0, -9.81, 0]);
+    HK.HP_World_SetGravity(worldId, [0, -9.8, 0]);
     HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP);
 
     const floorMat = new pc.StandardMaterial();
     floorMat.diffuseMap = getTexture(GRASS_TEX, 72, 72);
     floorMat.update();
-
-    const wallMat = new pc.StandardMaterial();
-    wallMat.diffuse = new pc.Color(1, 1, 1);
-    wallMat.opacity = 0.5;
-    wallMat.blendType = pc.BLEND_NORMAL;
-    wallMat.update();
 
     // Load the eraser texture via the asset system and re-update the material once it
     // arrives, so the diffuse map is reliably picked up by the mesh material's shader.
@@ -156,29 +150,14 @@ function initPhysics() {
         eraserMat.update();
     });
 
-    // Floor (static)
-    createStaticBox(0, -2, 0, 20, 2, 20);
+    // Small low floor (no walls), matching the other Havok eraser samples: a 20 x 0.1 x 20 slab
+    // at y = -10 that the heap overflows.
+    createStaticBox(0, -10, 0, 10, 0.05, 10);
     const floor = new pc.Entity();
     floor.addComponent('model', { type: 'box', material: floorMat });
-    floor.setLocalScale(40, 4, 40);
-    floor.setPosition(0, -2, 0);
+    floor.setLocalScale(20, 0.1, 20);
+    floor.setPosition(0, -10, 0);
     app.root.addChild(floor);
-
-    // Walls (static) — basket sides.
-    const wallData = [
-        { size: [10, 10, 1], pos: [0, 5, -5] },
-        { size: [10, 10, 1], pos: [0, 5,  5] },
-        { size: [1, 10, 10], pos: [-5, 5, 0] },
-        { size: [1, 10, 10], pos: [5, 5,  0] }
-    ];
-    for (const w of wallData) {
-        createStaticBox(w.pos[0], w.pos[1], w.pos[2], w.size[0] / 2, w.size[1] / 2, w.size[2] / 2);
-        const wall = new pc.Entity();
-        wall.addComponent('model', { type: 'box', material: wallMat });
-        wall.setLocalScale(w.size[0], w.size[1], w.size[2]);
-        wall.setPosition(w.pos[0], w.pos[1], w.pos[2]);
-        app.root.addChild(wall);
-    }
 
     // Shared eraser mesh + box collider (full side lengths = 2x half-extents).
     eraserMesh = new pc.Mesh(app.graphicsDevice);
@@ -200,7 +179,7 @@ function updatePhysics() {
         e.entity.setPosition(pos[0], pos[1], pos[2]);
         e.entity.setRotation(new pc.Quat(ori[0], ori[1], ori[2], ori[3]));
 
-        if (pos[1] < -10) {
+        if (pos[1] < -15) {
             HK.HP_Body_SetPosition(e.bodyId, spawnPosition());
             HK.HP_Body_SetOrientation(e.bodyId, randomQuaternion());
             HK.HP_Body_SetLinearVelocity(e.bodyId, [0, 0, 0]);
@@ -227,12 +206,13 @@ async function main() {
     app.root.addChild(light);
 
     camera = new pc.Entity('camera');
-    camera.addComponent('camera', { clearColor: new pc.Color(0.5, 0.5, 0.8), nearClip: 0.01, farClip: 1000, fov: 60 });
+    camera.addComponent('camera', { clearColor: new pc.Color(0.5, 0.5, 0.8), nearClip: 0.1, farClip: 1000, fov: 45 });
     camera.addComponent('script');
     app.root.addChild(camera);
     const cc = camera.script.create(CameraControls);
     cc.enableFly = false;
-    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 10, 40));
+    // Head-on view matching the WebGL/WebGPU + Havok eraser samples (eye at (0,0,40), origin).
+    cc.reset(new pc.Vec3(0, 0, 0), new pc.Vec3(0, 0, 40));
 
     initPhysics();
     setInterval(updatePhysics, 1000 / 60);

--- a/examples/rhodonite/havok/eraser/index.js
+++ b/examples/rhodonite/havok/eraser/index.js
@@ -1,7 +1,7 @@
 import Rn from 'rhodonite';
 
-// Rhodonite (rendering) + Havok low-level API (physics). Textured eraser boxes rain into a walled
-// basket on a ground slab; each collider is a box matching the eraser's extents.
+// Rhodonite (rendering) + Havok low-level API (physics). Textured eraser boxes rain onto a small
+// ground slab and overflow the edges; each collider is a box matching the eraser's extents.
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
@@ -165,7 +165,7 @@ const load = async function () {
   const worldRes = HK.HP_World_Create();
   checkResult(worldRes[0], 'HP_World_Create');
   worldId = worldRes[1];
-  checkResult(HK.HP_World_SetGravity(worldId, [0, -10, 0]), 'HP_World_SetGravity');
+  checkResult(HK.HP_World_SetGravity(worldId, [0, -9.8, 0]), 'HP_World_SetGravity');
   checkResult(HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP), 'HP_World_SetIdealStepTime');
 
   const sampler = new Rn.Sampler(engine, {
@@ -176,37 +176,16 @@ const load = async function () {
   });
   const eraserTex = await Rn.Texture.loadFromUrl(engine, await buildEraserAtlasDataUrl());
 
-  // Ground
-  createStaticBody([40, 4, 40], [0, -2, 0]);
+  // Ground: small low floor (no walls), matching the other Havok eraser samples - a
+  // 20 x 0.1 x 20 slab at y = -10 that the heap overflows.
+  createStaticBody([20, 0.1, 20], [0, -10, 0]);
   const groundMat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
   groundMat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([0.24, 0.4, 0.22, 1]));
   const groundEntity = Rn.MeshHelper.createCube(engine, { material: groundMat });
-  groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, -2, 0]);
-  groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([40, 4, 40]);
+  groundEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([0, -10, 0]);
+  groundEntity.getTransform().localScale = Rn.Vector3.fromCopyArray([20, 0.1, 20]);
   entities.push(groundEntity);
-  createDebugBox([40, 4, 40], [0, -2, 0], DEBUG_COLOR_STATIC);
-
-  // Walls
-  const wallDefs = [
-    { size: [10, 10, 1], pos: [0, 5, -5] },
-    { size: [10, 10, 1], pos: [0, 5, 5] },
-    { size: [1, 10, 10], pos: [-5, 5, 0] },
-    { size: [1, 10, 10], pos: [5, 5, 0] },
-  ];
-  const wallMat = Rn.MaterialHelper.createPbrUberMaterial(engine, { isLighting: true });
-  wallMat.setParameter('baseColorFactor', Rn.Vector4.fromCopyArray4([0.8, 0.8, 0.85, 0.35]));
-  try {
-    const blendMode = (Rn.AlphaMode && (Rn.AlphaMode.Blend ?? Rn.AlphaMode.Translucent));
-    if (blendMode !== undefined && blendMode !== null) wallMat.alphaMode = blendMode;
-  } catch (e) {}
-  for (const { size, pos } of wallDefs) {
-    createStaticBody(size, pos);
-    const wallEntity = Rn.MeshHelper.createCube(engine, { material: wallMat });
-    wallEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray(pos);
-    wallEntity.getTransform().localScale = Rn.Vector3.fromCopyArray(size);
-    entities.push(wallEntity);
-    createDebugBox(size, pos, DEBUG_COLOR_STATIC);
-  }
+  createDebugBox([20, 0.1, 20], [0, -10, 0], DEBUG_COLOR_STATIC);
 
   // Shared physics shape
   const psRes = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, ERASER_SIZE);
@@ -254,9 +233,9 @@ const load = async function () {
   } catch (e) { console.warn('[Eraser] baryCentric failed:', e); }
 
   for (let i = 0; i < ERASER_COUNT; i++) {
-    const x = (Math.random() - 0.5) * 8;
-    const y = 12 + Math.random() * 26;
-    const z = (Math.random() - 0.5) * 8;
+    const x = (Math.random() - 0.5) * 12;
+    const y = 14 + Math.random() * 14;
+    const z = (Math.random() - 0.5) * 12;
     const qx = Math.random() - 0.5;
     const qy = Math.random() - 0.5;
     const qz = Math.random() - 0.5;
@@ -286,12 +265,14 @@ const load = async function () {
 
   // Camera
   const cameraEntity = Rn.createCameraControllerEntity(engine);
-  cameraEntity.localPosition = Rn.Vector3.fromCopyArray([18, 24, 34]);
-  cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.6, 0.5, 0]);
+  // Fixed head-on view matching the other Havok eraser samples (eye at (0,0,40) looking at the
+  // origin, 45 deg FOV); no auto-rotation.
+  cameraEntity.localPosition = Rn.Vector3.fromCopyArray([0, 0, 40]);
+  cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([0, 0, 0]);
   const cameraComponent = cameraEntity.getCamera();
-  cameraComponent.zNear = 1.0;
-  cameraComponent.zFar = 200;
-  cameraComponent.setFovyAndChangeFocalLength(60);
+  cameraComponent.zNear = 0.1;
+  cameraComponent.zFar = 1000;
+  cameraComponent.setFovyAndChangeFocalLength(45);
   cameraComponent.aspect = window.innerWidth / window.innerHeight;
 
   // Lights
@@ -325,10 +306,9 @@ const load = async function () {
 
   setWireframeVisible(showWireframe);
 
-  // 1 ground + 4 walls = 5 static entities before eraser entities
-  const physicsEntityOffset = 5;
+  // 1 ground (no walls) static entity before the eraser entities
+  const physicsEntityOffset = 1;
 
-  let angle = 0;
   const draw = function () {
     HK.HP_World_Step(worldId, FIXED_TIMESTEP);
 
@@ -343,10 +323,10 @@ const load = async function () {
       debugEntity.getTransform().localPosition = Rn.Vector3.fromCopyArray([pos[0], pos[1], pos[2]]);
       debugEntity.getTransform().localRotation = Rn.Quaternion.fromCopyArray([ori[0], ori[1], ori[2], ori[3]]);
 
-      if (pos[1] < -10) {
-        const nx = (Math.random() - 0.5) * 8;
-        const ny = 12 + Math.random() * 26;
-        const nz = (Math.random() - 0.5) * 8;
+      if (pos[1] < -15) {
+        const nx = (Math.random() - 0.5) * 12;
+        const ny = 14 + Math.random() * 14;
+        const nz = (Math.random() - 0.5) * 12;
         const qx2 = Math.random() - 0.5;
         const qy2 = Math.random() - 0.5;
         const qz2 = Math.random() - 0.5;
@@ -358,14 +338,6 @@ const load = async function () {
         HK.HP_Body_SetAngularVelocity(bodyIds[i], [0, 0, 0]);
       }
     }
-
-    angle += 0.004;
-    cameraEntity.localPosition = Rn.Vector3.fromCopyArray([
-      Math.sin(angle) * 40,
-      24,
-      Math.cos(angle) * 40,
-    ]);
-    cameraEntity.localEulerAngles = Rn.Vector3.fromCopyArray([-0.6, angle, 0]);
 
     engine.process([expression]);
     requestAnimationFrame(draw);

--- a/examples/threejs/havok/eraser/index.js
+++ b/examples/threejs/havok/eraser/index.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-// three.js (rendering) + Havok low-level API (physics). Textured box erasers rain into a
-// walled basket on a grass floor; each collider is a box matching the eraser's extents.
+// three.js (rendering) + Havok low-level API (physics). Textured box erasers rain onto a small
+// grass floor and overflow the edges; each collider is a box matching the eraser's extents.
 
 const FIXED_TIMESTEP = 1 / 60;
 const IDENTITY_QUATERNION = [0, 0, 0, 1];
@@ -48,7 +48,7 @@ function randomQuaternion() {
 
 function spawnTransform() {
     return {
-        pos: [(Math.random() - 0.5) * 10, 20 + Math.random() * 12, (Math.random() - 0.5) * 10],
+        pos: [(Math.random() - 0.5) * 12, 14 + Math.random() * 14, (Math.random() - 0.5) * 12],
         q: randomQuaternion(),
     };
 }
@@ -60,8 +60,10 @@ function initThree() {
     scene.add(new THREE.HemisphereLight(0xbfd6ff, 0x444444, 1.0));
     scene.add(new THREE.AmbientLight(0x666666, 1.0));
 
-    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.01, 1000);
-    camera.position.set(0, 14, 44);
+    // Head-on camera matching the WebGL/WebGPU + Havok eraser samples (eye at (0,0,40) looking
+    // at the origin, 45 deg FOV).
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 0, 40);
 
     const light = new THREE.DirectionalLight(0xffffff, 2.0);
     light.position.set(30, 100, 50);
@@ -74,9 +76,8 @@ function initThree() {
     container.appendChild(renderer.domElement);
 
     controls = new OrbitControls(camera, renderer.domElement);
-    controls.target.set(0, 3, 0);
-    controls.autoRotate = true;
-    controls.autoRotateSpeed = 1.0;
+    controls.target.set(0, 0, 0);
+    controls.autoRotate = false;
 
     window.addEventListener('resize', () => {
         camera.aspect = window.innerWidth / window.innerHeight;
@@ -87,7 +88,7 @@ function initThree() {
 
 function initPhysics() {
     worldId = HK.HP_World_Create()[1];
-    HK.HP_World_SetGravity(worldId, [0, -9.81, 0]);
+    HK.HP_World_SetGravity(worldId, [0, -9.8, 0]);
     HK.HP_World_SetIdealStepTime(worldId, FIXED_TIMESTEP);
 
     const loader = new THREE.TextureLoader();
@@ -95,16 +96,10 @@ function initPhysics() {
     grassTex.wrapS = grassTex.wrapT = THREE.RepeatWrapping;
     grassTex.repeat.set(4, 4);
     const groundMat = new THREE.MeshLambertMaterial({ map: grassTex });
-    const wallMat = new THREE.MeshLambertMaterial({ color: 0xffffff, transparent: true, opacity: 0.4 });
 
-    createStaticBox([40, 4, 40], [0, -2, 0], groundMat);
-    const wallData = [
-        { size: [10, 10, 1], pos: [0, 5, -5] },
-        { size: [10, 10, 1], pos: [0, 5, 5] },
-        { size: [1, 10, 10], pos: [-5, 5, 0] },
-        { size: [1, 10, 10], pos: [5, 5, 0] },
-    ];
-    for (const { size, pos } of wallData) createStaticBox(size, pos, wallMat);
+    // Small low floor (no walls), matching the other Havok eraser samples: a 20 x 0.1 x 20 slab
+    // at y = -10 that the heap overflows.
+    createStaticBox([20, 0.1, 20], [0, -10, 0], groundMat);
 
     // Six separate face textures mapped onto a BoxGeometry (one material per face), the same
     // reliable layout as the three.js + Oimo eraser, so every "MOMO" face reads correctly.
@@ -154,7 +149,7 @@ function updatePhysics() {
         debugMeshes[i].position.set(pos[0], pos[1], pos[2]);
         debugMeshes[i].quaternion.set(ori[0], ori[1], ori[2], ori[3]);
 
-        if (pos[1] < -10) {
+        if (pos[1] < -15) {
             const t = spawnTransform();
             HK.HP_Body_SetPosition(bodyIds[i], t.pos);
             HK.HP_Body_SetOrientation(bodyIds[i], [t.q.x, t.q.y, t.q.z, t.q.w]);


### PR DESCRIPTION
## Summary

Second batch of the **Falling Eraser** flat-floor standardisation (after Babylon.js + Havok, #383). Aligns the **three.js**, **PlayCanvas**, **Filament** and **Rhodonite** + Havok eraser samples to the WebGL/WebGPU + Havok reference (no surrounding box).

## Changes (per sample)

- **Small floor, no walls**: remove the walls and replace the `40 x 4 x 40` ground with a `20 x 0.1 x 20` slab at `y = -10` that the heap overflows.
- **Same drop parameters**: 200 erasers, spawn `x,z` in ±6 / `y` in 14..28, recycle below `y = -15`.
- **Gravity** `-9.8`.
- **Fixed head-on camera**: eye at `(0,0,40)` looking at the origin, 45° FOV. three.js `OrbitControls.autoRotate` and the Rhodonite per-frame auto-orbit are removed.

Rhodonite's static-entity sync offset becomes `1` (ground only, no walls).

## Already correct

`webgl1`, `webgl2`, `webgpu` + Havok already matched the reference (gravity `-9.8`, ground `[20,0.1,20]` at `-10`, recycle `-15`, camera `(0,0,40)` / 45°) — no changes.

## Next (incremental)

- oimo / ammo / cannon eraser samples — align count (→200), gravity, ground, spawn, camera.
- WGSL compute eraser samples (babylonjs, webgpu) — replace the small ramp scene with the flat 20×20 layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)