### PR TITLE
Add W-key collider wireframe toggle to three.js Falling Balls examples

### DIFF
--- a/examples/threejs/cannon-es/balls/index.html
+++ b/examples/threejs/cannon-es/balls/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
     "imports": {

--- a/examples/threejs/cannon-es/balls/index.js
+++ b/examples/threejs/cannon-es/balls/index.js
@@ -7,6 +7,7 @@ let camera, scene, light, renderer, container, content;
 let controls;
 
 let meshs = [];
+let debugMeshs = [];
 let grounds = [];
 let matSphere, matGround, matGroundTrans;
 let matSpheres = [];
@@ -29,6 +30,9 @@ let world = new CANNON.World();
     world.broadphase = new CANNON.NaiveBroadphase();
     world.solver.iterations = 10;
 let bodys = [];
+
+const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 function init() {
 
@@ -101,6 +105,16 @@ function addStaticBox(size, position, rotation, spec) {
     grounds.push(mesh);
     mesh.castShadow = true;
     mesh.receiveShadow = true;
+
+    if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+            new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+            new THREE.LineBasicMaterial({ color: 0x44ee88 })
+        );
+        dbg.position.set(position[0], position[1], position[2]);
+        dbg.rotation.set(rotation[0] * ToRad, rotation[1] * ToRad, rotation[2] * ToRad);
+        scene.add(dbg);
+    }
 }
 
 function initCannonPhysics() {
@@ -167,6 +181,15 @@ function initCannonPhysics() {
         meshs[i].receiveShadow = true;
 
         scene.add(meshs[i]);
+
+        if (SHOW_DEBUG_COLLIDERS) {
+            const dbg = new THREE.LineSegments(
+                new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6)),
+                new THREE.LineBasicMaterial({ color: 0xff8844 })
+            );
+            scene.add(dbg);
+            debugMeshs[i] = dbg;
+        }
     }
 }
 
