### PR TITLE
Fix the Oimo shogi collider being twice the mesh size

### DIFF
--- a/examples/webgl1/oimo/shogi/index.js
+++ b/examples/webgl1/oimo/shogi/index.js
@@ -346,7 +346,8 @@ for (let i = 0; i < max; i++) {
     //bodys[i] = new OIMO.Body({type:'box', size:[w*2, h*2, d*2], pos:[p.x, p.y, p.z], move:true, world:world});
     bodys[i] = world.add({
         type: "box",
-        size: [w * 2, h * 2, d * 2],
+        // Match the rendered piece: the mesh spans +/-0.5w, +/-0.5h, +/-0.7d -> [w, h, 1.4d].
+        size: [w, h, d * 1.4],
         pos: [p.x, p.y, p.z],
         rot: [0, 0, 0],
         move: true,
@@ -455,7 +456,7 @@ setInterval(function () {
     for (let i = 0; i < max; i++) {
         let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q,
-            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
+            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w, h, d * 1.4]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
         if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }

--- a/examples/webgl2/oimo/shogi/index.js
+++ b/examples/webgl2/oimo/shogi/index.js
@@ -342,7 +342,8 @@ for (let i = 0; i < max; i++) {
     let p = genPosition();
     bodys[i] = world.add({
         type: "box",
-        size: [w * 2, h * 2, d * 2],
+        // Match the rendered piece: the mesh spans +/-0.5w, +/-0.5h, +/-0.7d -> [w, h, 1.4d].
+        size: [w, h, d * 1.4],
         pos: [p.x, p.y, p.z],
         rot: [0, 0, 0],
         move: true,
@@ -450,7 +451,7 @@ setInterval(function () {
     gl.uniform4fv(lineColorLoc, [1, 1, 0, 1]);
     for (let i = 0; i < max; i++) {
         const q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
-        mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w*2, h*2, d*2]);
+        mat4.fromRotationTranslationScale(wm, q, [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w, h, d * 1.4]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
         if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }

--- a/examples/webgpu/oimo/shogi/index.js
+++ b/examples/webgpu/oimo/shogi/index.js
@@ -349,7 +349,8 @@ async function init() {
         const p = genPosition();
         bodies[i] = world.add({
             type: 'box',
-            size: [pw * 2, ph * 2, pd * 2],
+            // Match the rendered piece: the mesh spans +/-0.5pw, +/-0.5ph, +/-0.7pd -> [pw, ph, 1.4pd].
+            size: [pw, ph, pd * 1.4],
             pos: [p.x, p.y, p.z],
             rot: [0, 0, 0],
             move: true,
@@ -535,7 +536,7 @@ function render() {
     for (let i = 0; i < MAX; i++) {
         const px=posArray[i*3], py=posArray[i*3+1], pz=posArray[i*3+2];
         const qx=rotArray[i*4], qy=rotArray[i*4+1], qz=rotArray[i*4+2], qw=rotArray[i*4+3];
-        makeModelMatrix(lineModelTmp, px, py, pz, qx, qy, qz, qw, pw*2, ph*2, pd*2);
+        makeModelMatrix(lineModelTmp, px, py, pz, qx, qy, qz, qw, pw, ph, pd * 1.4);
         const base = (i + 1) * (LINE_ALIGN / 4);
         lineUniformData.set(lineViewProj, base); lineUniformData.set(lineModelTmp, base + 16);
         lineUniformData[base+32]=1; lineUniformData[base+33]=1; lineUniformData[base+34]=0; lineUniformData[base+35]=1;


### PR DESCRIPTION
The **Oimo shogi** samples (WebGL 1.0 / WebGL 2.0 / WebGPU) had the physics shape about **twice the size of the rendered piece**.

The piece mesh spans `±0.5w, ±0.5h, ±0.7d` — bounding box **[w, h, 1.4d]** — but the Oimo box body (and its W-key debug wireframe) used **[w*2, h*2, d*2]** (twice the mesh in width/height). So the collider didn't line up with the piece and pieces rested with visible gaps.

**Fix:** set the body `size` and the wireframe scale to the mesh's actual bounding box **[w, h, 1.4d]** (`[pw, ph, 1.4pd]` for the WebGPU one) in all three samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)