### PR TITLE
Align three.js and WebGPU WGSL Falling Coins with Babylon.js approach

### DIFF
--- a/docs/physics-implementation-notes.md
+++ b/docs/physics-implementation-notes.md
@@ -254,6 +254,112 @@ if (pos.y < RESET_Y) {
 A small downward velocity (rather than exactly zero) keeps the recycled body from being considered
 asleep in mid‑air.
 
+### 3.8 Falling Coins — fixed‑axis spin model
+
+The *Falling Coins* samples (`wgsl_compute/coins`) use a different rotation scheme from the OBB
+boxes. Coins are sphere colliders, so spin has no effect on collisions, but it must look right
+visually — a coin tumbling through the air must *spin*, slow down when it hits the floor, and
+not accumulate angular error over thousands of frames.
+
+#### State layout (per coin, 4 × `vec4<f32>` = 64 bytes)
+
+```wgsl
+struct CoinState {
+    position : vec4<f32>,   // xyz = world position, w = seed (packed scalar)
+    velocity : vec4<f32>,   // xyz = linear velocity,  w unused
+    axis     : vec4<f32>,   // xyz = fixed unit rotation axis (set once at spawn, w unused)
+    spin     : vec4<f32>,   // x = accumulated angle (radians), y = per‑coin spin rate (zw unused)
+}
+```
+
+The key design choice is that **each coin has one fixed rotation axis** assigned at spawn time
+(uniformly distributed on the sphere) and a **fixed spin rate** (uniform in `[0.5, 2.0]` rad/s
+base). The visible spin is driven by those two constants plus the current linear speed:
+
+```wgsl
+const SPIN_BASE    : f32 = 4.0;   // base angular rate multiplier
+const SPIN_SPEED_K : f32 = 0.5;   // extra rate per (m/s) of linear speed
+const FLOOR_SPIN_F : f32 = 0.3;   // spin factor while on the floor
+
+let inAir      = !onFloor || pos.y - radius > groundY + 0.05;
+let spinFactor = select(FLOOR_SPIN_F, 1.0, inAir);
+angle += spinRate * (SPIN_BASE + speed * SPIN_SPEED_K) * spinFactor * dt;
+```
+
+- **Why fixed axis, not quaternion × angular velocity?** Quaternion integration needs angular
+  damping to converge; over many substeps a coin's spin decays to near‑zero and it slides without
+  rotating. The fixed‑axis model removes the damping problem: every coin always has its assigned
+  rate, driven by how fast it is moving, so coins moving slowly spin slowly and fast‑moving or
+  airborne coins tumble quickly.
+- **Why `spinFactor`?** Coins tumble freely in air (`spinFactor=1.0`) but visually slow down when
+  they touch the floor (`spinFactor=0.3`), mimicking friction without coupling the physics into
+  the rotation model.
+- **Speed cap.** A `MAX_SPEED = 25 m/s` clamp prevents runaway coins from accumulating infinite
+  speed after many substeps of overlapping collisions.
+
+#### Jacobi collision response
+
+The old sequential model accumulated impulses *in‑place* inside the neighbour loop:
+
+```wgsl
+// sequential (old)
+for j in neighbours { pos += halfCorrection; vel += impulse; }
+```
+
+Because reads came from `srcStates` (previous frame) but writes went directly to the
+current local `pos`/`vel`, corrections from later neighbours in the scan built on partially‑corrected
+state. The scan order isn't random — it follows the grid cell order — so one hemisphere of
+contacts consistently "wins", creating a subtle but visible directional drift in dense piles.
+
+The **Jacobi** model accumulates all corrections into separate accumulators and applies once:
+
+```wgsl
+// Jacobi (new)
+var posCorr = vec3<f32>(0.0);
+var velCorr = vec3<f32>(0.0);
+for j in neighbours {
+    posCorr += halfCorrection;
+    velCorr += impulse;
+}
+pos += posCorr;
+vel += velCorr;
+```
+
+All inputs come from `srcStates` (the ping‑pong read buffer), so no contact overrides another;
+the response to all neighbours is symmetric and order‑independent.
+
+#### Update ordering
+
+The old code applied `pos += vel * dt` before the floor and collision tests, meaning gravity
+could push a coin through the floor before the floor correction ran. The Babylon.js‑style
+ordering fixes this:
+
+```text
+1. gravity        → vel.y -= g * dt
+2. coin–coin      → Jacobi posCorr / velCorr
+3. floor contact  → clamp pos.y, apply restitution + friction multiplier
+4. speed cap      → clamp |vel| to MAX_SPEED
+5. position step  → pos += vel * dt     ← always last
+6. spin update    → angle += …
+7. linear damping → vel *= damping
+```
+
+Moving the position step to after all collision corrections means the floor and coin–coin
+responses act on the *updated* velocity, not the pre‑collision one, giving more stable stacking.
+
+#### Floor friction
+
+Rather than a full tangential impulse model, the floor applies a simple velocity multiplier to
+the horizontal components:
+
+```wgsl
+vel.x *= params.friction;   // friction = 0.92
+vel.z *= params.friction;
+```
+
+This is enough to make coins slow their lateral drift when they land, without the oscillation
+that a full Coulomb friction model can introduce in a simple explicit integrator.
+
 ---
 
 ## 4. Debugging GPU physics

--- a/examples/threejs/wgsl_compute/coins/index.html
+++ b/examples/threejs/wgsl_compute/coins/index.html
@@ -16,11 +16,12 @@ const GRID_Z : u32 = 64u;
 const CELL_CAPACITY : u32 = 8u;
 const CELL_SIZE : f32 = 1.7;
 const FLOOR_Y_C : f32 = -10.0;
+
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,   // xyz = unit rotation axis (w unused)
+    spin     : vec4<f32>,   // x = current angle, y = spin rate (zw unused)
 }
 
 struct CoinInfo {
@@ -34,21 +35,25 @@ struct SimParams {
     gravity     : f32,
     groundY     : f32,
     damping     : f32,
-    angDamping  : f32,
+    _pad0       : f32,
     restitution : f32,
     friction    : f32,
     time        : f32,
 }
 
-const GROUND_HALF : f32 = 13.0;
+const GROUND_HALF  : f32 = 13.0;
 const SPAWN_RADIUS : f32 = 3.0;
-const SPAWN_RATE : f32 = 350.0;
+const SPAWN_RATE   : f32 = 350.0;
+const MAX_SPEED    : f32 = 25.0;
+const SPIN_BASE    : f32 = 4.0;
+const SPIN_SPEED_K : f32 = 0.5;
+const FLOOR_SPIN_F : f32 = 0.3;
 
-@group(0) @binding(0) var<storage, read> srcStates : array<CoinState>;
-@group(0) @binding(1) var<storage, read_write> dstStates : array<CoinState>;
-@group(0) @binding(2) var<storage, read> infos : array<CoinInfo>;
-@group(0) @binding(3) var<uniform> params : SimParams;
-@group(0) @binding(4) var<storage, read> grid : array<u32>;
+@group(0) @binding(0) var<storage, read>        srcStates : array<CoinState>;
+@group(0) @binding(1) var<storage, read_write>  dstStates : array<CoinState>;
+@group(0) @binding(2) var<storage, read>        infos     : array<CoinInfo>;
+@group(0) @binding(3) var<uniform>              params    : SimParams;
+@group(0) @binding(4) var<storage, read>        grid      : array<u32>;
 
 fn cellCoord(p : vec3<f32>) -> vec3<i32> {
     return vec3<i32>(
@@ -64,20 +69,6 @@ fn cellHash(c : vec3<i32>) -> i32 {
     return c.x + c.y * i32(GRID_X) + c.z * i32(GRID_X) * i32(GRID_Y);
 }
 
-fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
-    return vec4<f32>(
-        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
-        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
-        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
-        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z,
-    );
-}
-
-fn normalizeQ(q : vec4<f32>) -> vec4<f32> {
-    let l = length(q);
-    return select(vec4<f32>(0.0, 0.0, 0.0, 1.0), q / l, l > 0.0001);
-}
-
 fn pcgHash(v : u32) -> u32 {
     let state = v * 747796405u + 2891336453u;
     let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
@@ -87,76 +78,47 @@ fn rndU(seed : u32) -> f32 {
     return f32(pcgHash(seed)) * (1.0 / 4294967296.0);
 }
 
-const ANG_SCALE : f32 = 0.3;
-
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let i = id.x;
     if (i >= COIN_CAPACITY) { return; }
 
-    let info = infos[i];
-    let radius = info.size.x;
-    let seed = srcStates[i].position.w;
+    let info     = infos[i];
+    let radius   = info.size.x;
+    let seed     = srcStates[i].position.w;
+    let axis     = srcStates[i].axis;
+    let spinRate = srcStates[i].spin.y;
 
-    var pos = srcStates[i].position.xyz;
-    var vel = srcStates[i].velocity.xyz;
-    var rot = srcStates[i].rotation;
-    var angVel = srcStates[i].angularVel.xyz;
+    var pos   = srcStates[i].position.xyz;
+    var vel   = srcStates[i].velocity.xyz;
+    var angle = srcStates[i].spin.x;
 
-    let sleepY = params.groundY - 30.0;
-    let spawnY = params.groundY + 50.0;
+    let sleepY    = params.groundY - 30.0;
+    let spawnY    = params.groundY + 50.0;
     let spawnTime = f32(i) / SPAWN_RATE;
 
     if (pos.y < sleepY) {
         if (params.time >= spawnTime) {
             let salt = i * 2654435761u + u32(params.time * 60.0) * 40503u;
-            let ang = rndU(salt) * 6.28318530718;
-            let rad = sqrt(rndU(salt + 1u)) * SPAWN_RADIUS;
-            pos = vec3<f32>(cos(ang) * rad, spawnY, sin(ang) * rad);
-            vel = vec3<f32>(0.0, -1.0, 0.0);
-            angVel = vec3<f32>(
-                (rndU(salt + 3u) - 0.5) * 6.0,
-                (rndU(salt + 4u) - 0.5) * 2.0,
-                (rndU(salt + 5u) - 0.5) * 6.0,
-            );
-            rot = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            let ang  = rndU(salt) * 6.28318530718;
+            let rad  = sqrt(rndU(salt + 1u)) * SPAWN_RADIUS;
+            pos   = vec3<f32>(cos(ang) * rad, spawnY, sin(ang) * rad);
+            vel   = vec3<f32>(0.0, -1.0, 0.0);
+            angle = 0.0;
         }
         dstStates[i].position = vec4<f32>(pos, seed);
         dstStates[i].velocity = vec4<f32>(vel, 0.0);
-        dstStates[i].rotation = rot;
-        dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+        dstStates[i].axis     = axis;
+        dstStates[i].spin     = vec4<f32>(angle, spinRate, 0.0, 0.0);
         return;
     }
 
+    // 1. Gravity
     vel.y -= params.gravity * params.dt;
-    pos += vel * params.dt;
 
-    let sp = length(angVel);
-    if (sp > 0.0001) {
-        let axis = angVel / sp;
-        let half = sp * params.dt * 0.5;
-        rot = normalizeQ(quatMul(vec4<f32>(axis * sin(half), cos(half)), rot));
-    }
-
-    if (pos.y - radius < params.groundY && abs(pos.x) < GROUND_HALF && abs(pos.z) < GROUND_HALF) {
-        pos.y = params.groundY + radius;
-        if (vel.y < 0.0) {
-            let vn = vel.y;
-            let Jn = -vn * (1.0 + params.restitution);
-            vel.y = -vn * params.restitution;
-            let r_c = vec3<f32>(0.0, -radius, 0.0);
-            let contactVel = vel + cross(angVel, r_c);
-            let tangVel = vec3<f32>(contactVel.x, 0.0, contactVel.z);
-            let tLen = length(tangVel);
-            if (tLen > 0.001) {
-                let tDir = tangVel / tLen;
-                let Jt = min(params.friction * Jn, tLen);
-                vel -= vec3<f32>(tDir.x * Jt, 0.0, tDir.z * Jt);
-                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
-            }
-        }
-    }
-
+    // 2. Coin–coin: Jacobi accumulation (scan srcStates, apply corrections once)
+    var posCorr = vec3<f32>(0.0);
+    var velCorr = vec3<f32>(0.0);
     let myCoord = cellCoord(pos);
     for (var dz = -1; dz <= 1; dz = dz + 1) {
         for (var dy = -1; dy <= 1; dy = dy + 1) {
@@ -164,42 +126,55 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
                 let cidx = cellHash(myCoord + vec3<i32>(dx, dy, dz));
                 if (cidx < 0) { continue; }
                 let cellBase = u32(cidx) * (CELL_CAPACITY + 1u);
-                let count = min(grid[cellBase], CELL_CAPACITY);
+                let count    = min(grid[cellBase], CELL_CAPACITY);
                 for (var k = 0u; k < count; k = k + 1u) {
                     let j = grid[cellBase + 1u + k];
                     if (j == i) { continue; }
-                    let other = srcStates[j];
+                    let other       = srcStates[j];
                     let otherRadius = infos[j].size.x;
-                    let delta = pos - other.position.xyz;
-                    let dist = length(delta);
-                    let minDist = radius + otherRadius;
+                    let delta       = pos - other.position.xyz;
+                    let dist        = length(delta);
+                    let minDist     = radius + otherRadius;
                     if (dist < minDist && dist > 1e-4) {
-                        let n = delta / dist;
+                        let n       = delta / dist;
                         let overlap = minDist - dist;
-                        pos += n * (overlap * 0.5);
+                        posCorr += n * (overlap * 0.5);
                         let relVel = vel - other.velocity.xyz;
-                        let vn = dot(relVel, n);
+                        let vn     = dot(relVel, n);
                         if (vn < 0.0) {
-                            let Jn = -(vn * (1.0 + params.restitution) * 0.5);
-                            vel += n * Jn;
-                            let r_c = -n * radius;
-                            let relVt = relVel - vn * n;
-                            let vtLen = length(relVt);
-                            if (vtLen > 0.001) {
-                                let tDir = relVt / vtLen;
-                                let Jt = min(params.friction * Jn, vtLen * 0.5);
-                                vel -= tDir * Jt;
-                                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
-                            }
+                            velCorr += n * (-(vn * (1.0 + params.restitution) * 0.5));
                         }
                     }
                 }
             }
         }
     }
+    pos += posCorr;
+    vel += velCorr;
 
+    // 3. Floor
+    let onFloor = abs(pos.x) < GROUND_HALF && abs(pos.z) < GROUND_HALF;
+    if (onFloor && pos.y - radius < params.groundY) {
+        pos.y = params.groundY + radius;
+        if (vel.y < 0.0) { vel.y = -vel.y * params.restitution; }
+        vel.x *= params.friction;
+        vel.z *= params.friction;
+    }
+
+    // 4. Speed cap
+    let speed = length(vel);
+    if (speed > MAX_SPEED) { vel = vel * (MAX_SPEED / speed); }
+
+    // 5. Position update
+    pos += vel * params.dt;
+
+    // 6. Spin: faster when airborne or moving fast, slow on the floor
+    let inAir      = !onFloor || pos.y - radius > params.groundY + 0.05;
+    let spinFactor = select(FLOOR_SPIN_F, 1.0, inAir);
+    angle += spinRate * (SPIN_BASE + speed * SPIN_SPEED_K) * spinFactor * params.dt;
+
+    // 7. Linear damping
     vel *= params.damping;
-    angVel *= params.angDamping;
 
     if (pos.y < sleepY) {
         pos = vec3<f32>(0.0, -1000.0 - f32(i) * 0.01, 0.0);
@@ -208,8 +183,8 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
 
     dstStates[i].position = vec4<f32>(pos, seed);
     dstStates[i].velocity = vec4<f32>(vel, 0.0);
-    dstStates[i].rotation = rot;
-    dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+    dstStates[i].axis     = axis;
+    dstStates[i].spin     = vec4<f32>(angle, spinRate, 0.0, 0.0);
 }
 </script>
 
@@ -230,10 +205,10 @@ const CELL_CAPACITY : u32 = 8u;
 const CELL_SIZE : f32 = 1.7;
 const FLOOR_Y_C : f32 = -10.0;
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,
+    spin     : vec4<f32>,
 }
 @group(0) @binding(0) var<storage, read> states : array<CoinState>;
 @group(0) @binding(1) var<storage, read_write> grid : array<atomic<u32>>;

--- a/examples/threejs/wgsl_compute/coins/index.js
+++ b/examples/threejs/wgsl_compute/coins/index.js
@@ -53,6 +53,7 @@ const coinMeshInfo = new Array(MAX_COINS);
 const typeGroups   = [[], [], []];
 
 const _pos   = new THREE.Vector3();
+const _axis  = new THREE.Vector3();
 const _quat  = new THREE.Quaternion();
 const _scale = new THREE.Vector3(1, 1, 1);
 const _mat   = new THREE.Matrix4();
@@ -141,11 +142,20 @@ async function initScene() {
 function createInitialStates() {
     const states = new Float32Array(MAX_COINS * STATE_FLOATS);
     for (let coin = 0; coin < MAX_COINS; coin++) {
-        const seed = ((coin * 37) % 101) / 101;
-        const base = coin * STATE_FLOATS;
-        states[base + 1]  = -1000 - coin * 0.01; // y: parked below floor
-        states[base + 3]  = seed;                 // position.w = seed
-        states[base + 11] = 1;                    // rotation.w = 1 (identity quat)
+        const seed  = ((coin * 37) % 101) / 101;
+        const base  = coin * STATE_FLOATS;
+        states[base + 1] = -1000 - coin * 0.01; // y: parked below floor
+        states[base + 3] = seed;                 // position.w = seed
+
+        // Random unit axis on the sphere (Marsaglia / spherical coords)
+        const u     = randomFromIndex(coin * 3);
+        const v     = randomFromIndex(coin * 3 + 1);
+        const theta = u * Math.PI * 2;
+        const phi   = Math.acos(2 * v - 1);
+        states[base + 8]  = Math.sin(phi) * Math.cos(theta); // axis.x
+        states[base + 9]  = Math.sin(phi) * Math.sin(theta); // axis.y
+        states[base + 10] = Math.cos(phi);                   // axis.z
+        states[base + 13] = 0.5 + randomFromIndex(coin * 3 + 2) * 1.5; // spin rate
     }
     return states;
 }
@@ -240,7 +250,8 @@ function updateCoins(data) {
             _mat.makeTranslation(0, -10000, 0);
         } else {
             _pos.set(data[off], y, data[off + 2]);
-            _quat.set(data[off + 8], data[off + 9], data[off + 10], data[off + 11]);
+            _axis.set(data[off + 8], data[off + 9], data[off + 10]);
+            _quat.setFromAxisAngle(_axis, data[off + 12]);
             _mat.compose(_pos, _quat, _scale);
         }
         coinMeshes[typeIdx].setMatrixAt(instIdx, _mat);
@@ -259,7 +270,7 @@ function animate(timeMs) {
 
     device.queue.writeBuffer(simParamsBuffer, 0, new Float32Array([
         dt / SUBSTEPS, 9.81, GROUND_Y, 0.9992,
-        0.999, 0.2, 0.98, time,
+        0, 0.2, 0.92, time,
     ]));
 
     const encoder        = device.createCommandEncoder();

--- a/examples/webgpu/wgsl_compute/coins/index.html
+++ b/examples/webgpu/wgsl_compute/coins/index.html
@@ -8,20 +8,22 @@
 
 <script id="cs" type="x-shader/x-compute">
 const COIN_CAPACITY : u32 = 8192u;
-// Uniform spatial grid for broad-phase collision (see cs-build / cs-clear).
-// CELL_SIZE must be >= the largest coin diameter so the 3x3x3 neighbour scan
-// catches every overlapping pair.
 const GRID_X : u32 = 64u;
 const GRID_Y : u32 = 64u;
 const GRID_Z : u32 = 64u;
 const CELL_CAPACITY : u32 = 8u;
 const CELL_SIZE : f32 = 1.7;
 const FLOOR_Y_C : f32 = -10.0;
+
+// axis  = fixed random rotation axis per coin (set at init, never changed).
+// spin  = x: accumulated angle, y: per-coin spin rate (set at init, never changed).
+// Using a fixed axis + speed-driven angle instead of full angular momentum keeps the
+// tumble visually convincing while avoiding angular-velocity integration instability.
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,   // xyz = unit rotation axis (w unused)
+    spin     : vec4<f32>,   // x = current angle, y = spin rate (zw unused)
 }
 
 struct CoinInfo {
@@ -35,21 +37,25 @@ struct SimParams {
     gravity     : f32,
     groundY     : f32,
     damping     : f32,
-    angDamping  : f32,
+    _pad0       : f32,
     restitution : f32,
-    friction    : f32,
+    friction    : f32,   // floor friction multiplier (applied to x/z velocity on contact)
     time        : f32,
 }
 
-const GROUND_HALF : f32 = 13.0;
-const SPAWN_RADIUS : f32 = 3.0;     // radius of the narrow spawn column at the top
-const SPAWN_RATE : f32 = 350.0;     // coins per second streamed into the column
+const GROUND_HALF  : f32 = 13.0;
+const SPAWN_RADIUS : f32 = 3.0;
+const SPAWN_RATE   : f32 = 350.0;
+const MAX_SPEED    : f32 = 25.0;
+const SPIN_BASE    : f32 = 4.0;    // minimum spin speed (rad/s per unit spin rate)
+const SPIN_SPEED_K : f32 = 0.5;   // extra spin per m/s of linear speed
+const FLOOR_SPIN_F : f32 = 0.3;   // spin factor when resting on the floor
 
-@group(0) @binding(0) var<storage, read> srcStates : array<CoinState>;
-@group(0) @binding(1) var<storage, read_write> dstStates : array<CoinState>;
-@group(0) @binding(2) var<storage, read> infos : array<CoinInfo>;
-@group(0) @binding(3) var<uniform> params : SimParams;
-@group(0) @binding(4) var<storage, read> grid : array<u32>;
+@group(0) @binding(0) var<storage, read>            srcStates : array<CoinState>;
+@group(0) @binding(1) var<storage, read_write>      dstStates : array<CoinState>;
+@group(0) @binding(2) var<storage, read>            infos     : array<CoinInfo>;
+@group(0) @binding(3) var<uniform>                  params    : SimParams;
+@group(0) @binding(4) var<storage, read>            grid      : array<u32>;
 
 fn cellCoord(p : vec3<f32>) -> vec3<i32> {
     return vec3<i32>(
@@ -65,23 +71,6 @@ fn cellHash(c : vec3<i32>) -> i32 {
     return c.x + c.y * i32(GRID_X) + c.z * i32(GRID_X) * i32(GRID_Y);
 }
 
-fn quatMul(a : vec4<f32>, b : vec4<f32>) -> vec4<f32> {
-    return vec4<f32>(
-        a.w*b.x + a.x*b.w + a.y*b.z - a.z*b.y,
-        a.w*b.y - a.x*b.z + a.y*b.w + a.z*b.x,
-        a.w*b.z + a.x*b.y - a.y*b.x + a.z*b.w,
-        a.w*b.w - a.x*b.x - a.y*b.y - a.z*b.z,
-    );
-}
-
-fn normalizeQ(q : vec4<f32>) -> vec4<f32> {
-    let l = length(q);
-    return select(vec4<f32>(0.0, 0.0, 0.0, 1.0), q / l, l > 0.0001);
-}
-
-// A sin-based hash correlates its outputs when the inputs are linear
-// (s, s+1, s+2 ...), biasing spawn positions along a diagonal. Use a
-// statistically stronger PCG hash instead.
 fn pcgHash(v : u32) -> u32 {
     let state = v * 747796405u + 2891336453u;
     let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
@@ -91,89 +80,48 @@ fn rndU(seed : u32) -> f32 {
     return f32(pcgHash(seed)) * (1.0 / 4294967296.0);
 }
 
-const ANG_SCALE : f32 = 0.3;
-
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) id : vec3<u32>) {
     let i = id.x;
-    if (i >= COIN_CAPACITY) {
-        return;
-    }
+    if (i >= COIN_CAPACITY) { return; }
 
-    let info = infos[i];
-    let radius = info.size.x;
-    let seed = srcStates[i].position.w;
+    let info     = infos[i];
+    let radius   = info.size.x;
+    let seed     = srcStates[i].position.w;
+    let axis     = srcStates[i].axis;        // pass through unchanged
+    let spinRate = srcStates[i].spin.y;      // pass through unchanged
 
-    var pos = srcStates[i].position.xyz;
-    var vel = srcStates[i].velocity.xyz;
-    var rot = srcStates[i].rotation;
-    var angVel = srcStates[i].angularVel.xyz;
+    var pos   = srcStates[i].position.xyz;
+    var vel   = srcStates[i].velocity.xyz;
+    var angle = srcStates[i].spin.x;
 
-    let sleepY = params.groundY - 30.0;
-    let spawnY = params.groundY + 50.0;
+    let sleepY    = params.groundY - 30.0;
+    let spawnY    = params.groundY + 50.0;
     let spawnTime = f32(i) / SPAWN_RATE;
 
-    // Coins start asleep below the floor and stream in over time (a few per frame)
-    // through a narrow column, so they fall like a waterfall instead of being dumped
-    // all at once. Spilled coins drop past the floor, sleep, and re-stream (see below),
-    // which keeps the pile at a steady height instead of growing into a mountain.
     if (pos.y < sleepY) {
         if (params.time >= spawnTime) {
-            // Fresh random position/spin each spawn; the per-frame term in the salt
-            // makes a recycled coin reappear at a different point in the column.
             let salt = i * 2654435761u + u32(params.time * 60.0) * 40503u;
-            let ang = rndU(salt) * 6.28318530718;
-            let rad = sqrt(rndU(salt + 1u)) * SPAWN_RADIUS;
-            pos = vec3<f32>(cos(ang) * rad, spawnY, sin(ang) * rad);
-            vel = vec3<f32>(0.0, -1.0, 0.0);
-            angVel = vec3<f32>(
-                (rndU(salt + 3u) - 0.5) * 6.0,
-                (rndU(salt + 4u) - 0.5) * 2.0,
-                (rndU(salt + 5u) - 0.5) * 6.0,
-            );
-            rot = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            let ang  = rndU(salt) * 6.28318530718;
+            let rad  = sqrt(rndU(salt + 1u)) * SPAWN_RADIUS;
+            pos   = vec3<f32>(cos(ang) * rad, spawnY, sin(ang) * rad);
+            vel   = vec3<f32>(0.0, -1.0, 0.0);
+            angle = 0.0;
         }
         dstStates[i].position = vec4<f32>(pos, seed);
         dstStates[i].velocity = vec4<f32>(vel, 0.0);
-        dstStates[i].rotation = rot;
-        dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+        dstStates[i].axis     = axis;
+        dstStates[i].spin     = vec4<f32>(angle, spinRate, 0.0, 0.0);
         return;
     }
 
+    // 1. Gravity
     vel.y -= params.gravity * params.dt;
-    pos += vel * params.dt;
 
-    let sp = length(angVel);
-    if (sp > 0.0001) {
-        let axis = angVel / sp;
-        let half = sp * params.dt * 0.5;
-        rot = normalizeQ(quatMul(vec4<f32>(axis * sin(half), cos(half)), rot));
-    }
-
-    // Sphere vs ground plane: keep the sphere centre one radius above the floor.
-    if (pos.y - radius < params.groundY && abs(pos.x) < GROUND_HALF && abs(pos.z) < GROUND_HALF) {
-        pos.y = params.groundY + radius;
-        if (vel.y < 0.0) {
-            let vn = vel.y;
-            let Jn = -vn * (1.0 + params.restitution);
-            vel.y = -vn * params.restitution;
-            let r_c = vec3<f32>(0.0, -radius, 0.0);
-            let contactVel = vel + cross(angVel, r_c);
-            let tangVel = vec3<f32>(contactVel.x, 0.0, contactVel.z);
-            let tLen = length(tangVel);
-            if (tLen > 0.001) {
-                let tDir = tangVel / tLen;
-                let Jt = min(params.friction * Jn, tLen);
-                vel -= vec3<f32>(tDir.x * Jt, 0.0, tDir.z * Jt);
-                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
-            }
-        }
-    }
-
-    // Sphere vs sphere using a uniform spatial grid: only the 3x3x3 neighbouring cells
-    // are scanned instead of every other coin, turning the broad phase from O(N^2) into
-    // roughly O(N) so far more coins can be simulated. Asleep coins are never inserted
-    // into the grid, so they are skipped automatically.
+    // 2. Coin–coin collision: Jacobi (accumulate all corrections, apply once) so the
+    //    push-out is independent of the cell scan order and the pile spreads evenly.
+    var posCorr = vec3<f32>(0.0);
+    var velCorr = vec3<f32>(0.0);
     let myCoord = cellCoord(pos);
     for (var dz = -1; dz <= 1; dz = dz + 1) {
         for (var dy = -1; dy <= 1; dy = dy + 1) {
@@ -181,45 +129,56 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
                 let cidx = cellHash(myCoord + vec3<i32>(dx, dy, dz));
                 if (cidx < 0) { continue; }
                 let cellBase = u32(cidx) * (CELL_CAPACITY + 1u);
-                let count = min(grid[cellBase], CELL_CAPACITY);
+                let count    = min(grid[cellBase], CELL_CAPACITY);
                 for (var k = 0u; k < count; k = k + 1u) {
                     let j = grid[cellBase + 1u + k];
                     if (j == i) { continue; }
-                    let other = srcStates[j];
+                    let other      = srcStates[j];
                     let otherRadius = infos[j].size.x;
-                    let delta = pos - other.position.xyz;   // points from the other coin to this one
-                    let dist = length(delta);
-                    let minDist = radius + otherRadius;
+                    let delta      = pos - other.position.xyz;
+                    let dist       = length(delta);
+                    let minDist    = radius + otherRadius;
                     if (dist < minDist && dist > 1e-4) {
-                        let n = delta / dist;
+                        let n       = delta / dist;
                         let overlap = minDist - dist;
-                        pos += n * (overlap * 0.5);
+                        posCorr += n * (overlap * 0.5);
                         let relVel = vel - other.velocity.xyz;
-                        let vn = dot(relVel, n);
+                        let vn     = dot(relVel, n);
                         if (vn < 0.0) {
-                            let Jn = -(vn * (1.0 + params.restitution) * 0.5);
-                            vel += n * Jn;
-                            let r_c = -n * radius;
-                            let relVt = relVel - vn * n;
-                            let vtLen = length(relVt);
-                            if (vtLen > 0.001) {
-                                let tDir = relVt / vtLen;
-                                let Jt = min(params.friction * Jn, vtLen * 0.5);
-                                vel -= tDir * Jt;
-                                angVel += cross(r_c, -tDir * Jt) * ANG_SCALE;
-                            }
+                            velCorr += n * (-(vn * (1.0 + params.restitution) * 0.5));
                         }
                     }
                 }
             }
         }
     }
+    pos += posCorr;
+    vel += velCorr;
 
+    // 3. Floor
+    let onFloor = abs(pos.x) < GROUND_HALF && abs(pos.z) < GROUND_HALF;
+    if (onFloor && pos.y - radius < params.groundY) {
+        pos.y = params.groundY + radius;
+        if (vel.y < 0.0) { vel.y = -vel.y * params.restitution; }
+        vel.x *= params.friction;
+        vel.z *= params.friction;
+    }
+
+    // 4. Speed cap
+    let speed = length(vel);
+    if (speed > MAX_SPEED) { vel = vel * (MAX_SPEED / speed); }
+
+    // 5. Position update
+    pos += vel * params.dt;
+
+    // 6. Spin: speed-proportional, slows when resting on the floor
+    let inAir      = !onFloor || pos.y - radius > params.groundY + 0.05;
+    let spinFactor = select(FLOOR_SPIN_F, 1.0, inAir);
+    angle += spinRate * (SPIN_BASE + speed * SPIN_SPEED_K) * spinFactor * params.dt;
+
+    // 7. Linear damping
     vel *= params.damping;
-    angVel *= params.angDamping;
 
-    // Recycle: a coin that fell past the floor (spilled off the edge) goes back to
-    // sleep below and re-streams from the top next frame.
     if (pos.y < sleepY) {
         pos = vec3<f32>(0.0, -1000.0 - f32(i) * 0.01, 0.0);
         vel = vec3<f32>(0.0, 0.0, 0.0);
@@ -227,8 +186,8 @@ fn main(@builtin(global_invocation_id) id : vec3<u32>) {
 
     dstStates[i].position = vec4<f32>(pos, seed);
     dstStates[i].velocity = vec4<f32>(vel, 0.0);
-    dstStates[i].rotation = rot;
-    dstStates[i].angularVel = vec4<f32>(angVel, 0.0);
+    dstStates[i].axis     = axis;
+    dstStates[i].spin     = vec4<f32>(angle, spinRate, 0.0, 0.0);
 }
 </script>
 
@@ -251,10 +210,10 @@ const CELL_CAPACITY : u32 = 8u;
 const CELL_SIZE : f32 = 1.7;
 const FLOOR_Y_C : f32 = -10.0;
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,
+    spin     : vec4<f32>,
 }
 @group(0) @binding(0) var<storage, read> states : array<CoinState>;
 @group(0) @binding(1) var<storage, read_write> grid : array<atomic<u32>>;
@@ -292,10 +251,10 @@ struct Camera {
 }
 
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,   // xyz = unit rotation axis
+    spin     : vec4<f32>,   // x = current angle
 }
 
 struct CoinInfo {
@@ -328,9 +287,10 @@ const COIN_CAPACITY : u32 = 8192u;
 @group(0) @binding(2) var<storage, read> infos : array<CoinInfo>;
 @group(0) @binding(3) var<storage, read> staticItems : array<StaticItem>;
 
-fn rotByQuat(v : vec3<f32>, q : vec4<f32>) -> vec3<f32> {
-    let t = 2.0 * cross(q.xyz, v);
-    return v + q.w * t + cross(q.xyz, t);
+fn rotByAxisAngle(v : vec3<f32>, axis : vec3<f32>, angle : f32) -> vec3<f32> {
+    let cs = cos(angle);
+    let sn = sin(angle);
+    return v * cs + cross(axis, v) * sn + axis * dot(axis, v) * (1.0 - cs);
 }
 
 @vertex
@@ -338,11 +298,13 @@ fn main(@location(0) position : vec3<f32>, @location(1) normal : vec3<f32>, @loc
     var out : VSOut;
     if (instance < COIN_CAPACITY) {
         let state = states[instance];
-        let info = infos[instance];
+        let info  = infos[instance];
+        let axis  = normalize(state.axis.xyz);
+        let angle = state.spin.x;
         let local = vec3<f32>(position.x * info.size.x, position.y * info.size.y * 2.0, position.z * info.size.x);
-        let world = rotByQuat(local, state.rotation) + state.position.xyz;
+        let world = rotByAxisAngle(local, axis, angle) + state.position.xyz;
         out.position = camera.viewProjection * vec4<f32>(world, 1.0);
-        out.normal = normalize(rotByQuat(normal, state.rotation));
+        out.normal = normalize(rotByAxisAngle(normal, axis, angle));
         out.uv = uv;
         out.color = info.color;
         out.atlas = info.size.z;
@@ -426,10 +388,10 @@ struct Camera {
 }
 
 struct CoinState {
-    position   : vec4<f32>,
-    velocity   : vec4<f32>,
-    rotation   : vec4<f32>,
-    angularVel : vec4<f32>,
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+    axis     : vec4<f32>,
+    spin     : vec4<f32>,
 }
 
 struct CoinInfo {

--- a/examples/webgpu/wgsl_compute/coins/index.js
+++ b/examples/webgpu/wgsl_compute/coins/index.js
@@ -424,7 +424,16 @@ async function createInitialData() {
         // being dumped into the scene all at once. (Other state floats stay zero.)
         states[stateBase + 1] = -1000 - coin * 0.01;   // y: parked below the floor
         states[stateBase + 3] = seed;                  // position.w carries the seed
-        states[stateBase + 11] = 1;                    // rotation = identity quaternion
+        // Random unit rotation axis (axis.xyz) — fixed per coin throughout the simulation.
+        const u = randomFromIndex(coin * 3);
+        const v = randomFromIndex(coin * 3 + 1);
+        const theta = u * Math.PI * 2;
+        const phi   = Math.acos(2 * v - 1);
+        states[stateBase + 8]  = Math.sin(phi) * Math.cos(theta); // axis.x
+        states[stateBase + 9]  = Math.sin(phi) * Math.sin(theta); // axis.y
+        states[stateBase + 10] = Math.cos(phi);                   // axis.z
+        // spin.y = per-coin rate (0.5–2.0), spin.x starts at 0
+        states[stateBase + 13] = 0.5 + randomFromIndex(coin * 3 + 2) * 1.5;
         const infoBase = coin * INFO_FLOATS;
         infos[infoBase + 0] = type.radius;
         infos[infoBase + 1] = type.halfHeight;
@@ -535,11 +544,9 @@ function frame(timeMs) {
     simFloats[1] = 9.81;               // gravity
     simFloats[2] = GROUND_Y;           // ground plane height
     simFloats[3] = 0.9992;             // linear damping
-    simFloats[4] = 0.999;              // angular damping
+    simFloats[4] = 0;                  // unused (_pad0)
     simFloats[5] = 0.2;                // restitution
-    // Ground tangential friction (velocity retained per ground contact). Spheres
-    // need low friction to slide outward, otherwise they jam into a steep mound.
-    simFloats[6] = 0.98;               // friction
+    simFloats[6] = 0.92;               // floor friction multiplier (x/z velocity scale on contact)
     simFloats[7] = time;               // elapsed seconds (drives streamed spawning)
     device.queue.writeBuffer(simParamsBuffer, 0, simData);
 


### PR DESCRIPTION
## Summary

- **Fixed-axis spin model**: replace quaternion + `angularVel` with a fixed random unit axis per coin and speed-proportional accumulated angle — eliminates angDamping decay that was killing rotation
- **Jacobi collision response**: accumulate `posCorr`/`velCorr` from all neighbor contacts and apply once per substep, removing scan-order directional bias in dense piles
- **Physics update ordering**: gravity → collision → floor → speed cap → position update → spin update → linear damping (matches Babylon.js; position step is now last)
- **Floor friction**: simplified to `vel.x/z *= 0.92` (was full tangential impulse); `angDamping` slot repurposed as `_pad0`; `MAX_SPEED = 25 m/s` cap added
- **JS init**: `createInitialStates` / `createInitialData` now assign a uniformly-distributed random axis and spin rate `[0.5, 2.0]` per coin
- **three.js renderer**: `updateCoins` reads axis + angle from buffer and calls `_quat.setFromAxisAngle()` to build the instance matrix
- **WebGPU renderer**: vertex shader replaces `rotByQuat` with Rodrigues `rotByAxisAngle`
- **Docs**: adds §3.8 to `docs/physics-implementation-notes.md` documenting the spin model, Jacobi approach, and update ordering

## Test plan

- [ ] Open `examples/webgpu/wgsl_compute/coins/index.html` — coins should tumble and rotate visibly while falling, slow spin on floor contact
- [ ] Open `examples/threejs/wgsl_compute/coins/index.html` — same visual behaviour
- [ ] Press W in both: wireframe sphere colliders appear
- [ ] Compare against `examples/babylonjs/wgsl_compute/coins/index.html` — motion should be visually similar

🤖 Generated with [Claude Code](https://claude.com/claude-code)