### PR TITLE
Add FPS display to top-right corner across 14 examples

### DIFF
--- a/examples/babylonjs/havok/marbles/index.html
+++ b/examples/babylonjs/havok/marbles/index.html
@@ -11,6 +11,7 @@
 
 <canvas id="c" width="465" height="465"></canvas>
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/babylonjs/havok/marbles/index.js
+++ b/examples/babylonjs/havok/marbles/index.js
@@ -94,8 +94,12 @@ async function init() {
 
     scene = createScene();
 
+    const fpsEl = document.getElementById('fps');
     engine.runRenderLoop(function () {
         scene.render();
+        if (fpsEl) {
+            fpsEl.textContent = 'FPS: ' + engine.getFps().toFixed(1);
+        }
     });
 };
 

--- a/examples/babylonjs/havok/marbles/style.css
+++ b/examples/babylonjs/havok/marbles/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/balls/index.html
+++ b/examples/babylonjs/wgsl_compute/balls/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/balls/index.js
+++ b/examples/babylonjs/wgsl_compute/balls/index.js
@@ -700,6 +700,7 @@ fn fs(@location(0) color : vec4<f32>) -> @location(0) vec4<f32> { return color; 
     };
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let currentState = 0;
     const startTime = performance.now();
@@ -769,7 +770,8 @@ fn fs(@location(0) color : vec4<f32>) -> @location(0) vec4<f32> { return color; 
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/balls/style.css
+++ b/examples/babylonjs/wgsl_compute/balls/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/box/index.html
+++ b/examples/babylonjs/wgsl_compute/box/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/box/index.js
+++ b/examples/babylonjs/wgsl_compute/box/index.js
@@ -420,6 +420,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
     }));
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let currentState = 0;
     const startTime = performance.now();
@@ -488,7 +489,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/box/style.css
+++ b/examples/babylonjs/wgsl_compute/box/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/coins/index.html
+++ b/examples/babylonjs/wgsl_compute/coins/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/coins/index.js
+++ b/examples/babylonjs/wgsl_compute/coins/index.js
@@ -810,6 +810,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
     });
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     const startTime = performance.now();
     const SPAWN_DURATION = COIN_COUNT / 1666;
@@ -929,7 +930,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/coins/style.css
+++ b/examples/babylonjs/wgsl_compute/coins/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/cone/index.html
+++ b/examples/babylonjs/wgsl_compute/cone/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/cone/index.js
+++ b/examples/babylonjs/wgsl_compute/cone/index.js
@@ -753,6 +753,7 @@ fn fs(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> { return vec4<f3
     };
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let currentState = 0;
     const startTime = performance.now();
@@ -824,7 +825,8 @@ fn fs(@location(0) color : vec3<f32>) -> @location(0) vec4<f32> { return vec4<f3
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/cone/style.css
+++ b/examples/babylonjs/wgsl_compute/cone/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/domino/index.html
+++ b/examples/babylonjs/wgsl_compute/domino/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/domino/index.js
+++ b/examples/babylonjs/wgsl_compute/domino/index.js
@@ -376,6 +376,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
     });
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
 
     scene.onBeforeRenderObservable.add(() => {
@@ -438,7 +439,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/domino/style.css
+++ b/examples/babylonjs/wgsl_compute/domino/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/eraser/index.html
+++ b/examples/babylonjs/wgsl_compute/eraser/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/eraser/index.js
+++ b/examples/babylonjs/wgsl_compute/eraser/index.js
@@ -598,6 +598,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(1.0, 0.85, 0.1, 1.0); }
     }));
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let currentState = 0;
     const startTime = performance.now();
@@ -666,7 +667,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(1.0, 0.85, 0.1, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/eraser/style.css
+++ b/examples/babylonjs/wgsl_compute/eraser/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/football/index.html
+++ b/examples/babylonjs/wgsl_compute/football/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/football/index.js
+++ b/examples/babylonjs/wgsl_compute/football/index.js
@@ -600,6 +600,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
     }));
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let currentState = 0;
     const startTime = performance.now();
@@ -682,7 +683,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/football/style.css
+++ b/examples/babylonjs/wgsl_compute/football/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/gltf/index.html
+++ b/examples/babylonjs/wgsl_compute/gltf/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/gltf/index.js
+++ b/examples/babylonjs/wgsl_compute/gltf/index.js
@@ -251,6 +251,7 @@ fn main() {
     const inertiaInv = 1.0 / Math.max(halfExtents.x * halfExtents.x + halfExtents.z * halfExtents.z, 0.001);
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let readbackBusy = false;
 
@@ -294,7 +295,8 @@ fn main() {
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/gltf/style.css
+++ b/examples/babylonjs/wgsl_compute/gltf/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/marbles/index.html
+++ b/examples/babylonjs/wgsl_compute/marbles/index.html
@@ -9,6 +9,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/marbles/index.js
+++ b/examples/babylonjs/wgsl_compute/marbles/index.js
@@ -738,6 +738,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(1.0, 0.85, 0.1, 1.0); }
     });
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     const startTime = performance.now();
     const SPAWN_DURATION = MARBLE_COUNT / 400;
