### PR TITLE
Reduce the WGSL eraser trembling where erasers overlap in the pile

### DIFF
--- a/examples/babylonjs/wgsl_compute/eraser/index.js
+++ b/examples/babylonjs/wgsl_compute/eraser/index.js
@@ -278,14 +278,16 @@ struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:ve
 // eraser spin violently, so we keep it gentle to read as a rigid box settling.
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
 const ANG_SCALE : f32 = 0.18;
-const PEN_SLOP  : f32 = 0.006;
-const BAUMGARTE : f32 = 0.4;
+// Soft resting contact: tolerate a small overlap (PEN_SLOP) and push out gently (BAUMGARTE), so
+// stacked erasers don't get shoved apart and pulled back every frame (the "trembling" at overlaps).
+const PEN_SLOP  : f32 = 0.02;
+const BAUMGARTE : f32 = 0.25;
 const MAX_PUSH  : f32 = 0.06;
-// Sleeping: once a body has been in contact and nearly still for SLEEP_TIME it is frozen
-// (skips integration/response entirely) so a settled pile stops trembling. velocity.w stores
-// the accumulated still-time; SLEEP_TIME (a sentinel) also marks "asleep".
-const WAKE_LIN  : f32 = 0.15;
-const WAKE_ANG  : f32 = 0.6;
+// Sleeping: once a body has been in contact and nearly still for SLEEP_TIME it is frozen (skips
+// integration/response entirely) so a settled pile stops trembling. Thresholds are raised a little
+// (with the leaky timer below) so a box still sleeps through small residual rocking.
+const WAKE_LIN  : f32 = 0.2;
+const WAKE_ANG  : f32 = 1.0;
 const SLEEP_TIME : f32 = 0.4;
 // Gravity torque about the contact: tips an overhanging / edge-balanced box toward a flat
 // rest and vanishes once balanced, so (unlike a forced "align" nudge) it does not keep a

--- a/examples/webgpu/wgsl_compute/eraser/index.js
+++ b/examples/webgpu/wgsl_compute/eraser/index.js
@@ -269,11 +269,15 @@ struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:ve
 
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
 const ANG_SCALE : f32 = 0.18;
-const PEN_SLOP  : f32 = 0.006;
-const BAUMGARTE : f32 = 0.4;
+// Soft resting contact: tolerate a small overlap (PEN_SLOP) and push out gently (BAUMGARTE), so
+// stacked erasers don't get shoved apart and pulled back every frame (the "trembling" at overlaps).
+const PEN_SLOP  : f32 = 0.02;
+const BAUMGARTE : f32 = 0.25;
 const MAX_PUSH  : f32 = 0.06;
-const WAKE_LIN  : f32 = 0.15;
-const WAKE_ANG  : f32 = 0.6;
+// Sleep thresholds raised a little (with the leaky timer below) so a resting box still falls
+// asleep through the small residual rocking a single contact point leaves.
+const WAKE_LIN  : f32 = 0.2;
+const WAKE_ANG  : f32 = 1.0;
 const SLEEP_TIME : f32 = 0.4;
 const GTIP : f32 = 4.5;
 // Gentle bias toward lying flat (big face down): the gravity-tip torque vanishes once a box is

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -295,11 +295,15 @@ struct Resp { dPos:vec3<f32>, dVel:vec3<f32>, dAng:vec3<f32>, hit:f32, normal:ve
 
 // Full-scale solver tuning shared with the WGSL shogi sample (the same OBB solver at this scale).
 const ANG_SCALE : f32 = 0.18;
-const PEN_SLOP  : f32 = 0.006;
-const BAUMGARTE : f32 = 0.4;
+// Soft resting contact: tolerate a small overlap (PEN_SLOP) and push out gently (BAUMGARTE), so
+// stacked erasers don't get shoved apart and pulled back every frame (the "trembling" at overlaps).
+const PEN_SLOP  : f32 = 0.02;
+const BAUMGARTE : f32 = 0.25;
 const MAX_PUSH  : f32 = 0.06;
-const WAKE_LIN  : f32 = 0.15;
-const WAKE_ANG  : f32 = 0.6;
+// Sleep thresholds raised a little (with the leaky timer below) so a resting box still falls
+// asleep through the small residual rocking a single contact point leaves.
+const WAKE_LIN  : f32 = 0.2;
+const WAKE_ANG  : f32 = 1.0;
 const SLEEP_TIME : f32 = 0.4;
 const GTIP : f32 = 4.5;
 // Gentle bias toward lying flat (big face down): the gravity-tip torque vanishes once a box is


### PR DESCRIPTION
Where erasers overlap/stack in the settled pile they trembled: a single contact point plus a stiff position push-out shoved overlapping boxes apart every frame, gravity pulled them back, and the residual motion kept them from sleeping.

**Fix — soften resting contacts and let settled boxes sleep through the residue, without re-introducing the tangential damping that made the pile clump:**
- `PEN_SLOP 0.006 → 0.02` — ignore tiny overlaps instead of correcting them.
- `BAUMGARTE 0.4 → 0.25` — push out more gently (less overshoot/oscillation).
- `WAKE_LIN/ANG 0.15/0.6 → 0.2/1.0` — with the existing leaky sleep timer, a resting box still falls asleep through small residual rocking.

No change to the contact response or sliding, so the pile still spreads and falls normally (the clump fix from #394 stands). Applied to both eraser samples and `eraser_debug`.

Note: GPU-only sim I can't run here. If a little overlap is now visible at rest that is the softer contact (cheaper than the trembling); if trembling persists I can push `BAUMGARTE` lower or bias the contact toward a deeper-sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)