### PR TITLE
Stop the WGSL eraser pile from clumping / settling too slowly

### DIFF
--- a/examples/babylonjs/wgsl_compute/eraser/index.js
+++ b/examples/babylonjs/wgsl_compute/eraser/index.js
@@ -277,24 +277,24 @@ struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:ve
 // Angular response is deliberately scaled down: a faithful inertia tensor makes a thin
 // eraser spin violently, so we keep it gentle to read as a rigid box settling.
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
-const ANG_SCALE : f32 = 0.10;
+const ANG_SCALE : f32 = 0.18;
 const PEN_SLOP  : f32 = 0.006;
 const BAUMGARTE : f32 = 0.4;
 const MAX_PUSH  : f32 = 0.06;
 // Sleeping: once a body has been in contact and nearly still for SLEEP_TIME it is frozen
 // (skips integration/response entirely) so a settled pile stops trembling. velocity.w stores
 // the accumulated still-time; SLEEP_TIME (a sentinel) also marks "asleep".
-const WAKE_LIN  : f32 = 0.3;
-const WAKE_ANG  : f32 = 1.2;   // tolerate small residual rocking so a settled box still sleeps (anti-jitter)
+const WAKE_LIN  : f32 = 0.15;
+const WAKE_ANG  : f32 = 0.6;
 const SLEEP_TIME : f32 = 0.4;
 // Gravity torque about the contact: tips an overhanging / edge-balanced box toward a flat
 // rest and vanishes once balanced, so (unlike a forced "align" nudge) it does not keep a
 // settled pile twitching.
 const GTIP : f32 = 4.5;
-// Extra bias toward lying flat (big face down). The gravity-tip torque above vanishes once a box
-// is balanced, so a box left standing on a thin edge (CoM right over the contact) never falls; this
-// rotates the eraser's big-face normal toward vertical so it topples flat.
-const GTIP_FLAT : f32 = 2.5;
+// Gentle bias toward lying flat (big face down): the gravity-tip torque vanishes once a box is
+// balanced, so without this a box can stand on a thin edge. Kept weak so a jumbled pile does not
+// get forced flat (the reference Oimo/Havok piles settle at mixed angles too).
+const GTIP_FLAT : f32 = 1.0;
 
 // Collide this eraser (A) against another OBB (B). pushFactor/impFactor are 1.0 for an
 // immovable static and 0.5 for an eraser-eraser pair (so each takes half). Only the six
@@ -427,10 +427,9 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         let upAxis = axA[1];
         let flatTarget = select(vec3<f32>(0.0, -1.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), upAxis.y >= 0.0);
         angVel += cross(upAxis, flatTarget) * (params.dt * GTIP_FLAT);
