### PR TITLE
Add Babylon.js Lite + Havok minimum example

### DIFF
--- a/examples/babylonjs-lite/havok/minimum/index.html
+++ b/examples/babylonjs-lite/havok/minimum/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Babylon.js Lite + Havok Minimum Example</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+<div id="hint">W: wireframe ON</div>
+<div id="fps">FPS: --</div>
+<canvas id="c"></canvas>
+<script type="module" src="index.js"></script>
+</body>
+</html>

--- a/examples/babylonjs-lite/havok/minimum/index.js
+++ b/examples/babylonjs-lite/havok/minimum/index.js
@@ -1,0 +1,131 @@
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createEngine,
+    createGround,
+    createHavokWorld,
+    createHemisphericLight,
+    createPhysicsAggregate,
+    createPhysicsViewer,
+    createSceneContext,
+    createStandardMaterial,
+    hidePhysicsBody,
+    loadTexture2D,
+    onBeforeRender,
+    PhysicsShapeType,
+    registerScene,
+    showPhysicsBody,
+    startEngine,
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+
+import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+
+const PHYSICS_SCALE = 1 / 10;
+const PHYSICS_FPS = 60;
+
+async function main() {
+    const canvas = document.getElementById('c');
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+    scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
+
+    // ArcRotateCamera — positioned behind and above the scene
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.0, 25, { x: 0, y: 2, z: 0 });
+    scene.camera = camera;
+    attachControl(camera, canvas, scene);
+
+    // Hemispheric light
+    const light = createHemisphericLight([0, 1, 0]);
+    light.intensity = 1.0;
+    addToScene(scene, light);
+
+    // Standard material with frog texture
+    const material = createStandardMaterial();
+    material.diffuseTexture = await loadTexture2D(engine, '../../../../assets/textures/frog.jpg');
+    material.emissiveColor = [1, 1, 1];
+
+    // Ground — flat plane 20×20 at y = -2
+    const ground = createGround(engine, { width: 200 * PHYSICS_SCALE, height: 200 * PHYSICS_SCALE });
+    ground.material = material;
+    ground.position.set(0, -20 * PHYSICS_SCALE, 0);
+    addToScene(scene, ground);
+
+    // Falling box — size 5, starts at y = 10
+    const cube = createBox(engine, 50 * PHYSICS_SCALE);
+    cube.material = material;
+    cube.position.set(0, 100 * PHYSICS_SCALE, 0);
+    addToScene(scene, cube);
+
+    // FPS display (top-right)
+    const fpsEl = document.getElementById('fps');
+    let lastTime = performance.now();
+    let frameCount = 0;
+    onBeforeRender(scene, () => {
+        frameCount++;
+        const now = performance.now();
+        if (now - lastTime >= 1000) {
+            fpsEl.textContent = 'FPS: ' + Math.round(frameCount * 1000 / (now - lastTime));
+            frameCount = 0;
+            lastTime = now;
+        }
+    });
+
+    // Camera auto-rotation (1 degree per frame at 60 fps)
+    onBeforeRender(scene, () => {
+        camera.alpha += Math.PI / 180.0 / 60.0;
+    });
+
+    // Havok physics — WASM loads automatically from the same CDN path
+    const hknp = await HavokPhysics();
+    const world = createHavokWorld(scene, hknp, { x: 0, y: -9.8, z: 0 });
+
+    // Dynamic rigid body for the box
+    const cubeAggregate = createPhysicsAggregate(world, cube, PhysicsShapeType.BOX, {
+        mass: 1,
+        friction: 0.2,
+        restitution: 0.5,
+    });
+
+    // Static rigid body for the ground
+    const groundAggregate = createPhysicsAggregate(world, ground, PhysicsShapeType.BOX, {
+        mass: 0,
+        friction: 0.1,
+        restitution: 0.1,
+    });
+
+    // Physics wireframe viewer (W key to toggle)
+    const viewer = createPhysicsViewer(scene, world);
+    let showWireframe = true;
+    showPhysicsBody(viewer, cubeAggregate.body);
+    showPhysicsBody(viewer, groundAggregate.body);
+
+    window.addEventListener('keydown', (e) => {
+        if (e.repeat) return;
+        if (e.code === 'KeyW' || e.key === 'w' || e.key === 'W') {
+            showWireframe = !showWireframe;
+            if (showWireframe) {
+                showPhysicsBody(viewer, cubeAggregate.body);
+                showPhysicsBody(viewer, groundAggregate.body);
+            } else {
+                hidePhysicsBody(viewer, cubeAggregate.body);
+                hidePhysicsBody(viewer, groundAggregate.body);
+            }
+            const hint = document.getElementById('hint');
+            if (hint) hint.textContent = 'W: wireframe ' + (showWireframe ? 'ON' : 'OFF');
+        }
+    });
+
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+main().catch((err) => {
+    console.error('Babylon.js Lite error:', err);
+    document.body.style.color = '#f88';
+    document.body.style.padding = '1rem';
+    document.body.style.fontFamily = 'monospace';
+    document.body.innerHTML = '<b>Error:</b> ' + err.message +
+        '<br><br>This example requires a WebGPU-capable browser (Chrome 113+, Edge 113+).';
+});

