### PR TITLE
Align WebGL1 + Oimo Eraser with the flat-floor reference

### DIFF
--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -245,8 +245,19 @@ gl.bindBuffer(gl.ARRAY_BUFFER, eraserPosVBO);
 gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, eraserIBO);
 
-let world = new OIMO.World();
-world.gravity = new OIMO.Vec3(0, -9.8, 0);
+// Configure the world like the other Oimo samples. The bare `new OIMO.World()` keeps Oimo's
+// defaults (notably worldscale 100), which runs the simulation in 1/100-scale space; with the
+// dense overflowing pile it never settles and stays very expensive. Match glboost/oimo:
+// worldscale 1, sweep-and-prune broadphase, a fixed 1/60 step and 8 iterations.
+let world = new OIMO.World({
+    timestep: 1 / 60,
+    iterations: 8,
+    broadphase: 2, // 1 brute force, 2 sweep and prune, 3 volume tree
+    worldscale: 1,
+    random: true,
+    info: false,
+    gravity: [0, -9.8, 0]
+});
 
 // Spawn x,z in +/-6 and y in 14..28, matching the other eraser samples.
 let genPosition = function () {

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -74,9 +74,9 @@ gl.uniformMatrix4fv(
     perspective(45, c.width / c.height, 0.1, 1000.0)
 );
 
-let w = 1.0;
-let h = 0.2;
-let d = 0.5;
+let w = 1.2;
+let h = 0.3;
+let d = 0.6;
 let position = new Float32Array([
         // Front face
         -w, -h,  d, // v0
@@ -178,7 +178,7 @@ for (let i = 0; i < strides.length; i++) {
     gl.enableVertexAttribArray(i);
 }
 
-let max = 300;
+let max = 200;
 let posStride = 3;
 let rotStride = 4;
 let posBuffer =  gl.createBuffer();
@@ -246,18 +246,17 @@ gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, eraserIBO);
 
 let world = new OIMO.World();
-world.gravity = new OIMO.Vec3(0, -0.98, 0);
+world.gravity = new OIMO.Vec3(0, -9.8, 0);
 
+// Spawn x,z in +/-6 and y in 14..28, matching the other eraser samples.
 let genPosition = function () {
-    let p = new OIMO.Vec3(Math.random() - 0.5, Math.random() + 1 , Math.random() - 0.5);
-    p = new OIMO.Vec3().scale(p, 15);
-    return p;
+    return new OIMO.Vec3((Math.random() - 0.5) * 12, 14 + Math.random() * 14, (Math.random() - 0.5) * 12);
 };
 
-//let ground = new OIMO.Body({size:[13, 0.1, 13], pos:[0, -10, 0], world:world});
+// Small low floor (no walls), matching the other eraser samples: a 20 x 0.1 x 20 slab at y = -10.
 let ground = world.add({
         type: "box",
-        size: [13, 0.1, 13],
+        size: [20, 0.1, 20],
         pos:[0, -10, 0],
         rot: [0, 0, 0],
         move: false,
@@ -332,7 +331,7 @@ animate();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, boxWireIB);
     let wm = mat4.create();
     let gp = ground.getPosition();
-    mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [13, 0.1, 13]);
+    mat4.fromRotationTranslationScale(wm, [0,0,0,1], [gp.x, gp.y, gp.z], [20, 0.1, 20]);
     gl.uniformMatrix4fv(lineModelLoc, false, wm);
     gl.uniform4fv(lineColorLoc, [0, 1, 0, 1]);
     if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);


### PR DESCRIPTION
Standardises the WebGL1 + Oimo **Falling Eraser** sample on the shared flat-floor look (reference: `webgl2/havok/eraser`), so it can be compared side-by-side with the other eraser cells.

## Changes
- **200 erasers** sized **[2.4, 0.6, 1.2]** (was 300 at [2.0, 0.4, 1.0]).
- **Floor 20 x 0.1 x 20 at y = -10** for both the physics body and the debug wireframe (was 13 x 0.1 x 13).
- **Gravity -9.8** (was -0.98, which made the erasers fall ~10x too slowly).
- **Spawn** x,z in ±6 and y in 14..28 (was ±7.5 / 15..30); recycle below y = -15 unchanged.
- Camera (eye at (0,0,40), 45° FOV looking at the origin) already matched the reference.

Note: this raw WebGL1 sample has no solid floor mesh (the floor is only the physics body + the W-toggle wireframe); that pre-existing behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)