@@ -185,7 +208,12 @@ function updateCannonPhysics() {
         mesh.quaternion.y = body.quaternion.y;
         mesh.quaternion.z = body.quaternion.z;
         mesh.quaternion.w = body.quaternion.w;
-        
+
+        if (SHOW_DEBUG_COLLIDERS && debugMeshs[i]) {
+            debugMeshs[i].position.copy(mesh.position);
+            debugMeshs[i].quaternion.copy(mesh.quaternion);
+        }
+
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
             let y = 10 + Math.random() * 8;
@@ -203,5 +231,28 @@ function loop() {
     requestAnimationFrame(loop);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    scene.traverse((object) => {
+        if (object.isLineSegments) {
+            object.visible = visible;
+        }
+    });
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 init();
 loop();
+setWireframeVisible(showWireframe);

--- a/examples/threejs/cannon-es/balls/style.css
+++ b/examples/threejs/cannon-es/balls/style.css
@@ -9,3 +9,23 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#container {
+  width: 100vw;
+  height: 100vh;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/oimo/balls/index.html
+++ b/examples/threejs/oimo/balls/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimo/balls/index.js
+++ b/examples/threejs/oimo/balls/index.js
@@ -6,6 +6,7 @@ let camera, scene, light, renderer, container, content;
 let controls;
 
 let meshs = [];
+let debugMeshs = [];
 let grounds = [];
 let matSphere, matGround, matGroundTrans;
 let matSpheres = [];
@@ -33,6 +34,9 @@ let world = new OIMO.World({
     gravity: [0, -9.8, 0] 
 });
 let bodys = [];
+
+const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 function init() {
 
@@ -105,6 +109,16 @@ function addStaticBox(size, position, rotation, spec) {
     grounds.push(mesh);
     mesh.castShadow = true;
     mesh.receiveShadow = true;
+
+    if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+            new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+            new THREE.LineBasicMaterial({ color: 0x44ee88 })
+        );
+        dbg.position.set(position[0], position[1], position[2]);
+        dbg.rotation.set(rotation[0] * ToRad, rotation[1] * ToRad, rotation[2] * ToRad);
+        scene.add(dbg);
+    }
 }
 
 function initOimoPhysics() {
@@ -135,7 +149,7 @@ function initOimoPhysics() {
         let rot = boxDataSet[i].rot;
         let surfaceBody = world.add({
             type: "box",
-            size: [size[0]/2, size[1]/2, size[2]/2],
+            size: [size[0], size[1], size[2]],
             pos: [pos[0], pos[1], pos[2]],
             rot: [0, 0, 0],
             move: false,
@@ -180,6 +194,15 @@ function initOimoPhysics() {
         meshs[i].receiveShadow = true;
 
         scene.add(meshs[i]);
+
+        if (SHOW_DEBUG_COLLIDERS) {
+            const dbg = new THREE.LineSegments(
+                new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6)),
+                new THREE.LineBasicMaterial({ color: 0xff8844 })
+            );
+            scene.add(dbg);
+            debugMeshs[i] = dbg;
+        }
     }
 }
 
@@ -198,7 +221,12 @@ function updateOimoPhysics() {
         mesh.quaternion.y = body.quaternion.y;
         mesh.quaternion.z = body.quaternion.z;
         mesh.quaternion.w = body.quaternion.w;
-        
+
+        if (SHOW_DEBUG_COLLIDERS && debugMeshs[i]) {
+            debugMeshs[i].position.copy(mesh.position);
+            debugMeshs[i].quaternion.copy(mesh.quaternion);
+        }
+
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
             let y = 10 + Math.random() * 8;
@@ -214,5 +242,28 @@ function loop() {
     requestAnimationFrame(loop);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    scene.traverse((object) => {
+        if (object.isLineSegments) {
+            object.visible = visible;
+        }
+    });
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 init();
 loop();
+setWireframeVisible(showWireframe);

--- a/examples/threejs/oimo/balls/style.css
+++ b/examples/threejs/oimo/balls/style.css
@@ -9,3 +9,23 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#container {
+  width: 100vw;
+  height: 100vh;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/oimophysics/balls/index.html
+++ b/examples/threejs/oimophysics/balls/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimophysics/balls/index.js
+++ b/examples/threejs/oimophysics/balls/index.js
@@ -6,6 +6,7 @@ let camera, scene, light, renderer, container, content;
 let controls;
 
 let meshs = [];
+let debugMeshs = [];
 let grounds = [];
 let matSphere, matGround, matGroundTrans;
 let matSpheres = [];
@@ -27,6 +28,9 @@ let textures = [];
 let world = new OIMO.World();
 world.gravity = new OIMO.Vec3(0, -9.80665, 0);
 let bodys = [];
+
+const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 function init() {
 
@@ -95,6 +99,16 @@ function addStaticBox(size, position, rotation, spec) {
     grounds.push(mesh);
     mesh.castShadow = true;
     mesh.receiveShadow = true;
+
+    if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+            new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+            new THREE.LineBasicMaterial({ color: 0x44ee88 })
+        );
+        dbg.position.set(position[0], position[1], position[2]);
+        dbg.rotation.set(rotation[0] * ToRad, rotation[1] * ToRad, rotation[2] * ToRad);
+        scene.add(dbg);
+    }
 }
 
 function initOimoPhysics() {
@@ -173,6 +187,15 @@ function initOimoPhysics() {
         meshs[i].receiveShadow = true;
 
         scene.add(meshs[i]);
+
+        if (SHOW_DEBUG_COLLIDERS) {
+            const dbg = new THREE.LineSegments(
+                new THREE.WireframeGeometry(new THREE.SphereGeometry(w / 2, 8, 6)),
+                new THREE.LineBasicMaterial({ color: 0xff8844 })
+            );
+            scene.add(dbg);
+            debugMeshs[i] = dbg;
+        }
     }
 
     setInterval( () => {
@@ -196,7 +219,12 @@ function updateOimoPhysics() {
         mesh.quaternion.y = body.getOrientation().y;
         mesh.quaternion.z = body.getOrientation().z;
         mesh.quaternion.w = body.getOrientation().w;
-        
+
+        if (SHOW_DEBUG_COLLIDERS && debugMeshs[i]) {
+            debugMeshs[i].position.copy(mesh.position);
+            debugMeshs[i].quaternion.copy(mesh.quaternion);
+        }
+
         // reset position
         if (mesh.position.y < -10) {
             let x = -5 + Math.random() * 10;
@@ -216,5 +244,28 @@ function loop() {
     requestAnimationFrame(loop);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    scene.traverse((object) => {
+        if (object.isLineSegments) {
+            object.visible = visible;
+        }
+    });
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 init();
 loop();
+setWireframeVisible(showWireframe);

--- a/examples/threejs/oimophysics/balls/style.css
+++ b/examples/threejs/oimophysics/balls/style.css
@@ -9,3 +9,23 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#container {
+  width: 100vw;
+  height: 100vh;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/rapier/balls/index.html
+++ b/examples/threejs/rapier/balls/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/rapier/balls/index.js
+++ b/examples/threejs/rapier/balls/index.js
@@ -6,6 +6,7 @@ import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 let camera, scene, light, renderer, container, content;
 let controls;
 let meshs = [];
+let debugMeshs = [];
 let grounds = [];
 let matSphere, matGround, matGroundTrans;
 let matSpheres = [];
@@ -23,6 +24,9 @@ const dataSet = [
 let textures = [];
 let world;
 let bodys = [];
+
+const SHOW_DEBUG_COLLIDERS = true;
+let showWireframe = true;
 
 async function init() {
     await RAPIER.init();
@@ -87,6 +91,7 @@ async function init() {
         updatePhysics();
     }, 1000 / 60);
 
+    setWireframeVisible(showWireframe);
     loop();
 }
 
@@ -99,10 +104,20 @@ function addStaticBox(size, position, rotation, spec) {
     mesh.castShadow = true;
     mesh.receiveShadow = true;
     scene.add(mesh);
+
+    if (SHOW_DEBUG_COLLIDERS) {
+        const dbg = new THREE.LineSegments(
+            new THREE.EdgesGeometry(new THREE.BoxGeometry(size[0], size[1], size[2])),
+            new THREE.LineBasicMaterial({ color: 0x44ee88 })
+        );
+        dbg.position.set(position[0], position[1], position[2]);
+        dbg.rotation.set(rotation[0] * ToRad, rotation[1] * ToRad, rotation[2] * ToRad);
+        scene.add(dbg);
+    }
 }
 
 function initRapierPhysics() {
-    let groundColliderDesc = RAPIER.ColliderDesc.cuboid(20, 2, 20);
+    let groundColliderDesc = RAPIER.ColliderDesc.cuboid(10, 1, 10);
     let groundBodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(0, -2, 0);
     let groundBody = world.createRigidBody(groundBodyDesc);
     world.createCollider(groundColliderDesc, groundBody);
@@ -150,6 +165,15 @@ function initRapierPhysics() {
 
         scene.add(mesh);
         meshs[i] = mesh;
+
+        if (SHOW_DEBUG_COLLIDERS) {
+            const dbg = new THREE.LineSegments(
+                new THREE.WireframeGeometry(new THREE.SphereGeometry(radius, 8, 6)),
+                new THREE.LineBasicMaterial({ color: 0xff8844 })
+            );
+            scene.add(dbg);
+            debugMeshs[i] = dbg;
+        }
     }
 }
 
@@ -165,6 +189,11 @@ function updatePhysics() {
 
         mesh.position.set(position.x, position.y, position.z);
         mesh.quaternion.set(rotation.x, rotation.y, rotation.z, rotation.w);
+
+        if (SHOW_DEBUG_COLLIDERS && debugMeshs[i]) {
+            debugMeshs[i].position.copy(mesh.position);
+            debugMeshs[i].quaternion.copy(mesh.quaternion);
+        }
 
         // 床を超えて落ちたオブジェクトの位置をリセット
         if (mesh.position.y < -10) {
@@ -185,5 +214,27 @@ function loop() {
     controls.update();
     requestAnimationFrame(loop);
 }
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    scene.traverse((object) => {
+        if (object.isLineSegments) {
+            object.visible = visible;
+        }
+    });
+    const hint = document.getElementById('hint');
+    if (hint) {
+        hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+    }
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) {
+        return;
+    }
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 
 init();

--- a/examples/threejs/rapier/balls/style.css
+++ b/examples/threejs/rapier/balls/style.css
@@ -9,3 +9,23 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#container {
+  width: 100vw;
+  height: 100vh;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

Adds the W-key collider wireframe toggle (matching the three.js + Havok sibling) to the four three.js Falling Balls examples that lacked it: **Oimo.js, cannon-es, OimoPhysics, and Rapier**.

Each example now:
- Draws green box wireframes for the ground/walls and orange sphere wireframes that follow the balls.
- Shows a `W: wireframe ON/OFF` hint and toggles all collider wireframes via a `keydown` handler.

## Collider/mesh alignment

While adding faithful collider wireframes, two colliders that diverged from their meshes (and from the other samples) were aligned:

- **Oimo.js**: wall colliders used half the wall mesh size (`size/2`); now use the full size.
- **Rapier**: `ColliderDesc.cuboid()` takes half-extents, so `cuboid(20, 2, 20)` was twice the 20×2×20 ground mesh; changed to `cuboid(10, 1, 10)`.

## Test plan

- Open each `examples/threejs/{oimo,cannon-es,oimophysics,rapier}/balls/index.html` and confirm the wireframes render and toggle on/off with the W key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)