-        // Strong damping while resting on the floor so a box settles quickly and stops rocking
-        // (a single contact point can only approximate face support). Airborne motion is untouched.
-        angVel *= 0.85;
-        vel *= 0.92;
+        // Light damping while resting; gentle enough that a forming pile can still slide and
+        // spread out instead of freezing into a sticky clump.
+        angVel *= 0.95;
         if (length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG) {
             sleepTimer += params.dt;
         } else {

--- a/examples/webgpu/wgsl_compute/eraser/index.js
+++ b/examples/webgpu/wgsl_compute/eraser/index.js
@@ -268,18 +268,18 @@ fn satPen(T:vec3<f32>, axA:mat3x3<f32>, heA:vec3<f32>, axB:mat3x3<f32>, heB:vec3
 struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:vec3<f32>, lever:vec3<f32>, }
 
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
-const ANG_SCALE : f32 = 0.10;
+const ANG_SCALE : f32 = 0.18;
 const PEN_SLOP  : f32 = 0.006;
 const BAUMGARTE : f32 = 0.4;
 const MAX_PUSH  : f32 = 0.06;
-const WAKE_LIN  : f32 = 0.3;
-const WAKE_ANG  : f32 = 1.2;   // tolerate small residual rocking so a settled box still sleeps (anti-jitter)
+const WAKE_LIN  : f32 = 0.15;
+const WAKE_ANG  : f32 = 0.6;
 const SLEEP_TIME : f32 = 0.4;
 const GTIP : f32 = 4.5;
-// Extra bias toward lying flat (big face down). The gravity-tip torque above vanishes once a box
-// is balanced, so a box left standing on a thin edge (CoM right over the contact) never falls; this
-// rotates the eraser's big-face normal toward vertical so it topples flat.
-const GTIP_FLAT : f32 = 2.5;
+// Gentle bias toward lying flat (big face down): the gravity-tip torque vanishes once a box is
+// balanced, so without this a box can stand on a thin edge. Kept weak so a jumbled pile does not
+// get forced flat (the reference Oimo/Havok piles settle at mixed angles too).
+const GTIP_FLAT : f32 = 1.0;
 
 // Collide this eraser (A) against another OBB (B). Only the six face normals are used as
 // separating axes (no edge cross-products), so the contact normal is a stable face direction.
@@ -402,10 +402,9 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         let upAxis = axA[1];
         let flatTarget = select(vec3<f32>(0.0, -1.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), upAxis.y >= 0.0);
         angVel += cross(upAxis, flatTarget) * (params.dt * GTIP_FLAT);
-        // Strong damping while resting on the floor so a box settles quickly and stops rocking
-        // (a single contact point can only approximate face support). Airborne motion is untouched.
-        angVel *= 0.85;
-        vel *= 0.92;
+        // Light damping while resting; gentle enough that a forming pile can still slide and
+        // spread out instead of freezing into a sticky clump.
+        angVel *= 0.95;
         if (length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG) {
             sleepTimer += params.dt;
         } else {

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -294,18 +294,18 @@ fn satPen(T:vec3<f32>, axA:mat3x3<f32>, heA:vec3<f32>, axB:mat3x3<f32>, heB:vec3
 struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:vec3<f32>, lever:vec3<f32>, }
 
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
-const ANG_SCALE : f32 = 0.10;
+const ANG_SCALE : f32 = 0.18;
 const PEN_SLOP  : f32 = 0.006;
 const BAUMGARTE : f32 = 0.4;
 const MAX_PUSH  : f32 = 0.06;
-const WAKE_LIN  : f32 = 0.3;
-const WAKE_ANG  : f32 = 1.2;   // tolerate small residual rocking so a settled box still sleeps (anti-jitter)
+const WAKE_LIN  : f32 = 0.15;
+const WAKE_ANG  : f32 = 0.6;
 const SLEEP_TIME : f32 = 0.4;
 const GTIP : f32 = 4.5;
-// Extra bias toward lying flat (big face down). The gravity-tip torque above vanishes once a box
-// is balanced, so a box left standing on a thin edge (CoM right over the contact) never falls; this
-// rotates the eraser's big-face normal toward vertical so it topples flat.
-const GTIP_FLAT : f32 = 2.5;
+// Gentle bias toward lying flat (big face down): the gravity-tip torque vanishes once a box is
+// balanced, so without this a box can stand on a thin edge. Kept weak so a jumbled pile does not
+// get forced flat (the reference Oimo/Havok piles settle at mixed angles too).
+const GTIP_FLAT : f32 = 1.0;
 
 // Collide this eraser (A) against another OBB (B). Only the six face normals are used as
 // separating axes (no edge cross-products), so the contact normal is a stable face direction.
@@ -428,10 +428,9 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
         let upAxis = axA[1];
         let flatTarget = select(vec3<f32>(0.0, -1.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), upAxis.y >= 0.0);
         angVel += cross(upAxis, flatTarget) * (params.dt * GTIP_FLAT);
-        // Strong damping while resting on the floor so a box settles quickly and stops rocking
-        // (a single contact point can only approximate face support). Airborne motion is untouched.
-        angVel *= 0.85;
-        vel *= 0.92;
+        // Light damping while resting; gentle enough that a forming pile can still slide and
+        // spread out instead of freezing into a sticky clump.
+        angVel *= 0.95;
         if (length(vel) < WAKE_LIN && length(angVel) < WAKE_ANG) {
             sleepTimer += params.dt;
         } else {


### PR DESCRIPTION
The 200-eraser WebGPU + WGSL pile was clumping together (erasers looked glued, the heap grew into a tall sticky tower) and erasers seemed slow to fall.

**Cause:** the previous settling pass was tuned on a *single* eraser and was far too aggressive for the full pile — strong in-contact damping (`angVel *= 0.85`, `vel *= 0.92`) plus eager sleep (`WAKE_LIN/ANG` raised to 0.3 / 1.2) drained the relative velocity between neighbouring erasers and froze them the moment they touched, so the pile stuck together and built upward instead of spreading and falling.

**Fix — back those out so a forming pile can slide and spread:**
- Remove the linear contact damping (no `vel *= 0.92`); angVel contact damping `0.85 → 0.95`.
- `WAKE_LIN 0.3 → 0.15`, `WAKE_ANG 1.2 → 0.6` (don't sleep bodies still moving in the pile).
- `ANG_SCALE 0.10 → 0.18` so erasers tumble off each other naturally.
- `GTIP_FLAT 2.5 → 1.0`: keep only a gentle flatten bias — the reference Oimo/Havok piles settle at mixed angles, so don't force them flat.

The genuine bug fixes already in master (contact-lever support point, airborne tumble, speed-gated restitution, leaky sleep) are kept. Applied to both eraser samples and the `eraser_debug` diagnostic.

Note: GPU-only sim I can't run here. This trades the very-clean single-eraser settle for a natural, spreading pile (a little residual jitter is fine and matches the other engines). If the pile now looks good but you still want crisper isolated settling, that can be re-added behind a "mostly at rest" gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)