### PR TITLE
Add three.js (WebGPU) + WGSL Compute Shader Minimum example

### DIFF
--- a/examples/threejs/wgsl_compute/minimum/index.html
+++ b/examples/threejs/wgsl_compute/minimum/index.html
@@ -140,8 +140,9 @@ fn main() {
 <script type="importmap">
 {
   "imports": {
-    "three": "https://cdn.jsdelivr.net/gh/mrdoob/three.js/build/three.module.js",
-    "three/addons/": "https://cdn.jsdelivr.net/gh/mrdoob/three.js/examples/jsm/"
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.webgpu.js",
+    "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.webgpu.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
   }
 }
 </script>

--- a/examples/threejs/wgsl_compute/minimum/index.html
+++ b/examples/threejs/wgsl_compute/minimum/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>three.js (WebGPU) + WGSL Compute Shader Minimum Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+<div id="container"></div>
+<div id="hint">W: wireframe ON</div>
+
+<script id="cs" type="x-shader/x-compute">
+struct PhysicsState {
+    position   : vec4<f32>,
+    velocity   : vec4<f32>,
+    rotation   : vec4<f32>,
+    angularVel : vec4<f32>,
+}
+struct SimParams {
+    dt          : f32,
+    gravity     : f32,
+    groundY     : f32,
+    restitution : f32,
+    halfSize    : f32,
+    friction    : f32,
+    mass        : f32,
+    iInv        : f32,
+}
+
+@group(0) @binding(0) var<storage, read_write> state  : PhysicsState;
+@group(0) @binding(1) var<uniform>             params : SimParams;
+
+fn quatMul(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(
+        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
+        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
+        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
+        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z,
+    );
+}
+
+fn rotByQuat(v: vec3<f32>, q: vec4<f32>) -> vec3<f32> {
+    let t = 2.0 * cross(q.xyz, v);
+    return v + q.w * t + cross(q.xyz, t);
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    var pos    = state.position.xyz;
+    var vel    = state.velocity.xyz;
+    var rot    = state.rotation;
+    var angVel = state.angularVel.xyz;
+
+    let mInv = 1.0 / params.mass;
+    let iInv = params.iInv;
+    let h    = params.halfSize;
+    let mu   = params.friction;
+
+    angVel *= 0.999;
+
+    vel.y -= params.gravity * params.dt;
+    pos   += vel * params.dt;
+
+    let angSpeed = length(angVel);
+    if (angSpeed > 0.0001) {
+        let axis      = angVel / angSpeed;
+        let halfAngle = angSpeed * params.dt * 0.5;
+        let dq        = vec4<f32>(axis * sin(halfAngle), cos(halfAngle));
+        rot = normalize(quatMul(dq, rot));
+    }
+
+    var numContact = 0u;
+    var sumR       = vec3<f32>(0.0);
+    var minWorldY  = 0.0;
+
+    for (var mask = 0u; mask < 8u; mask++) {
+        let lx = select(-h, h, (mask & 1u) != 0u);
+        let ly = select(-h, h, (mask & 2u) != 0u);
+        let lz = select(-h, h, (mask & 4u) != 0u);
+        let r_world = rotByQuat(vec3<f32>(lx, ly, lz), rot);
+        let worldY  = pos.y + r_world.y;
+        if (worldY < params.groundY) {
+            numContact++;
+            sumR += r_world;
+            if (numContact == 1u || worldY < minWorldY) { minWorldY = worldY; }
+        }
+    }
+
+    if (numContact > 0u) {
+        let r = sumR / f32(numContact);
+
+        let vn = vel.y + angVel.z * r.x - angVel.x * r.z;
+        var jn = 0.0;
+        if (vn < 0.0) {
+            let e  = select(params.restitution, 0.0, abs(vn) < 1.0);
+            let dn = mInv + iInv * (r.x * r.x + r.z * r.z);
+            jn     = -(1.0 + e) * vn / dn;
+
+            vel.y    += jn * mInv;
+            angVel.x -= iInv * jn * r.z;
+            angVel.z += iInv * jn * r.x;
+        }
+
+        let vt    = vec3<f32>(vel.x + angVel.y*r.z - angVel.z*r.y,
+                              0.0,
+                              vel.z + angVel.x*r.y - angVel.y*r.x);
+        let vtLen = length(vt);
+        if (vtLen > 0.0001) {
+            let tDir    = vt / vtLen;
+            let rCrossT = cross(r, tDir);
+            let denom_t = mInv + iInv * dot(rCrossT, rCrossT);
+            let jn_eff  = max(abs(jn), params.mass * params.gravity * params.dt);
+            let jt      = clamp(-vtLen / denom_t, -mu * jn_eff, mu * jn_eff);
+
+            vel    += (jt * mInv) * tDir;
+            angVel += iInv * jt * rCrossT;
+        }
+
+        pos.y += params.groundY - minWorldY;
+
+        if (length(vel) < 0.05 && length(angVel) < 0.05) {
+            vel    = vec3<f32>(0.0);
+            angVel = vec3<f32>(0.0);
+        }
+    }
+
+    if (pos.y < -30.0) {
+        pos    = vec3<f32>(0.0, 12.0, 0.0);
+        vel    = vec3<f32>(0.0, 0.0, 0.0);
+        rot    = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        angVel = vec3<f32>(0.3, 0.8, 0.2);
+    }
+
+    state.position   = vec4<f32>(pos, 0.0);
+    state.velocity   = vec4<f32>(vel, 0.0);
+    state.rotation   = rot;
+    state.angularVel = vec4<f32>(angVel, 0.0);
+}
+</script>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/gh/mrdoob/three.js/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/gh/mrdoob/three.js/examples/jsm/"
+  }
+}
+</script>
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/threejs/wgsl_compute/minimum/index.html
+++ b/examples/threejs/wgsl_compute/minimum/index.html
@@ -140,9 +140,9 @@ fn main() {
 <script type="importmap">
 {
   "imports": {
-    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.webgpu.js",
-    "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.webgpu.js",
-    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+    "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.js",
+    "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
   }
 }
 </script>

--- a/examples/threejs/wgsl_compute/minimum/index.js
+++ b/examples/threejs/wgsl_compute/minimum/index.js
@@ -1,6 +1,5 @@
-import * as THREE from 'three';
+import * as THREE from 'three/webgpu';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
 // Physics constants (same as webgpu/wgsl_compute/minimum)
 const GROUND_Y  = -2.0;
@@ -173,7 +172,7 @@ async function main() {
 
     initScene();
 
-    renderer = new WebGPURenderer({ antialias: true });
+    renderer = new THREE.WebGPURenderer({ antialias: true });
     renderer.setClearColor(0xffffff);
     renderer.setSize(window.innerWidth, window.innerHeight);
     document.getElementById('container').appendChild(renderer.domElement);

--- a/examples/threejs/wgsl_compute/minimum/index.js
+++ b/examples/threejs/wgsl_compute/minimum/index.js
@@ -1,0 +1,201 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+
+// Physics constants (same as webgpu/wgsl_compute/minimum)
+const GROUND_Y  = -2.0;
+const CUBE_HALF = 2.5;
+const CUBE_SIZE = 5.0;
+const MASS      = 1.0;
+const I_INV     = 6.0 / (MASS * CUBE_SIZE * CUBE_SIZE);
+const SUBSTEPS  = 4;
+
+let showWireframe = true;
+let scene, camera, renderer, controls;
+let meshGround, meshCube;
+let debugGround, debugCube;
+
+// Raw WebGPU for WGSL compute physics
+let device;
+let computePipeline, physicsBuffer, readbackBuffer, simParamsBuffer, physicsBindGroup;
+let readbackBusy = false;
+let lastTime = -1;
+
+// CPU-side copy of physics state (updated from GPU readback each frame)
+const cubePos = [0, 12, 0];
+const cubeRot = [0, 0, 0, 1]; // quaternion xyzw
+
+function initScene() {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 200);
+    camera.position.set(0, 20, 35);
+
+    const loader = new THREE.TextureLoader();
+    const texture = loader.load('../../../../assets/textures/frog.jpg');
+    const material = new THREE.MeshBasicMaterial({ map: texture });
+
+    meshGround = new THREE.Mesh(new THREE.BoxGeometry(20, 1, 20), material);
+    meshGround.position.set(0, GROUND_Y - 0.5, 0);
+    scene.add(meshGround);
+
+    meshCube = new THREE.Mesh(new THREE.BoxGeometry(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE), material);
+    meshCube.position.set(cubePos[0], cubePos[1], cubePos[2]);
+    scene.add(meshCube);
+
+    debugGround = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(20, 1, 20)),
+        new THREE.LineBasicMaterial({ color: 0x44ee88 })
+    );
+    debugGround.position.set(0, GROUND_Y - 0.5, 0);
+    scene.add(debugGround);
+
+    debugCube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE)),
+        new THREE.LineBasicMaterial({ color: 0xff8844 })
+    );
+    debugCube.position.set(cubePos[0], cubePos[1], cubePos[2]);
+    scene.add(debugCube);
+}
+
+function initPhysics() {
+    const computeShaderWGSL = document.getElementById('cs').textContent;
+
+    computePipeline = device.createComputePipeline({
+        layout:  'auto',
+        compute: {
+            module:     device.createShaderModule({ code: computeShaderWGSL }),
+            entryPoint: 'main',
+        },
+    });
+
+    const initialState = new Float32Array([
+        0, 12, 0, 0,      // position xyz, pad
+        0,  0, 0, 0,      // velocity xyz, pad
+        0,  0, 0, 1,      // rotation quaternion xyzw (identity)
+        0.3, 0.8, 0.2, 0, // angularVel xyz, pad
+    ]);
+
+    physicsBuffer = device.createBuffer({
+        size:             initialState.byteLength,
+        usage:            GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+        mappedAtCreation: true,
+    });
+    new Float32Array(physicsBuffer.getMappedRange()).set(initialState);
+    physicsBuffer.unmap();
+
+    readbackBuffer = device.createBuffer({
+        size:  64,
+        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
+
+    simParamsBuffer = device.createBuffer({
+        size:  32,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    physicsBindGroup = device.createBindGroup({
+        layout:  computePipeline.getBindGroupLayout(0),
+        entries: [
+            { binding: 0, resource: { buffer: physicsBuffer } },
+            { binding: 1, resource: { buffer: simParamsBuffer } },
+        ],
+    });
+}
+
+function animate(timeMs) {
+    if (lastTime < 0) lastTime = timeMs;
+    const dt = Math.min((timeMs - lastTime) / 1000, 1 / 30);
+    lastTime = timeMs;
+
+    // Upload simulation parameters
+    device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([
+        dt / SUBSTEPS, 9.81, GROUND_Y, 0.5, CUBE_HALF, 0.5, MASS, I_INV,
+    ]));
+
+    // Dispatch compute passes (SUBSTEPS per frame for stability)
+    const encoder = device.createCommandEncoder();
+    for (let s = 0; s < SUBSTEPS; s++) {
+        const cp = encoder.beginComputePass();
+        cp.setPipeline(computePipeline);
+        cp.setBindGroup(0, physicsBindGroup);
+        cp.dispatchWorkgroups(1);
+        cp.end();
+    }
+    if (!readbackBusy) {
+        encoder.copyBufferToBuffer(physicsBuffer, 0, readbackBuffer, 0, 64);
+    }
+    device.queue.submit([encoder.finish()]);
+
+    // Async readback: update CPU-side state from previous frame's copy
+    if (!readbackBusy) {
+        readbackBusy = true;
+        readbackBuffer.mapAsync(GPUMapMode.READ).then(() => {
+            const data = new Float32Array(readbackBuffer.getMappedRange().slice(0));
+            readbackBuffer.unmap();
+            cubePos[0] = data[0]; cubePos[1] = data[1]; cubePos[2] = data[2];
+            cubeRot[0] = data[8]; cubeRot[1] = data[9]; cubeRot[2] = data[10]; cubeRot[3] = data[11];
+            readbackBusy = false;
+        }).catch(() => { readbackBusy = false; });
+    }
+
+    // Sync three.js mesh to physics state
+    meshCube.position.set(cubePos[0], cubePos[1], cubePos[2]);
+    meshCube.quaternion.set(cubeRot[0], cubeRot[1], cubeRot[2], cubeRot[3]);
+    if (debugCube) {
+        debugCube.position.copy(meshCube.position);
+        debugCube.quaternion.copy(meshCube.quaternion);
+    }
+
+    controls.update();
+    renderer.render(scene, camera);
+}
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    if (debugGround) debugGround.visible = visible;
+    if (debugCube) debugCube.visible = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
+
+async function main() {
+    if (!navigator.gpu) {
+        document.getElementById('hint').textContent = 'WebGPU is not supported in this browser.';
+        return;
+    }
+
+    initScene();
+
+    renderer = new WebGPURenderer({ antialias: true });
+    renderer.setClearColor(0xffffff);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.getElementById('container').appendChild(renderer.domElement);
+
+    controls = new OrbitControls(camera, renderer.domElement);
+    controls.target.set(0, 3, 0);
+    controls.autoRotate = true;
+    controls.autoRotateSpeed = 1.0;
+
+    window.addEventListener('resize', () => {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    // Initialize WebGPU renderer — device is available after this call
+    await renderer.init();
+    device = renderer.backend.device;
+
+    initPhysics();
+    setWireframeVisible(showWireframe);
+    renderer.setAnimationLoop(animate);
+}
+
+main().catch(console.error);

--- a/examples/threejs/wgsl_compute/minimum/style.css
+++ b/examples/threejs/wgsl_compute/minimum/style.css
@@ -1,0 +1,31 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+body {
+  background: #fff;
+  font: 30px sans-serif;
+}
+
+#container {
+  width: 100vw;
+  height: 100vh;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Add `examples/threejs/wgsl_compute/minimum/` — a new minimum example combining **three.js WebGPURenderer** for rendering with a **raw WGSL compute shader** for physics simulation
- Physics device is obtained via `renderer.backend.device` after `await renderer.init()`
- WGSL compute shader is identical to `webgpu/wgsl_compute/minimum` (semi-implicit Euler, OBB vs ground-plane collision, Coulomb friction)
- Rendering uses `THREE.MeshBasicMaterial` + frog texture, `OrbitControls` with autoRotate
- W-key collider wireframe toggle (green ground `0x44ee88`, orange cube `0xff8844`)
- WebGPU not supported message shown if `navigator.gpu` is unavailable

## Architecture

```
three.js WebGPURenderer           raw WebGPU (via renderer.backend.device)
─────────────────────────         ──────────────────────────────────────
Scene / Camera / Mesh             computePipeline (WGSL physics shader)
OrbitControls + autoRotate        physicsBuffer (StorageBuffer)
MeshBasicMaterial + texture       simParamsBuffer (UniformBuffer)
LineSegments wireframe            readbackBuffer (MapRead + async)
renderer.render(scene, camera)    device.queue.submit([compute encoder])
```

## Test plan

- [ ] Open in Chrome/Edge with WebGPU enabled
- [ ] Confirm cube falls and bounces on the ground
- [ ] Confirm OrbitControls (drag/scroll) and autoRotate work
- [ ] Press W — wireframe toggles OFF, hint changes to "W: wireframe OFF"
- [ ] Press W again — wireframe toggles ON
- [ ] On a non-WebGPU browser: confirm error message shown in hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)