### PR TITLE
Add W-key wireframe toggle to WebGPU + WGSL Stacked Boxes example

### DIFF
--- a/examples/webgpu/wgsl_compute/box/index.html
+++ b/examples/webgpu/wgsl_compute/box/index.html
@@ -193,7 +193,43 @@ fn main(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> {
 }
 </script>
 
+<div id="hint">W: wireframe ON</div>
 <canvas id="c" width="465" height="465"></canvas>
+
+<script id="wvs" type="x-shader/x-vertex">
+struct Camera {
+    viewProjection : mat4x4<f32>,
+}
+struct BoxState {
+    position : vec4<f32>,
+    velocity : vec4<f32>,
+}
+const COUNT : u32 = 256u;
+
+@group(0) @binding(0) var<uniform> camera : Camera;
+@group(0) @binding(1) var<storage, read> states : array<BoxState>;
+
+@vertex
+fn main(
+    @location(0) position : vec3<f32>,
+    @builtin(instance_index) instance : u32,
+) -> @builtin(position) vec4<f32> {
+    var worldPos : vec3<f32>;
+    if (instance < COUNT) {
+        worldPos = position + states[instance].position.xyz;
+    } else {
+        worldPos = position * vec3<f32>(32.0, 0.4, 32.0) + vec3<f32>(0.0, -2.2, 0.0);
+    }
+    return camera.viewProjection * vec4<f32>(worldPos, 1.0);
+}
+</script>
+
+<script id="wfs" type="x-shader/x-fragment">
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.53, 0.27, 1.0);
+}
+</script>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/box/index.js
+++ b/examples/webgpu/wgsl_compute/box/index.js
@@ -30,13 +30,16 @@ const SUBSTEPS = 5;
 const BOX_HALF = 0.5;
 const GROUND_Y = -2.0;
 
+let showWireframe = true;
 let device, context, format, depthTexture;
-let renderPipeline, computePipeline;
+let renderPipeline, computePipeline, wirePipeline;
 let vertexBuffer, normalBuffer, indexBuffer, indexCount;
+let wireVertexBuffer, wireIndexBuffer, wireIndexCount;
 let cameraBuffer, colorBuffer, simParamsBuffer;
 let stateBuffers = [];
 let renderBindGroups = [];
 let computeBindGroups = [];
+let wireBindGroups = [];
 let currentState = 0;
 let lastTime = -1;
 
