### PR TITLE
Add IBL and fix coin rotation for three.js + WGSL Falling Coins example

### DIFF
--- a/examples/threejs/wgsl_compute/coins/index.html
+++ b/examples/threejs/wgsl_compute/coins/index.html
@@ -87,6 +87,8 @@ fn rndU(seed : u32) -> f32 {
     return f32(pcgHash(seed)) * (1.0 / 4294967296.0);
 }
 
+const ANG_SCALE : f32 = 0.3;
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let i = id.x;
@@ -129,16 +131,29 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     vel.y -= params.gravity * params.dt;
     pos += vel * params.dt;
 
-    let hw = angVel * 0.5 * params.dt;
-    let dq = quatMul(vec4<f32>(hw, 0.0), rot);
-    rot = normalizeQ(rot + dq);
+    let sp = length(angVel);
+    if (sp > 0.0001) {
+        let axis = angVel / sp;
+        let half = sp * params.dt * 0.5;
+        rot = normalizeQ(quatMul(vec4<f32>(axis * sin(half), cos(half)), rot));
+    }
 
     if (pos.y - radius < params.groundY && abs(pos.x) < GROUND_HALF && abs(pos.z) < GROUND_HALF) {
         pos.y = params.groundY + radius;
         if (vel.y < 0.0) {
-            vel.y = -vel.y * params.restitution;
-            vel.x *= params.friction;
-            vel.z *= params.friction;
+            let vn = vel.y;
+            let Jn = -vn * (1.0 + params.restitution);
+            vel.y = -vn * params.restitution;
+            let r_c = vec3<f32>(0.0, -radius, 0.0);
+            let contactVel = vel + cross(angVel, r_c);
+            let tangVel = vec3<f32>(contactVel.x, 0.0, contactVel.z);
+            let tLen = length(tangVel);
+            if (tLen > 0.001) {
+                let tDir = tangVel / tLen;
+                let Jt = min(params.friction * Jn, tLen);
+                vel -= vec3<f32>(tDir.x * Jt, 0.0, tDir.z * Jt);
+                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
+            }
         }
     }
 
@@ -165,7 +180,17 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
                         let relVel = vel - other.velocity.xyz;
                         let vn = dot(relVel, n);
                         if (vn < 0.0) {
-                            vel -= n * (vn * (1.0 + params.restitution) * 0.5);
+                            let Jn = -(vn * (1.0 + params.restitution) * 0.5);
+                            vel += n * Jn;
+                            let r_c = -n * radius;
+                            let relVt = relVel - vn * n;
+                            let vtLen = length(relVt);
+                            if (vtLen > 0.001) {
+                                let tDir = relVt / vtLen;
+                                let Jt = min(params.friction * Jn, vtLen * 0.5);
+                                vel -= tDir * Jt;
+                                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
+                            }
                         }
                     }
                 }

--- a/examples/threejs/wgsl_compute/coins/index.js
+++ b/examples/threejs/wgsl_compute/coins/index.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three/webgpu';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { HDRCubeTextureLoader } from 'three/addons/loaders/HDRCubeTextureLoader.js';
 
 const FLOOR_BUMP_FILE = '../../../../assets/textures/floor_bump.png';
 const ROCKN_FILE      = '../../../../assets/textures/rockn.png';
@@ -242,7 +243,7 @@ function animate(timeMs) {
 
     device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([
         dt / SUBSTEPS, 9.81, GROUND_Y, 0.9992,
-        0.992, 0.2, 0.98, time,
+        0.999, 0.2, 0.98, time,
     ]));
 
     const encoder        = device.createCommandEncoder();
@@ -310,8 +311,9 @@ async function main() {
 
     await initScene();
 
+    scene.background = new THREE.Color(0x1a1a1f);
+
     renderer = new THREE.WebGPURenderer({ antialias: true });
-    renderer.setClearColor(0x1a1a1f);
     renderer.setSize(window.innerWidth, window.innerHeight);
     document.getElementById('container').appendChild(renderer.domElement);
 
@@ -326,6 +328,21 @@ async function main() {
 
     await renderer.init();
     device = renderer.backend.device;
+
+    const BASE_HDR = 'https://cx20.github.io/gltf-test/textures/papermill_hdr/specular/';
+    new HDRCubeTextureLoader().load(
+        ['specular_posx_0.hdr', 'specular_negx_0.hdr',
+         'specular_posy_0.hdr', 'specular_negy_0.hdr',
+         'specular_posz_0.hdr', 'specular_negz_0.hdr'].map(f => BASE_HDR + f),
+        (hdrCubeMap) => {
+            hdrCubeMap.mapping = THREE.CubeReflectionMapping;
+            const pmrem = new THREE.PMREMGenerator(renderer);
+            pmrem.compileCubemapShader();
+            scene.environment = pmrem.fromCubemap(hdrCubeMap).texture;
+            scene.background  = hdrCubeMap;
+            pmrem.dispose();
+        }
+    );
 
     initPhysics();
     setWireframeVisible(showWireframe);


### PR DESCRIPTION
## Summary

- Add papermill HDR IBL via `HDRCubeTextureLoader` + `PMREMGenerator` (same pattern as marbles PR #425); `MeshStandardMaterial` coins now reflect the environment
- Fix coin rotation — coins now tumble during fall and spin on collision:
  - Reduce `angDamping` from `0.992` → `0.999` per substep so initial angular velocity survives the ~3-second fall (was decaying to <1% of original)
  - Switch rotation integration to stable axis-angle method (same as shogi)
  - Add angular impulse from ground contact: friction × lever-arm torque using contact velocity that includes the spinning contribution (`ω × r_contact`)
  - Add friction-driven angular impulse for coin-coin collisions

## Test plan

- [ ] Open `examples/threejs/wgsl_compute/coins/` in a WebGPU-capable browser
- [ ] Verify coins tumble and change orientation while falling (not locked to identity)
- [ ] Verify coins spin/bounce differently after hitting the floor
- [ ] Verify IBL environment map loads (papermill HDR skybox visible in background)
- [ ] Verify metallic coins reflect the environment (gold/silver/copper sheen)
- [ ] Verify W-key wireframe toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)