### PR TITLE
Add W-key collider wireframe toggle to three.js Minimum examples (all 8 engines)

### DIFF
--- a/examples/threejs/ammo/minimum/index.html
+++ b/examples/threejs/ammo/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/ammo/minimum/index.js
+++ b/examples/threejs/ammo/minimum/index.js
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const SCALE = 1 / 20;
 const deltaT = 60;
 
+let showWireframe = true;
 let scene;
 let controls;
 let loader;
@@ -12,6 +13,7 @@ let texture;
 let world;
 let objs = [];
 let numObjects = 0;
+let debugGround, debugCube;
 
 class Box {
     constructor(x, y, z, w, h, d, m) {
@@ -180,6 +182,11 @@ function init() {
     let ground = new Plane(0, 0, 0, 80 * SCALE, 0, 0xdddddd);
     scene.add(ground.threeObj);
     world.addRigidBody(ground.bulletObj);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(80 * SCALE, 2 * SCALE, 80 * SCALE)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     createBox();
 
@@ -210,8 +217,12 @@ function init() {
             let obj = objs[i];
             obj.move();
         }
+        if (objs[0] && debugCube) {
+            debugCube.position.copy(objs[0].threeObj.position);
+            debugCube.quaternion.copy(objs[0].threeObj.quaternion);
+        }
     }
- 
+
 }
 
 function createBox() {
@@ -225,9 +236,30 @@ function createBox() {
     let box = new Box(x1, y1, z1, w, h, d, 10);
     scene.add(box.threeObj);
     world.addRigidBody(box.bulletObj);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(x1, y1, z1);
+    scene.add(debugCube);
     objs.push(box);
     numObjects++;
 }
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 
 window.addEventListener("load", function() {
     loader = new THREE.TextureLoader();
@@ -235,5 +267,6 @@ window.addEventListener("load", function() {
 
     Ammo().then(function(Ammo) {
         init();
+        setWireframeVisible(showWireframe);
     });
 }, false);

--- a/examples/threejs/ammo/minimum/style.css
+++ b/examples/threejs/ammo/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/ammo_legacy/minimum/index.html
+++ b/examples/threejs/ammo_legacy/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/ammo_legacy/minimum/index.js
+++ b/examples/threejs/ammo_legacy/minimum/index.js
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 const SCALE = 1 / 20;
 const deltaT = 60;
 
+let showWireframe = true;
 let scene;
 let controls;
 let loader;
@@ -12,6 +13,7 @@ let texture;
 let world;
 let objs = [];
 let numObjects = 0;
+let debugGround, debugCube;
 
 class Box {
     constructor(x, y, z, w, h, d, m) {
@@ -180,6 +182,11 @@ function init() {
     let ground = new Plane(0, 0, 0, 80 * SCALE, 0, 0xdddddd);
     scene.add(ground.threeObj);
     world.addRigidBody(ground.bulletObj);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(80 * SCALE, 2 * SCALE, 80 * SCALE)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     createBox();
 
@@ -210,8 +217,12 @@ function init() {
             let obj = objs[i];
             obj.move();
         }
+        if (objs[0] && debugCube) {
+            debugCube.position.copy(objs[0].threeObj.position);
+            debugCube.quaternion.copy(objs[0].threeObj.quaternion);
+        }
     }
- 
+
 }
 
 function createBox() {
@@ -225,9 +236,30 @@ function createBox() {
     let box = new Box(x1, y1, z1, w, h, d, 10);
     scene.add(box.threeObj);
     world.addRigidBody(box.bulletObj);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(w, h, d)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(x1, y1, z1);
+    scene.add(debugCube);
     objs.push(box);
     numObjects++;
 }
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 
 window.addEventListener("load", function() {
     loader = new THREE.TextureLoader();
@@ -235,5 +267,6 @@ window.addEventListener("load", function() {
 
     Ammo().then(function(Ammo) {
         init();
+        setWireframeVisible(showWireframe);
     });
 }, false);

--- a/examples/threejs/ammo_legacy/minimum/style.css
+++ b/examples/threejs/ammo_legacy/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/cannon-es/minimum/index.html
+++ b/examples/threejs/cannon-es/minimum/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
     "imports": {

--- a/examples/threejs/cannon-es/minimum/index.js
+++ b/examples/threejs/cannon-es/minimum/index.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import * as CANNON from 'cannon';
 
+let showWireframe = true;
 let container;
 let camera, scene, renderer;
 let meshGround;
@@ -10,6 +11,7 @@ let world;
 let shape;
 let body;
 let controls;
+let debugGround, debugCube;
 
 function initCannon() {
     // Setup our world
@@ -66,11 +68,22 @@ function initThree() {
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = 0;
     scene.add(meshGround);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     meshCube.rigidBody = body; // THREE.Object3D#rigidBody has a field of CANNON.RigidBody
     scene.add(meshCube);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
 
     renderer = new THREE.WebGLRenderer();
     renderer.setClearColor(0xffffff);
@@ -101,12 +114,32 @@ function updatePhysics() {
     meshCube.quaternion.y = body.quaternion.y;
     meshCube.quaternion.z = body.quaternion.z;
     meshCube.quaternion.w = body.quaternion.w;
+    if (debugCube) {
+        debugCube.position.set(body.position.x, body.position.y, body.position.z);
+        debugCube.quaternion.set(body.quaternion.x, body.quaternion.y, body.quaternion.z, body.quaternion.w);
+    }
 }
 
 function render() {
     renderer.render(scene, camera);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 initCannon();
 initThree();
+setWireframeVisible(showWireframe);
 animate();

--- a/examples/threejs/cannon-es/minimum/style.css
+++ b/examples/threejs/cannon-es/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/cannon/minimum/index.html
+++ b/examples/threejs/cannon/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/cannon/minimum/index.js
+++ b/examples/threejs/cannon/minimum/index.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+let showWireframe = true;
 let container;
 let camera, scene, renderer;
 let meshGround;
@@ -9,6 +10,7 @@ let world;
 let shape;
 let body;
 let controls;
+let debugGround, debugCube;
 
 function initCannon() {
     // Setup our world
@@ -65,11 +67,22 @@ function initThree() {
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = 0;
     scene.add(meshGround);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     meshCube.rigidBody = body; // THREE.Object3D#rigidBody has a field of CANNON.RigidBody
     scene.add(meshCube);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
 
     renderer = new THREE.WebGLRenderer();
     renderer.setClearColor(0xffffff);
@@ -100,12 +113,32 @@ function updatePhysics() {
     meshCube.quaternion.y = body.quaternion.y;
     meshCube.quaternion.z = body.quaternion.z;
     meshCube.quaternion.w = body.quaternion.w;
+    if (debugCube) {
+        debugCube.position.set(body.position.x, body.position.y, body.position.z);
+        debugCube.quaternion.set(body.quaternion.x, body.quaternion.y, body.quaternion.z, body.quaternion.w);
+    }
 }
 
 function render() {
     renderer.render(scene, camera);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 initCannon();
 initThree();
+setWireframeVisible(showWireframe);
 animate();

--- a/examples/threejs/cannon/minimum/style.css
+++ b/examples/threejs/cannon/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/oimo/minimum/index.html
+++ b/examples/threejs/oimo/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimo/minimum/index.js
+++ b/examples/threejs/oimo/minimum/index.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+let showWireframe = true;
 let container;
 let camera, scene, renderer;
 let controls;
@@ -8,6 +9,7 @@ let meshGround;
 let meshCube;
 let world;
 let body;
+let debugGround, debugCube;
 
 function initOimo() {
     world = new OIMO.World({ 
@@ -57,10 +59,21 @@ function initThree() {
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = 0;
     scene.add(meshGround);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
 
     renderer = new THREE.WebGLRenderer();
     renderer.setClearColor(0xffffff);
@@ -91,12 +104,32 @@ function updatePhysics() {
     meshCube.quaternion.y = body.quaternion.y;
     meshCube.quaternion.z = body.quaternion.z;
     meshCube.quaternion.w = body.quaternion.w;
+    if (debugCube) {
+        debugCube.position.set(body.position.x, body.position.y, body.position.z);
+        debugCube.quaternion.set(body.quaternion.x, body.quaternion.y, body.quaternion.z, body.quaternion.w);
+    }
 }
 
 function render() {
     renderer.render(scene, camera);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 initOimo();
 initThree();
+setWireframeVisible(showWireframe);
 animate();

--- a/examples/threejs/oimo/minimum/style.css
+++ b/examples/threejs/oimo/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/oimophysics/minimum/index.html
+++ b/examples/threejs/oimophysics/minimum/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/oimophysics/minimum/index.js
+++ b/examples/threejs/oimophysics/minimum/index.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+let showWireframe = true;
 let container;
 let camera, scene, renderer;
 let meshGround;
@@ -8,6 +9,7 @@ let meshCube;
 let world;
 let body;
 let controls;
+let debugGround, debugCube;
 
 function initOimo() {
     world = new OIMO.World();
@@ -48,10 +50,21 @@ function initThree() {
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = 0;
     scene.add(meshGround);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     let geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
 
     renderer = new THREE.WebGLRenderer();
     renderer.setClearColor(0xffffff);
@@ -82,12 +95,32 @@ function updatePhysics() {
     meshCube.quaternion.y = body.getOrientation().y;
     meshCube.quaternion.z = body.getOrientation().z;
     meshCube.quaternion.w = body.getOrientation().w;
+    if (debugCube) {
+        debugCube.position.set(body.getPosition().x, body.getPosition().y, body.getPosition().z);
+        debugCube.quaternion.set(body.getOrientation().x, body.getOrientation().y, body.getOrientation().z, body.getOrientation().w);
+    }
 }
 
 function render() {
     renderer.render(scene, camera);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 initOimo();
 initThree();
+setWireframeVisible(showWireframe);
 animate();

--- a/examples/threejs/oimophysics/minimum/style.css
+++ b/examples/threejs/oimophysics/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/physx/minimum/index.html
+++ b/examples/threejs/physx/minimum/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/physx/minimum/index.js
+++ b/examples/threejs/physx/minimum/index.js
@@ -1,6 +1,9 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
+let showWireframe = true;
+let debugGround, debugCube;
+
 class Box {
     constructor(x, y, z, w, h, d, texture) {
         this.x = x;
@@ -161,10 +164,21 @@ function init(PhysX) {
     let ground = new Ground(0, 0, 0, 4, 0.1, 4, texture);
     sceneThree.add(ground.threeObj);
     scenePhysx.addActor(ground.physxObj);
-    
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    sceneThree.add(debugGround);
+
     let box = new Box(0, 2, 0, 1, 1, 1, texture);
     sceneThree.add(box.threeObj);
     scenePhysx.addActor(box.physxObj);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    sceneThree.add(debugCube);
     box.move();
 
     const renderer = new THREE.WebGLRenderer( { antialias: true } );
@@ -179,15 +193,35 @@ function init(PhysX) {
         scenePhysx.fetchResults(true);
 
         box.move();
+        if (debugCube) {
+            debugCube.position.copy(box.threeObj.position);
+            debugCube.quaternion.copy(box.threeObj.quaternion);
+        }
 
         renderer.render( sceneThree, camera );
     }
 
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 window.addEventListener("load", function() {
     PhysX().then(function(PhysX) {
         init(PhysX);
+        setWireframeVisible(showWireframe);
     });
 }, false);
 

--- a/examples/threejs/physx/minimum/style.css
+++ b/examples/threejs/physx/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}

--- a/examples/threejs/rapier/minimum/index.html
+++ b/examples/threejs/rapier/minimum/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="hint">W: wireframe ON</div>
 <script type="importmap">
 {
 	"imports": {

--- a/examples/threejs/rapier/minimum/index.js
+++ b/examples/threejs/rapier/minimum/index.js
@@ -2,11 +2,13 @@
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 
+let showWireframe = true;
 let container;
 let camera, scene, renderer;
 let meshGround, meshCube;
 let world, groundBody, boxBody;
 let controls;
+let debugGround, debugCube;
 
 async function initRapier() {
     await RAPIER.init();
@@ -44,10 +46,21 @@ function initThree() {
     meshGround = new THREE.Mesh(geometryGround, material);
     meshGround.position.y = 0;
     scene.add(meshGround);
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(4, 0.1, 4)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    scene.add(debugGround);
 
     const geometryCube = new THREE.BoxGeometry(1, 1, 1);
     meshCube = new THREE.Mesh(geometryCube, material);
     scene.add(meshCube);
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(0, 2, 0);
+    scene.add(debugCube);
 
     renderer = new THREE.WebGLRenderer();
     renderer.setClearColor(0xffffff);
@@ -70,6 +83,10 @@ function updatePhysics() {
 
     meshCube.position.set(boxPosition.x, boxPosition.y, boxPosition.z);
     meshCube.quaternion.set(boxRotation.x, boxRotation.y, boxRotation.z, boxRotation.w);
+    if (debugCube) {
+        debugCube.position.set(boxPosition.x, boxPosition.y, boxPosition.z);
+        debugCube.quaternion.set(boxRotation.x, boxRotation.y, boxRotation.z, boxRotation.w);
+    }
 }
 
 function animate() {
@@ -82,7 +99,23 @@ function render() {
     renderer.render(scene, camera);
 }
 
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
 initRapier().then(() => {
     initThree();
+    setWireframeVisible(showWireframe);
     animate();
 });

--- a/examples/threejs/rapier/minimum/style.css
+++ b/examples/threejs/rapier/minimum/style.css
@@ -9,3 +9,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Add W-key physics collider wireframe on/off toggle to all 8 three.js Minimum examples: cannon-es, cannon, rapier, oimo, oimophysics, ammo, ammo_legacy, physx
- Each example gains `debugGround` (green `0x44ee88`) and `debugCube` (orange `0xff8844`) `LineSegments` that track physics body pose each step
- `setWireframeVisible()` helper toggles visibility and updates the `#hint` overlay
- `style.css` updated with `#hint` positioning/styling to match the existing havok/minimum pattern

## Test plan

- [ ] Open each of the 8 minimum examples in a browser
- [ ] Confirm wireframe collider outlines are visible on load (ON by default)
- [ ] Press W key — wireframe toggles OFF, hint text changes to "W: wireframe OFF"
- [ ] Press W again — wireframe toggles ON
- [ ] Confirm physics simulation still runs correctly (cube falls and lands on ground)

🤖 Generated with [Claude Code](https://claude.com/claude-code)