### PR TITLE
Add an eraser-count control to the eraser_debug samples

### DIFF
--- a/examples/webgpu/havok/eraser_debug/index.html
+++ b/examples/webgpu/havok/eraser_debug/index.html
@@ -125,6 +125,7 @@ fn main() -> @location(0) vec4<f32> {
 <canvas id="c" width="465" height="465"></canvas>
 
 <div id="hint">W: wireframe ON</div>
+<script src="https://cdn.jsdelivr.net/npm/lil-gui@0.20"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/havok/eraser_debug/index.js
+++ b/examples/webgpu/havok/eraser_debug/index.js
@@ -31,7 +31,10 @@ let showWireframe = true;
 let debugBoxVertexBuffer, debugBoxIndexBuffer, debugBoxIndexCount = 0;
 let lineUniformBuffer, lineBindGroup, lineUniformData, eraserLineModel = null;
 
-const MAX = 5;   // DEBUG: a few probe erasers (restore to 200 for the normal scene)
+// DEBUG: eraser count is chosen from the control panel (which reloads with ?count=N). The first
+// PROBE_COUNT erasers use fixed probe poses and are graphed; any extra ones form a random pile.
+const MAX = Math.max(1, Math.min(500, parseInt(new URLSearchParams(location.search).get('count'), 10) || 5));
+const PROBE_COUNT = Math.min(MAX, 5);
 const NUM_LINE_OBJECTS = MAX + 1;
 
 // DEBUG: 5 erasers dropped from known poses (matches the WGSL eraser_debug), plus on-screen graphs.
@@ -45,8 +48,8 @@ const DEBUG_SETUP = [
     { x:  6, eul: [0.5, 0.5, 0.5], w: [3, 3, 3] },   // full tumble, far out
 ];
 let debugCanvas = null, debugCtx = null, debugStartTime = 0, debugPrevT = 0;
-const debugSamples = Array.from({ length: MAX }, () => []);  // per eraser: {t, tilt, w, y}
-const debugPrevQuat = Array.from({ length: MAX }, () => null);
+const debugSamples = Array.from({ length: PROBE_COUNT }, () => []);  // per probe eraser: {t, tilt, w, y}
+const debugPrevQuat = Array.from({ length: PROBE_COUNT }, () => null);
 
 function quatFromEuler(x, y, z) {
     const cx = Math.cos(x * 0.5), sx = Math.sin(x * 0.5);
@@ -166,6 +169,7 @@ async function createEraserAtlasTexture() {
 }
 
 async function init() {
+    createDebugControls();
     canvas = document.getElementById('c');
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
@@ -299,11 +303,17 @@ async function init() {
 
     bodies = [];
     for (let i = 0; i < MAX; i++) {
-        // DEBUG: deterministic pose so the post-landing settling is reproducible.
-        const s = DEBUG_SETUP[i % DEBUG_SETUP.length];
-        const q = quatFromEuler(s.eul[0], s.eul[1], s.eul[2]);
-        bodies[i] = createBody(eraserShape, HK.MotionType.DYNAMIC, [s.x, 14, 0], q, true);
-        HK.HP_Body_SetAngularVelocity(bodies[i], s.w);
+        if (i < PROBE_COUNT) {
+            // DEBUG: deterministic probe pose (graphed) so the post-landing settling is reproducible.
+            const s = DEBUG_SETUP[i];
+            const q = quatFromEuler(s.eul[0], s.eul[1], s.eul[2]);
+            bodies[i] = createBody(eraserShape, HK.MotionType.DYNAMIC, [s.x, 14, 0], q, true);
+            HK.HP_Body_SetAngularVelocity(bodies[i], s.w);
+        } else {
+            // Extra erasers form a random pile around the probes.
+            const p = genPosition();
+            bodies[i] = createBody(eraserShape, HK.MotionType.DYNAMIC, [p.x, p.y, p.z], randomQuaternion(), true);
+        }
     }
     debugStartTime = performance.now();
 
@@ -497,7 +507,7 @@ function render() {
     // back to finite-differencing the orientation if this build doesn't expose the getter - that
     // fallback is noisy because its step is the variable render interval, not the physics step.
     const hasAngVelApi = typeof HK.HP_Body_GetAngularVelocity === 'function';
-    for (let i = 0; i < MAX; i++) {
+    for (let i = 0; i < PROBE_COUNT; i++) {
         const p = HK.HP_Body_GetPosition(bodies[i])[1];
         const q = HK.HP_Body_GetOrientation(bodies[i])[1];
         let wMag;
@@ -524,6 +534,28 @@ function render() {
     requestAnimationFrame(render);
 }
 
+// DEBUG: a small control panel to pick how many erasers to drop. Changing it reloads the page with
+// ?count=N (a clean full re-init); the first 5 stay fixed probe poses, the rest form a pile.
+function createDebugControls() {
+    const wrap = document.createElement('div');
+    Object.assign(wrap.style, {
+        position: 'fixed', left: '8px', top: '36px', zIndex: 9999,
+        font: '13px monospace', color: '#0f0', background: 'rgba(0,0,0,0.45)',
+        padding: '4px 8px', borderRadius: '4px',
+    });
+    wrap.appendChild(document.createTextNode('Erasers: '));
+    const sel = document.createElement('select');
+    [1, 5, 10, 20, 50, 100, 200].forEach((n) => {
+        const o = document.createElement('option');
+        o.value = String(n); o.textContent = String(n);
+        if (n === MAX) o.selected = true;
+        sel.appendChild(o);
+    });
+    sel.addEventListener('change', () => { location.search = '?count=' + sel.value; });
+    wrap.appendChild(sel);
+    document.body.appendChild(wrap);
+}
+
 // DEBUG: three stacked time-series graphs (tilt angle, |angVel|, height) on a 2D overlay canvas,
 // so the post-landing behaviour is visible without console logs (matches the WGSL eraser_debug).
 function drawDebugViz() {
@@ -545,7 +577,7 @@ function drawDebugViz() {
 
     // Legend
     let lx = 10;
-    for (let k = 0; k < MAX; k++) {
+    for (let k = 0; k < PROBE_COUNT; k++) {
         ctx.fillStyle = DEBUG_COLORS[k];
         ctx.fillRect(lx, 6, 10, 10);
         ctx.fillText(DEBUG_LABELS[k], lx + 13, 12);
@@ -579,7 +611,7 @@ function drawDebugViz() {
             ctx.strokeStyle = '#00ff9988'; ctx.setLineDash([4, 3]); ctx.beginPath();
             ctx.moveTo(x0, vy(p.guide)); ctx.lineTo(x0 + pw, vy(p.guide)); ctx.stroke(); ctx.setLineDash([]);
         }
-        for (let k = 0; k < MAX; k++) {
+        for (let k = 0; k < PROBE_COUNT; k++) {
             const s = debugSamples[k];
             ctx.strokeStyle = DEBUG_COLORS[k]; ctx.lineWidth = 1.5; ctx.beginPath();
             let started = false;

--- a/examples/webgpu/havok/eraser_debug/index.js
+++ b/examples/webgpu/havok/eraser_debug/index.js
@@ -534,26 +534,16 @@ function render() {
     requestAnimationFrame(render);
 }
 
-// DEBUG: a small control panel to pick how many erasers to drop. Changing it reloads the page with
+// DEBUG: lil-gui control panel to pick how many erasers to drop. Changing it reloads the page with
 // ?count=N (a clean full re-init); the first 5 stay fixed probe poses, the rest form a pile.
 function createDebugControls() {
-    const wrap = document.createElement('div');
-    Object.assign(wrap.style, {
-        position: 'fixed', left: '8px', top: '36px', zIndex: 9999,
-        font: '13px monospace', color: '#0f0', background: 'rgba(0,0,0,0.45)',
-        padding: '4px 8px', borderRadius: '4px',
-    });
-    wrap.appendChild(document.createTextNode('Erasers: '));
-    const sel = document.createElement('select');
-    [1, 5, 10, 20, 50, 100, 200].forEach((n) => {
-        const o = document.createElement('option');
-        o.value = String(n); o.textContent = String(n);
-        if (n === MAX) o.selected = true;
-        sel.appendChild(o);
-    });
-    sel.addEventListener('change', () => { location.search = '?count=' + sel.value; });
-    wrap.appendChild(sel);
-    document.body.appendChild(wrap);
+    if (!window.lil || !window.lil.GUI) return;   // CDN not available
+    const gui = new lil.GUI({ title: 'Debug' });
+    // Move it under the wireframe hint (top-left); the graph overlay already sits top-right.
+    Object.assign(gui.domElement.style, { left: '8px', right: 'auto', top: '40px' });
+    const params = { erasers: MAX };
+    gui.add(params, 'erasers', [1, 5, 10, 20, 50, 100, 200]).name('Erasers')
+        .onChange((v) => { location.search = '?count=' + v; });
 }
 
 // DEBUG: three stacked time-series graphs (tilt angle, |angVel|, height) on a 2D overlay canvas,

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.html
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.html
@@ -9,6 +9,7 @@
 <canvas id="c"></canvas>
 <div id="hint">W: wireframe ON</div>
 
+<script src="https://cdn.jsdelivr.net/npm/lil-gui@0.20"></script>
 <script src="index.js"></script>
 </body>
 </html>

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -18,8 +18,11 @@ const ERASER_TEXTURES = [
     '../../../../assets/textures/eraser_003/eraser_back.png',
 ];
 
-const ERASER_COUNT = 5;   // DEBUG: a few erasers for problem isolation (restore to 200 afterwards)
-const DEBUG = ERASER_COUNT <= 8;   // when on, read the state back each frame and graph it on-screen
+// DEBUG: eraser count is chosen from the control panel (which reloads with ?count=N). The first
+// PROBE_COUNT erasers use fixed probe poses and are graphed; any extra ones form a random pile.
+const ERASER_COUNT = Math.max(1, Math.min(500, parseInt(new URLSearchParams(location.search).get('count'), 10) || 5));
+const PROBE_COUNT = Math.min(ERASER_COUNT, 5);
+const DEBUG = true;
 const STATE_FLOATS = 16;
 const SUBSTEPS = 8;   // more solver iterations per frame so deep stacks converge (top stops trembling)
 const EHE = [1.2, 0.3, 0.6];  // eraser half-extents (2.4 x 0.6 x 1.2), matching the reference eraser samples
@@ -157,52 +160,45 @@ function hashF(n) { return (hash32(n) & 0xffffff) / 0xffffff; }
 const DEBUG_COLORS = ['#ff5555', '#55dd55', '#5599ff', '#ffaa33', '#ff66dd'];
 const DEBUG_LABELS = ['flat x=-6', 'flat x=0', 'tilt45 x=4', 'yaw x=-3', 'tumble x=6'];
 
+// The first 5 erasers use these fixed probe poses (graphed); these match DEBUG_LABELS/COLORS.
+const DEBUG_PROBES = [
+    { x: -6, eul: [0.0, 0.0, 0.0], w: [0, 0, 0] },   // flat, far out
+    { x:  0, eul: [0.0, 0.0, 0.0], w: [0, 0, 0] },   // flat, centre (baseline)
+    { x:  4, eul: [0.8, 0.0, 0.0], w: [0, 0, 0] },   // tilted ~46 deg, should tip flat
+    { x: -3, eul: [0.0, 0.0, 0.0], w: [0, 4, 0] },   // flat + yaw spin
+    { x:  6, eul: [0.5, 0.5, 0.5], w: [3, 3, 3] },   // full tumble, far out
+];
+
 function createInitialStates() {
     const states = new Float32Array(ERASER_COUNT * STATE_FLOATS);
-
-    // DEBUG: 5 erasers dropped from known poses to probe the *post-landing* settling. Spread
-    // across x so we can see whether position still affects the landing (the old contact-lever bug).
-    if (DEBUG && ERASER_COUNT <= 8) {
-        const setup = [
-            { x: -6, eul: [0.0, 0.0, 0.0], w: [0, 0, 0] },   // flat, far out
-            { x:  0, eul: [0.0, 0.0, 0.0], w: [0, 0, 0] },   // flat, centre (baseline)
-            { x:  4, eul: [0.8, 0.0, 0.0], w: [0, 0, 0] },   // tilted ~46 deg, should tip flat
-            { x: -3, eul: [0.0, 0.0, 0.0], w: [0, 4, 0] },   // flat + yaw spin
-            { x:  6, eul: [0.5, 0.5, 0.5], w: [3, 3, 3] },   // full tumble, far out
-        ];
-        for (let i = 0; i < ERASER_COUNT; i++) {
-            const s = setup[i % setup.length];
-            const base = i * STATE_FLOATS;
+    for (let i = 0; i < ERASER_COUNT; i++) {
+        const base = i * STATE_FLOATS;
+        if (i < PROBE_COUNT) {
+            // Known probe pose (graphed), spread across x.
+            const s = DEBUG_PROBES[i];
             const q = quatFromEuler(s.eul[0], s.eul[1], s.eul[2]);
             states[base + 0] = s.x; states[base + 1] = 14; states[base + 2] = 0; states[base + 3] = 0.5;
             states[base + 8] = q[0]; states[base + 9] = q[1]; states[base + 10] = q[2]; states[base + 11] = q[3];
             states[base + 12] = s.w[0]; states[base + 13] = s.w[1]; states[base + 14] = s.w[2];
+        } else {
+            // Extra erasers form a random pile around the probes (random x,z, orientation, tumble).
+            const seed = hash32(i + 1);
+            states[base + 0] = (hashF(seed)     - 0.5) * 12;
+            states[base + 1] = 14 + (i / ERASER_COUNT) * 14 + (hashF(seed + 1) - 0.5) * 2;
+            states[base + 2] = (hashF(seed + 2) - 0.5) * 12;
+            states[base + 3] = hashF(seed + 6);
+            const q = quatFromEuler(
+                (hashF(seed + 7) - 0.5) * Math.PI * 2,
+                (hashF(seed + 8) - 0.5) * Math.PI * 2,
+                (hashF(seed + 9) - 0.5) * Math.PI * 2);
+            states[base + 8]  = q[0];
+            states[base + 9]  = q[1];
+            states[base + 10] = q[2];
+            states[base + 11] = q[3];
+            states[base + 12] = (hashF(seed + 3) - 0.5) * 6;
+            states[base + 13] = (hashF(seed + 4) - 0.5) * 6;
+            states[base + 14] = (hashF(seed + 5) - 0.5) * 6;
         }
-        return states;
-    }
-
-    for (let i = 0; i < ERASER_COUNT; i++) {
-        const base = i * STATE_FLOATS;
-        const seed = hash32(i + 1);
-        // Decorrelate every axis (the old i-based pattern spawned the erasers in neat columns):
-        // random x,z over the floor, a random orientation and a random tumble so they rain down
-        // and settle in a natural jumble. Keep the height loosely stratified by i (plus jitter) so
-        // they do not all overlap at the instant they spawn.
-        states[base + 0] = (hashF(seed)     - 0.5) * 12;                          // x in +/-6
-        states[base + 1] = 14 + (i / ERASER_COUNT) * 14 + (hashF(seed + 1) - 0.5) * 2; // y ~14..28
-        states[base + 2] = (hashF(seed + 2) - 0.5) * 12;                          // z in +/-6
-        states[base + 3] = hashF(seed + 6);                                       // seed (0..1)
-        const q = quatFromEuler(
-            (hashF(seed + 7) - 0.5) * Math.PI * 2,
-            (hashF(seed + 8) - 0.5) * Math.PI * 2,
-            (hashF(seed + 9) - 0.5) * Math.PI * 2);
-        states[base + 8]  = q[0];
-        states[base + 9]  = q[1];
-        states[base + 10] = q[2];
-        states[base + 11] = q[3];
-        states[base + 12] = (hashF(seed + 3) - 0.5) * 6;                          // tumble (angVel)
-        states[base + 13] = (hashF(seed + 4) - 0.5) * 6;
-        states[base + 14] = (hashF(seed + 5) - 0.5) * 6;
     }
     return states;
 }
@@ -558,7 +554,7 @@ let startTime = 0, lastTime = 0;
 let frameCount = 0, lastFpsT = 0, fps = 0;
 // DEBUG: GPU readback + on-screen time-series graphs.
 let debugReadback = null, debugPending = false, debugCanvas = null, debugCtx = null;
-const debugSamples = Array.from({ length: ERASER_COUNT }, () => []);  // per eraser: {t, tilt, w, y}
+const debugSamples = Array.from({ length: PROBE_COUNT }, () => []);  // per probe eraser: {t, tilt, w, y}
 
 function updateCamera(dt) {
     // Fixed head-on camera matching the reference eraser samples: eye at (0,0,40) looking at the
@@ -578,6 +574,28 @@ function resize() {
 
 // DEBUG: draw three stacked time-series graphs (tilt angle, |angVel|, height) for the probe
 // erasers onto a 2D overlay canvas, so the post-landing behaviour is visible without console logs.
+// DEBUG: a small control panel to pick how many erasers to drop. Changing it reloads the page with
+// ?count=N (a clean full re-init); the first 5 stay fixed probe poses, the rest form a pile.
+function createDebugControls() {
+    const wrap = document.createElement('div');
+    Object.assign(wrap.style, {
+        position: 'fixed', left: '8px', top: '36px', zIndex: 9999,
+        font: '13px monospace', color: '#0f0', background: 'rgba(0,0,0,0.45)',
+        padding: '4px 8px', borderRadius: '4px',
+    });
+    wrap.appendChild(document.createTextNode('Erasers: '));
+    const sel = document.createElement('select');
+    [1, 5, 10, 20, 50, 100, 200].forEach((n) => {
+        const o = document.createElement('option');
+        o.value = String(n); o.textContent = String(n);
+        if (n === ERASER_COUNT) o.selected = true;
+        sel.appendChild(o);
+    });
+    sel.addEventListener('change', () => { location.search = '?count=' + sel.value; });
+    wrap.appendChild(sel);
+    document.body.appendChild(wrap);
+}
+
 function drawDebugViz() {
     if (!debugCanvas) {
         debugCanvas = document.createElement('canvas');
@@ -597,7 +615,7 @@ function drawDebugViz() {
 
     // Legend
     let lx = 10;
-    for (let k = 0; k < ERASER_COUNT; k++) {
+    for (let k = 0; k < PROBE_COUNT; k++) {
         ctx.fillStyle = DEBUG_COLORS[k];
         ctx.fillRect(lx, 6, 10, 10);
         ctx.fillText(DEBUG_LABELS[k], lx + 13, 12);
@@ -635,7 +653,7 @@ function drawDebugViz() {
             ctx.moveTo(x0, vy(p.guide)); ctx.lineTo(x0 + pw, vy(p.guide)); ctx.stroke(); ctx.setLineDash([]);
         }
         // series
-        for (let k = 0; k < ERASER_COUNT; k++) {
+        for (let k = 0; k < PROBE_COUNT; k++) {
             const s = debugSamples[k];
             ctx.strokeStyle = DEBUG_COLORS[k]; ctx.lineWidth = 1.5; ctx.beginPath();
             let started = false;
@@ -723,7 +741,7 @@ function render() {
             const a = new Float32Array(debugReadback.getMappedRange()).slice();
             debugReadback.unmap();
             debugPending = false;
-            for (let k = 0; k < ERASER_COUNT; k++) {
+            for (let k = 0; k < PROBE_COUNT; k++) {
                 const o = k * STATE_FLOATS;
                 const qx = a[o + 8], qy = a[o + 9], qz = a[o + 10];
                 // Tilt of the eraser's big face from horizontal: angle of its local up-axis from
@@ -752,6 +770,7 @@ function render() {
 }
 
 async function init() {
+    createDebugControls();
     canvas = document.getElementById('c');
     if (!navigator.gpu) {
         document.getElementById('hint').textContent = 'WebGPU is not available in this browser.';

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -574,26 +574,16 @@ function resize() {
 
 // DEBUG: draw three stacked time-series graphs (tilt angle, |angVel|, height) for the probe
 // erasers onto a 2D overlay canvas, so the post-landing behaviour is visible without console logs.
-// DEBUG: a small control panel to pick how many erasers to drop. Changing it reloads the page with
+// DEBUG: lil-gui control panel to pick how many erasers to drop. Changing it reloads the page with
 // ?count=N (a clean full re-init); the first 5 stay fixed probe poses, the rest form a pile.
 function createDebugControls() {
-    const wrap = document.createElement('div');
-    Object.assign(wrap.style, {
-        position: 'fixed', left: '8px', top: '36px', zIndex: 9999,
-        font: '13px monospace', color: '#0f0', background: 'rgba(0,0,0,0.45)',
-        padding: '4px 8px', borderRadius: '4px',
-    });
-    wrap.appendChild(document.createTextNode('Erasers: '));
-    const sel = document.createElement('select');
-    [1, 5, 10, 20, 50, 100, 200].forEach((n) => {
-        const o = document.createElement('option');
-        o.value = String(n); o.textContent = String(n);
-        if (n === ERASER_COUNT) o.selected = true;
-        sel.appendChild(o);
-    });
-    sel.addEventListener('change', () => { location.search = '?count=' + sel.value; });
-    wrap.appendChild(sel);
-    document.body.appendChild(wrap);
+    if (!window.lil || !window.lil.GUI) return;   // CDN not available
+    const gui = new lil.GUI({ title: 'Debug' });
+    // Move it under the FPS hint (top-left); the graph overlay already sits top-right.
+    Object.assign(gui.domElement.style, { left: '8px', right: 'auto', top: '40px' });
+    const params = { erasers: ERASER_COUNT };
+    gui.add(params, 'erasers', [1, 5, 10, 20, 50, 100, 200]).name('Erasers')
+        .onChange((v) => { location.search = '?count=' + v; });
 }
 
 function drawDebugViz() {

--- a/examples/webgpu/wgsl_compute/eraser_debug/style.css
+++ b/examples/webgpu/wgsl_compute/eraser_debug/style.css
@@ -3,6 +3,11 @@
   padding: 0;
   border: 0;
   overflow: hidden;
+}
+
+/* Only the canvas fills the window; scoping this here (instead of `*`) keeps the
+   lil-gui debug panel from being stretched to full height. */
+html, body, #c {
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
Lets you test the eraser settling with different counts straight from the page.

Both `eraser_debug` samples (WGSL compute and Havok) now read the eraser count from a `?count=N` query param, chosen from a small **"Erasers:"** dropdown (1 / 5 / 10 / 20 / 50 / 100 / 200) that reloads the page (a clean full re-init).

- The **first 5** erasers keep the fixed probe poses (flat ×2, 46° tilt, yaw spin, full tumble) and are the ones graphed.
- Any **extra** erasers spawn at random to form a pile around the probes.

So you can watch a probe settle either alone (`count=5`) or buried inside a crowd of N (`count=50`, `200`, …). Default is 5 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)