### PR TITLE
Steady the top of the WGSL eraser stack with more solver iterations

### DIFF
--- a/examples/babylonjs/wgsl_compute/eraser/index.js
+++ b/examples/babylonjs/wgsl_compute/eraser/index.js
@@ -23,7 +23,7 @@ const ERASER_TEXTURES = [
 
 const ERASER_COUNT = 200;
 const STATE_FLOATS = 16;
-const SUBSTEPS = 5;
+const SUBSTEPS = 8;   // more solver iterations per frame so deep stacks converge (top stops trembling)
 const EHE = [1.2, 0.3, 0.6];  // eraser half-extents (2.4 x 0.6 x 1.2), matching the reference eraser samples
 
 // Static collider: a small low floor (no walls, no ramp), matching the flat-floor reference

--- a/examples/webgpu/wgsl_compute/eraser/index.js
+++ b/examples/webgpu/wgsl_compute/eraser/index.js
@@ -21,7 +21,7 @@ const ERASER_TEXTURES = [
 
 const ERASER_COUNT = 200;
 const STATE_FLOATS = 16;
-const SUBSTEPS = 5;
+const SUBSTEPS = 8;   // more solver iterations per frame so deep stacks converge (top stops trembling)
 const EHE = [1.2, 0.3, 0.6];  // eraser half-extents (2.4 x 0.6 x 1.2), matching the reference eraser samples
 
 // Static collider: a small low floor (no walls, no ramp), matching the flat-floor reference

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -21,7 +21,7 @@ const ERASER_TEXTURES = [
 const ERASER_COUNT = 5;   // DEBUG: a few erasers for problem isolation (restore to 200 afterwards)
 const DEBUG = ERASER_COUNT <= 8;   // when on, read the state back each frame and graph it on-screen
 const STATE_FLOATS = 16;
-const SUBSTEPS = 5;
+const SUBSTEPS = 8;   // more solver iterations per frame so deep stacks converge (top stops trembling)
 const EHE = [1.2, 0.3, 0.6];  // eraser half-extents (2.4 x 0.6 x 1.2), matching the reference eraser samples
 
 // Static collider: a small low floor (no walls, no ramp), matching the flat-floor reference


### PR DESCRIPTION
The bottom of the eraser pile (anchored by the static floor) settles, but the **top of a multi-layer stack kept trembling**.

**Cause:** the solver runs a single Jacobi-style contact pass per substep against the neighbours' *previous* positions. That converges slowly for deep stacks, so the upper layers never quite come to rest and never sleep — they quiver on a support that is itself still adjusting.

**Fix:** raise `SUBSTEPS 5 → 8` — more (finer) iterations per frame let a deep stack converge, so the upper erasers settle and fall asleep instead of trembling. The total per-frame timestep is unchanged (`1/(60*SUBSTEPS)` per substep); only the GPU cost goes up modestly. Applied to both eraser samples and `eraser_debug`.

Note: GPU-only sim I can't run here. If the top still trembles, the next step is to bump SUBSTEPS further or let the upper layers sleep more readily once the stack below them is asleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)