--- a/examples/babylonjs-lite/havok/minimum/style.css
+++ b/examples/babylonjs-lite/havok/minimum/style.css
@@ -1,0 +1,43 @@
+* {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  background: #000;
+  font: 30px sans-serif;
+}
+
+#hint {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}
+
+#fps {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  width: auto;
+  height: auto;
+  color: #9f9;
+  background: rgba(0, 0, 0, 0.45);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font: 13px monospace;
+  pointer-events: none;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary

- Adds `examples/babylonjs-lite/havok/minimum` — the first example using [@babylonjs/lite](https://github.com/BabylonJS/Babylon-Lite), a WebGPU-only, tree-shakable subset of Babylon.js
- A textured box falls onto a flat ground plane driven by Havok physics (same scene parameters as the existing `babylonjs/havok/minimum`)
- W key toggles physics body wireframes on/off via `createPhysicsViewer` / `showPhysicsBody` / `hidePhysicsBody`
- FPS counter displayed in the top-right corner

## About Babylon.js Lite

[Babylon.js Lite](https://github.com/BabylonJS/Babylon-Lite) (`@babylonjs/lite`) is a WebGPU-exclusive, fully tree-shakable rendering engine derived from Babylon.js. It uses factory functions instead of constructors, plain data instead of class instances, and explicit `addToScene()` registration.

Key differences from the standard `babylonjs/havok` example:
| Babylon.js | Babylon.js Lite |
|---|---|
| `new WebGPUEngine(canvas)` | `await createEngine(canvas)` |
| `new Scene(engine)` | `createSceneContext(engine)` |
| `engine.runRenderLoop(...)` | `await startEngine(engine)` |
| `new ArcRotateCamera(...)` | `createArcRotateCamera(α, β, r, target)` |
| `MeshBuilder.CreateBox(...)` | `createBox(engine, size)` |
| `new HavokPlugin()` + `scene.enablePhysics(...)` | `createHavokWorld(scene, hknp, gravity)` |
| `new PhysicsAggregate(...)` | `createPhysicsAggregate(world, mesh, type, opts)` |
| `new Debug.PhysicsViewer(scene)` | `createPhysicsViewer(scene, world)` |

## Technical Notes

- No build step — ES module imports served directly from jsDelivr CDN (`@babylonjs/lite@1.0.1`, `@babylonjs/havok@1.3.12`)
- Havok WASM resolves automatically via `import.meta.url` when the ESM script is loaded from CDN
- Requires a WebGPU-capable browser (Chrome 113+, Edge 113+)

## Test plan

- [ ] Open `examples/babylonjs-lite/havok/minimum/index.html` in Chrome/Edge with WebGPU support
- [ ] Verify box falls onto ground and settles (Havok physics active)
- [ ] Verify FPS counter appears in top-right corner
- [ ] Press W → wireframe toggles OFF (hint updates to "W: wireframe OFF")
- [ ] Press W again → wireframe toggles ON
- [ ] Verify no console errors on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)