### PR TITLE
Fix Babylon.js + Havok Falling Balls running too fast

### DIFF
--- a/examples/babylonjs/havok/balls/index.js
+++ b/examples/babylonjs/havok/balls/index.js
@@ -2,7 +2,7 @@ const HAVOK_WASM_URL = 'https://cx20.github.io/gltf-test/libs/babylonjs/dev/Havo
 let engine;
 let scene;
 let canvas;
-const PHYSICS_SCALE = 1/100;
+const PHYSICS_SCALE = 1/10;
 let showWireframe = true;
 let physicsViewer = null;
 const trackedBodies = [];
@@ -210,7 +210,9 @@ const createScene = function() {
         
         objects.push(s);
 
-        y += 20 * PHYSICS_SCALE;
+        // Small per-ball spawn-height stagger in pre-scale units (kept constant so it does
+        // not blow up when PHYSICS_SCALE changes; matches the WebGL/WebGPU spawn range).
+        y += 0.2;
     }
     scene.registerBeforeRender(function() {
         objects.forEach(function(obj) {
@@ -227,7 +229,9 @@ const createScene = function() {
                 body.setAngularVelocity(new BABYLON.Vector3(0,0,0));
             }
         });
-        scene.activeCamera.alpha += Math.PI * 1.0 / 180.0 * scene.getAnimationRatio();
+        // Rotate ~0.2 rad/s to match the WebGL/WebGPU samples (getAnimationRatio keeps it
+        // frame-rate independent: getAnimationRatio() / 60 is the per-frame time in seconds).
+        scene.activeCamera.alpha += 0.2 * scene.getAnimationRatio() / 60;
     });
 
     return scene;


### PR DESCRIPTION
## Summary

The **Babylon.js + Havok Falling Balls** example simulated noticeably faster than the WebGL/WebGPU + Havok counterparts. The cause was a unit/scale mismatch.

## Root cause & fix

- **World scale**: the example used `PHYSICS_SCALE = 1/100`, while every other Babylon.js sample uses `1/10`. Gravity (`-9.8`) and the timestep are not scaled, so a 10×-smaller world makes objects fall ~√10 times faster relative to their size. Aligned it to `1/10` — the framing is unchanged (geometry and camera all scale by `PHYSICS_SCALE`); only the physics speed settles (~3× slower), matching the WebGL/WebGPU samples.
- **Spawn height**: `y += 20 * PHYSICS_SCALE` was tuned for `1/100`; kept it constant (`y += 0.2`) so the spawn column does not blow up at `1/10`, matching the WebGL/WebGPU spawn range.
- **Camera**: the auto-rotating camera spun at ~60 deg/s; slowed it to ~0.2 rad/s to match the WebGL/WebGPU samples (still frame-rate independent via `getAnimationRatio`).

## Test plan

- Open `examples/babylonjs/havok/balls/index.html` and confirm the ball fall speed and camera rotation match the WebGL/WebGPU + Havok balls examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)