@@ -827,7 +828,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(1.0, 0.85, 0.1, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/marbles/style.css
+++ b/examples/babylonjs/wgsl_compute/marbles/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/minimum/index.html
+++ b/examples/babylonjs/wgsl_compute/minimum/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/minimum/index.js
+++ b/examples/babylonjs/wgsl_compute/minimum/index.js
@@ -245,6 +245,7 @@ fn main() {
     });
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let readbackBusy = false;
 
@@ -289,7 +290,8 @@ fn main() {
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/minimum/style.css
+++ b/examples/babylonjs/wgsl_compute/minimum/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/babylonjs/wgsl_compute/shogi/index.html
+++ b/examples/babylonjs/wgsl_compute/shogi/index.html
@@ -8,6 +8,7 @@
 <body>
 
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
 
 <script src="index.js"></script>

--- a/examples/babylonjs/wgsl_compute/shogi/index.js
+++ b/examples/babylonjs/wgsl_compute/shogi/index.js
@@ -648,6 +648,7 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
     const GRAVITY = 9.8;
 
     const hint = document.getElementById('hint');
+    const fpsEl = document.getElementById('fps');
     let frameCount = 0, lastFpsT = performance.now(), fps = 0;
     let ping = 0;
     const startTime = performance.now();
@@ -721,7 +722,8 @@ fn fs() -> @location(0) vec4<f32> { return vec4<f32>(0.1, 1.0, 0.35, 1.0); }
         if (now - lastFpsT > 500) {
             fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
             frameCount = 0; lastFpsT = now;
-            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+            if (fpsEl) fpsEl.textContent = fps + ' FPS';
         }
     });
 

--- a/examples/babylonjs/wgsl_compute/shogi/style.css
+++ b/examples/babylonjs/wgsl_compute/shogi/style.css
@@ -12,6 +12,21 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/webgpu/wgsl_compute/eraser/index.html
+++ b/examples/webgpu/wgsl_compute/eraser/index.html
@@ -8,6 +8,7 @@
 
 <canvas id="c"></canvas>
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 
 <script src="index.js"></script>
 </body>

--- a/examples/webgpu/wgsl_compute/eraser/index.js
+++ b/examples/webgpu/wgsl_compute/eraser/index.js
@@ -612,7 +612,9 @@ function render() {
         fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
         frameCount = 0; lastFpsT = now;
         const hint = document.getElementById('hint');
-        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+        const fpsEl = document.getElementById('fps');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        if (fpsEl) fpsEl.textContent = fps + ' FPS';
     }
 
     requestAnimationFrame(render);

--- a/examples/webgpu/wgsl_compute/eraser/style.css
+++ b/examples/webgpu/wgsl_compute/eraser/style.css
@@ -12,6 +12,20 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}
+
 #hint {
   position: fixed;
   top: 8px;

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.html
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.html
@@ -8,6 +8,7 @@
 
 <canvas id="c"></canvas>
 <div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
 
 <script src="https://cdn.jsdelivr.net/npm/lil-gui@0.20"></script>
 <script src="index.js"></script>

--- a/examples/webgpu/wgsl_compute/eraser_debug/index.js
+++ b/examples/webgpu/wgsl_compute/eraser_debug/index.js
@@ -753,7 +753,9 @@ function render() {
         fps = (frameCount * 1000 / (now - lastFpsT)) | 0;
         frameCount = 0; lastFpsT = now;
         const hint = document.getElementById('hint');
-        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF') + ' · ' + fps + ' FPS';
+        const fpsEl = document.getElementById('fps');
+        if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        if (fpsEl) fpsEl.textContent = fps + ' FPS';
     }
 
     requestAnimationFrame(render);

--- a/examples/webgpu/wgsl_compute/eraser_debug/style.css
+++ b/examples/webgpu/wgsl_compute/eraser_debug/style.css
@@ -17,6 +17,20 @@ body {
   font: 30px sans-serif;
 }
 
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #0f0;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+}
+
 #hint {
   position: fixed;
   top: 8px;


### PR DESCRIPTION
## Summary

- Add a separate `#fps` element (top-right) to 14 examples that previously showed FPS inside the wireframe hint or had no FPS display at all
- `W: wireframe ON/OFF` remains in the top-left `#hint` element as before
- FPS is now displayed independently in the top-right corner with matching style (`#9f9` for babylonjs/wgsl_compute, `#0f0` for webgpu/wgsl_compute)

### Affected examples

| Group | Examples |
|---|---|
| `babylonjs/havok` | marbles (new — uses `engine.getFps()`) |
| `babylonjs/wgsl_compute` | balls, box, coins, cone, domino, eraser, football, gltf, marbles, minimum, shogi |
| `webgpu/wgsl_compute` | eraser, eraser_debug |

## Test plan

- [ ] Open each example and confirm `FPS: --` appears top-right on load, then updates to a live value
- [ ] Press W and confirm wireframe hint updates top-left without touching the FPS display
- [ ] Verify FPS counter is readable on both light (babylonjs) and dark (webgpu) backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)