### PR TITLE
Fix two Oimo Falling Eraser bugs (WebGL1 wireframe, Babylon explosion)

### DIFF
--- a/examples/babylonjs/oimo/eraser/index.js
+++ b/examples/babylonjs/oimo/eraser/index.js
@@ -183,7 +183,9 @@ const createScene = function(eraserAtlasUrl) {
     scene = new BABYLON.Scene(engine);
     scene.enablePhysics(new BABYLON.Vector3(0, -9.8, 0), new BABYLON.OimoJSPlugin());
     setupPhysicsDebugWireframe(scene);
-    scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio());
+    // Keep the default 1/60 s physics step. setTimeStep(getAnimationRatio()) made the step ~1 s
+    // (animationRatio is ~1 at 60 fps), which integrated a whole second per step and blew the
+    // erasers apart in mid-air.
     scene.clearColor = new BABYLON.Color4(0.5, 0.5, 0.8, 1.0);
 
     // Fixed head-on camera matching the WebGL/WebGPU + Havok eraser samples (eye at (0,0,40)

--- a/examples/webgl1/oimo/eraser/index.js
+++ b/examples/webgl1/oimo/eraser/index.js
@@ -350,7 +350,7 @@ animate();
     for (let i = 0; i < max; i++) {
         let q = quat.fromValues(rotArray[i*4], rotArray[i*4+1], rotArray[i*4+2], rotArray[i*4+3]);
         mat4.fromRotationTranslationScale(wm, q,
-            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [2, 0.4, 1]);
+            [posArray[i*3], posArray[i*3+1], posArray[i*3+2]], [w * 2, h * 2, d * 2]);
         gl.uniformMatrix4fv(lineModelLoc, false, wm);
         if (showWireframe) gl.drawElements(gl.LINES, 24, gl.UNSIGNED_SHORT, 0);
     }


### PR DESCRIPTION
Two **Falling Eraser** bugs in the Oimo samples:

### WebGL 1.0 + Oimo — collider wireframe not visible
The eraser wireframe scale was a stale `[2, 0.4, 1]`, smaller than the actual `[2.4, 0.6, 1.2]` mesh/body (since `w,h,d` were bumped to `1.2,0.3,0.6`). The smaller wireframe sat entirely *inside* the opaque eraser and was occluded, so pressing **W** showed nothing on the pieces. Scaled it to `[w*2, h*2, d*2]` so it matches the mesh/body and is visible.

### Babylon.js + Oimo — erasers explode in mid-air
The step was set with `scene.getPhysicsEngine().setTimeStep(scene.getAnimationRatio())`. `getAnimationRatio()` is ~1 at 60 fps, so the physics timestep became **~1 second** — a whole second integrated per step blew the bodies apart in the air. Removed that call so the default **1/60 s** step is used (same as the other Babylon eraser samples; this is the same fix already applied to the Cannon one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)