@@ -99,6 +102,27 @@ function createBoxGeometry() {
     device.queue.writeBuffer(normalBuffer, 0, normals);
     device.queue.writeBuffer(indexBuffer, 0, indices);
     indexCount = indices.length;
+}
+
+function createWireframeGeometry() {
+    // 8 unique corners of a unit box
+    const corners = new Float32Array([
+        -0.5, -0.5, -0.5,   0.5, -0.5, -0.5,
+         0.5,  0.5, -0.5,  -0.5,  0.5, -0.5,
+        -0.5, -0.5,  0.5,   0.5, -0.5,  0.5,
+         0.5,  0.5,  0.5,  -0.5,  0.5,  0.5,
+    ]);
+    // 12 edges as line-list pairs
+    const edges = new Uint16Array([
+        0,1, 1,5, 5,4, 4,0,   // bottom face
+        3,2, 2,6, 6,7, 7,3,   // top face
+        0,3, 1,2, 5,6, 4,7,   // vertical edges
+    ]);
+    wireVertexBuffer = device.createBuffer({ size: corners.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    wireIndexBuffer  = device.createBuffer({ size: edges.byteLength,   usage: GPUBufferUsage.INDEX  | GPUBufferUsage.COPY_DST });
+    device.queue.writeBuffer(wireVertexBuffer, 0, corners);
+    device.queue.writeBuffer(wireIndexBuffer,  0, edges);
+    wireIndexCount = edges.length;
 }
 
 function createInitialStates() {
@@ -179,15 +203,18 @@ function frame(timeMs) {
         currentState = 1 - currentState;
     }
 
+    const colorView = context.getCurrentTexture().createView();
+    const depthView = depthTexture.createView();
+
     const renderPass = encoder.beginRenderPass({
         colorAttachments: [{
-            view: context.getCurrentTexture().createView(),
+            view: colorView,
             clearValue: { r: 0.97, g: 0.97, b: 0.98, a: 1.0 },
             loadOp: 'clear',
             storeOp: 'store',
         }],
         depthStencilAttachment: {
-            view: depthTexture.createView(),
+            view: depthView,
             depthClearValue: 1.0,
             depthLoadOp: 'clear',
             depthStoreOp: 'store',
@@ -202,6 +229,27 @@ function frame(timeMs) {
     renderPass.drawIndexed(indexCount, INSTANCE_COUNT);
     renderPass.end();
 
+    if (showWireframe) {
+        const wirePass = encoder.beginRenderPass({
+            colorAttachments: [{
+                view: colorView,
+                loadOp: 'load',
+                storeOp: 'store',
+            }],
+            depthStencilAttachment: {
+                view: depthView,
+                depthLoadOp: 'load',
+                depthStoreOp: 'store',
+            },
+        });
+        wirePass.setPipeline(wirePipeline);
+        wirePass.setVertexBuffer(0, wireVertexBuffer);
+        wirePass.setIndexBuffer(wireIndexBuffer, 'uint16');
+        wirePass.setBindGroup(0, wireBindGroups[currentState]);
+        wirePass.drawIndexed(wireIndexCount, INSTANCE_COUNT);
+        wirePass.end();
+    }
+
     device.queue.submit([encoder.finish()]);
     requestAnimationFrame(frame);
 }
@@ -215,6 +263,7 @@ async function init() {
     format = navigator.gpu.getPreferredCanvasFormat();
 
     createBoxGeometry();
+    createWireframeGeometry();
 
     const initialStates = createInitialStates();
     for (let i = 0; i < 2; i++) {
@@ -266,6 +315,22 @@ async function init() {
         },
     });
 
+    wirePipeline = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+            module: device.createShaderModule({ code: document.getElementById('wvs').textContent }),
+            entryPoint: 'main',
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x3' }] }],
+        },
+        fragment: {
+            module: device.createShaderModule({ code: document.getElementById('wfs').textContent }),
+            entryPoint: 'main',
+            targets: [{ format }],
+        },
+        primitive: { topology: 'line-list' },
+        depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'less-equal' },
+    });
+
     for (let i = 0; i < 2; i++) {
         renderBindGroups.push(device.createBindGroup({
             layout: renderPipeline.getBindGroupLayout(0),
@@ -282,6 +347,14 @@ async function init() {
                 { binding: 0, resource: { buffer: stateBuffers[i] } },
                 { binding: 1, resource: { buffer: stateBuffers[1 - i] } },
                 { binding: 2, resource: { buffer: simParamsBuffer } },
+            ],
+        }));
+
+        wireBindGroups.push(device.createBindGroup({
+            layout: wirePipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: cameraBuffer } },
+                { binding: 1, resource: { buffer: stateBuffers[i] } },
             ],
         }));
     }
@@ -339,5 +412,18 @@ function mat4Multiply(out, a, b) {
         }
     }
 }
+
+function setWireframeVisible(visible) {
+    showWireframe = visible;
+    const hint = document.getElementById('hint');
+    if (hint) hint.textContent = 'W: wireframe ' + (visible ? 'ON' : 'OFF');
+}
+
+window.addEventListener('keydown', (event) => {
+    if (event.repeat) return;
+    if (event.code === 'KeyW' || event.key === 'w' || event.key === 'W') {
+        setWireframeVisible(!showWireframe);
+    }
+});
 
 init().catch(err => console.error(err));

--- a/examples/webgpu/wgsl_compute/box/style.css
+++ b/examples/webgpu/wgsl_compute/box/style.css
@@ -11,3 +11,17 @@ body {
   background: #fff;
   font: 30px sans-serif;
 }
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #333;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary

- Add a second render pipeline with `line-list` topology that draws box collider edges (12 edges × 2 vertices per box) as an orange wireframe overlay on all 257 instances (256 boxes + 1 ground)
- Wireframe pass uses `loadOp: 'load'` to draw on top of the main render without clearing, with `depthCompare: 'less-equal'` so only front-facing edges are visible
- W key toggles wireframe on/off; hint text updates to show current state

## Test plan

- [ ] Open `examples/webgpu/wgsl_compute/box/index.html` — orange wireframe edges visible on all boxes and the ground plane by default
- [ ] Press W — wireframe hides; press W again — wireframe reappears
- [ ] Hint text in top-left reads "W: wireframe ON / OFF" accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)