### PR TITLE
Give the WGSL compute Eraser a small bounce on landing

### DIFF
--- a/examples/babylonjs/wgsl_compute/eraser/index.js
+++ b/examples/babylonjs/wgsl_compute/eraser/index.js
@@ -383,7 +383,7 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     var leverSum = vec3<f32>(0.0);
 
     // Floor (static).
-    var r = collide(pos, vel, angVel, axA, GROUND_C, vec3<f32>(0.0), identity, GROUND_HE, 1.0, 1.0, 0.0, 0.5);
+    var r = collide(pos, vel, angVel, axA, GROUND_C, vec3<f32>(0.0), identity, GROUND_HE, 1.0, 1.0, 0.2, 0.5);
     pos += r.dPos; vel += r.dVel; angVel += r.dAng; contacts += r.hit; leverSum += r.lever;
 
     // Eraser-eraser (read neighbours from the previous state). Against an already-sleeping
@@ -392,7 +392,7 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         if (j == i) { continue; }
         let o = srcStates[j];
         let push = select(0.5, 1.0, o.velocity.w >= SLEEP_TIME);
-        r = collide(pos, vel, angVel, axA, o.position.xyz, o.velocity.xyz, quatToAxes(o.rotation), EHE, push, 0.5, 0.0, 0.45);
+        r = collide(pos, vel, angVel, axA, o.position.xyz, o.velocity.xyz, quatToAxes(o.rotation), EHE, push, 0.5, 0.1, 0.45);
         pos += r.dPos; vel += r.dVel; angVel += r.dAng; contacts += r.hit; leverSum += r.lever;
     }
 
@@ -407,7 +407,7 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     if (contacts > 0.0) {
         let rAvg = leverSum / contacts;
         angVel += cross(-rAvg, vec3<f32>(0.0, -params.gravity, 0.0)) * (params.dt * GTIP);
-        angVel *= 0.9;
+        angVel *= 0.95;
         if (length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG) {
             sleepTimer += params.dt;
         } else {

--- a/examples/webgpu/wgsl_compute/eraser/index.js
+++ b/examples/webgpu/wgsl_compute/eraser/index.js
@@ -363,14 +363,14 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     var contacts = 0.0;
     var leverSum = vec3<f32>(0.0);
 
-    var r = collide(pos, vel, angVel, axA, GROUND_C, vec3<f32>(0.0), identity, GROUND_HE, 1.0, 1.0, 0.0, 0.5);
+    var r = collide(pos, vel, angVel, axA, GROUND_C, vec3<f32>(0.0), identity, GROUND_HE, 1.0, 1.0, 0.2, 0.5);
     pos += r.dPos; vel += r.dVel; angVel += r.dAng; contacts += r.hit; leverSum += r.lever;
 
     for (var j = 0u; j < COUNT; j++) {
         if (j == i) { continue; }
         let o = srcStates[j];
         let push = select(0.5, 1.0, o.velocity.w >= SLEEP_TIME);
-        r = collide(pos, vel, angVel, axA, o.position.xyz, o.velocity.xyz, quatToAxes(o.rotation), EHE, push, 0.5, 0.0, 0.45);
+        r = collide(pos, vel, angVel, axA, o.position.xyz, o.velocity.xyz, quatToAxes(o.rotation), EHE, push, 0.5, 0.1, 0.45);
         pos += r.dPos; vel += r.dVel; angVel += r.dAng; contacts += r.hit; leverSum += r.lever;
     }
 
@@ -381,7 +381,7 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     if (contacts > 0.0) {
         let rAvg = leverSum / contacts;
         angVel += cross(-rAvg, vec3<f32>(0.0, -params.gravity, 0.0)) * (params.dt * GTIP);
-        angVel *= 0.9;
+        angVel *= 0.95;
         if (length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG) {
             sleepTimer += params.dt;
         } else {


### PR DESCRIPTION
The WGSL eraser solver used **restitution 0** for both the floor and eraser-eraser contacts (and damped angular velocity hard on contact), so erasers did not bounce at all and stopped dead the instant they touched the floor — unlike the other eraser samples, which bounce and tumble a little.

## Fix
- **Floor restitution 0 → 0.2** and **eraser-eraser restitution 0 → 0.1**, matching the Oimo/Havok eraser samples (restitution ~0.1–0.2).
- Soften the per-contact angular damping (`0.9 → 0.95`) so erasers tumble briefly as they land instead of freezing immediately.

The per-substep drag, sleep thresholds and the rest of the solver tuning are unchanged, so the pile still settles. Applied identically to `webgpu/wgsl_compute/eraser` and `babylonjs/wgsl_compute/eraser`.

Note: GPU-only sim I can't run here — if it now bounces too much or the pile jitters without settling, the restitution (0.2 / 0.1) can be dialed back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)