### PR TITLE
Bump Babylon.js Lite to 1.2.0 and reference libraries via importmap

### DIFF
--- a/examples/babylonjs-lite/havok/balls/index.html
+++ b/examples/babylonjs-lite/havok/balls/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/balls/index.js
+++ b/examples/babylonjs-lite/havok/balls/index.js
@@ -7,7 +7,7 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_SCALE = 1 / 10;

--- a/examples/babylonjs-lite/havok/balls/index.js
+++ b/examples/babylonjs-lite/havok/balls/index.js
@@ -7,8 +7,8 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/box/index.html
+++ b/examples/babylonjs-lite/havok/box/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/box/index.js
+++ b/examples/babylonjs-lite/havok/box/index.js
@@ -6,8 +6,8 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/box/index.js
+++ b/examples/babylonjs-lite/havok/box/index.js
@@ -6,7 +6,7 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_SCALE = 1 / 10;

--- a/examples/babylonjs-lite/havok/coins/index.html
+++ b/examples/babylonjs-lite/havok/coins/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/coins/index.js
+++ b/examples/babylonjs-lite/havok/coins/index.js
@@ -6,7 +6,7 @@ import {
     hidePhysicsBody, loadEnvironment, loadGltf, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const BASE_URL = 'https://cx20.github.io/gltf-test';

--- a/examples/babylonjs-lite/havok/coins/index.js
+++ b/examples/babylonjs-lite/havok/coins/index.js
@@ -6,8 +6,8 @@ import {
     hidePhysicsBody, loadEnvironment, loadGltf, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const BASE_URL = 'https://cx20.github.io/gltf-test';
 const DUCK_URL = BASE_URL + '/sampleModels/Duck/glTF/Duck.gltf';

--- a/examples/babylonjs-lite/havok/cone/index.html
+++ b/examples/babylonjs-lite/havok/cone/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/cone/index.js
+++ b/examples/babylonjs-lite/havok/cone/index.js
@@ -8,7 +8,7 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/cone/index.js
+++ b/examples/babylonjs-lite/havok/cone/index.js
@@ -8,8 +8,8 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_FPS = 60;
 const CONE_COUNT = 120;

--- a/examples/babylonjs-lite/havok/domino/index.html
+++ b/examples/babylonjs-lite/havok/domino/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/domino/index.js
+++ b/examples/babylonjs-lite/havok/domino/index.js
@@ -5,7 +5,7 @@ import {
     createSceneContext, createStandardMaterial,
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_SCALE = 1 / 10;

--- a/examples/babylonjs-lite/havok/domino/index.js
+++ b/examples/babylonjs-lite/havok/domino/index.js
@@ -5,8 +5,8 @@ import {
     createSceneContext, createStandardMaterial,
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/eraser/index.html
+++ b/examples/babylonjs-lite/havok/eraser/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/eraser/index.js
+++ b/examples/babylonjs-lite/havok/eraser/index.js
@@ -6,8 +6,8 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_FPS = 60;
 const ERASER_COUNT = 200;

--- a/examples/babylonjs-lite/havok/eraser/index.js
+++ b/examples/babylonjs-lite/havok/eraser/index.js
@@ -6,7 +6,7 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/football/index.html
+++ b/examples/babylonjs-lite/havok/football/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/football/index.js
+++ b/examples/babylonjs-lite/havok/football/index.js
@@ -6,8 +6,8 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/football/index.js
+++ b/examples/babylonjs-lite/havok/football/index.js
@@ -6,7 +6,7 @@ import {
     hidePhysicsBody, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_SCALE = 1 / 10;

--- a/examples/babylonjs-lite/havok/gltf/index.html
+++ b/examples/babylonjs-lite/havok/gltf/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON / click: jump</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/gltf/index.js
+++ b/examples/babylonjs-lite/havok/gltf/index.js
@@ -5,7 +5,7 @@ import {
     hidePhysicsBody, loadGltf, onBeforeRender, PhysicsShapeType,
     registerScene, setMeshVisible, showPhysicsBody, startEngine,
     setPhysicsBodyLinearVelocity,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const DUCK_URL = 'https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/Duck.gltf';

--- a/examples/babylonjs-lite/havok/gltf/index.js
+++ b/examples/babylonjs-lite/havok/gltf/index.js
@@ -5,8 +5,8 @@ import {
     hidePhysicsBody, loadGltf, onBeforeRender, PhysicsShapeType,
     registerScene, setMeshVisible, showPhysicsBody, startEngine,
     setPhysicsBodyLinearVelocity,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const DUCK_URL = 'https://rawcdn.githack.com/cx20/gltf-test/1f6515ce/sampleModels/Duck/glTF/Duck.gltf';
 const PHYSICS_FPS = 30;

--- a/examples/babylonjs-lite/havok/marbles/index.html
+++ b/examples/babylonjs-lite/havok/marbles/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/marbles/index.js
+++ b/examples/babylonjs-lite/havok/marbles/index.js
@@ -5,7 +5,7 @@ import {
     hidePhysicsBody, loadEnvironment, loadGltf, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, setMeshVisible, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const BASE_URL = 'https://cx20.github.io/gltf-test';

--- a/examples/babylonjs-lite/havok/marbles/index.js
+++ b/examples/babylonjs-lite/havok/marbles/index.js
@@ -5,8 +5,8 @@ import {
     hidePhysicsBody, loadEnvironment, loadGltf, loadTexture2D, onBeforeRender, PhysicsShapeType,
     registerScene, setMeshVisible, showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const BASE_URL = 'https://cx20.github.io/gltf-test';
 const MODEL_URL = BASE_URL + '/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';

--- a/examples/babylonjs-lite/havok/minimum/index.html
+++ b/examples/babylonjs-lite/havok/minimum/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/minimum/index.js
+++ b/examples/babylonjs-lite/havok/minimum/index.js
@@ -18,7 +18,7 @@ import {
     registerScene,
     showPhysicsBody,
     startEngine,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 

--- a/examples/babylonjs-lite/havok/minimum/index.js
+++ b/examples/babylonjs-lite/havok/minimum/index.js
@@ -18,9 +18,9 @@ import {
     registerScene,
     showPhysicsBody,
     startEngine,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
+} from '@babylonjs/lite';
 
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/shogi/index.html
+++ b/examples/babylonjs-lite/havok/shogi/index.html
@@ -8,6 +8,14 @@
 <div id="hint">W: wireframe ON</div>
 <div id="fps">FPS: --</div>
 <canvas id="c"></canvas>
+<script type="importmap">
+{
+  "imports": {
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+  }
+}
+</script>
 <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/examples/babylonjs-lite/havok/shogi/index.js
+++ b/examples/babylonjs-lite/havok/shogi/index.js
@@ -8,7 +8,7 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
 import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
 
 const PHYSICS_FPS = 60;

--- a/examples/babylonjs-lite/havok/shogi/index.js
+++ b/examples/babylonjs-lite/havok/shogi/index.js
@@ -8,8 +8,8 @@ import {
     registerSceneWithShadowSupport, setShadowTaskCasterMeshes,
     showPhysicsBody, startEngine,
     setPhysicsBodyAngularVelocity, setPhysicsBodyLinearVelocity, setPhysicsBodyPreStep,
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+} from '@babylonjs/lite';
+import HavokPhysics from '@babylonjs/havok';
 
 const PHYSICS_FPS = 60;
 const PIECE_COUNT = 300;


### PR DESCRIPTION
## Summary

For the Babylon.js Lite + Havok examples:

1. Bump `@babylonjs/lite` from `1.0.1` to `1.2.0`.
2. Move the versioned CDN URLs for `@babylonjs/lite` and `@babylonjs/havok` out of `index.js` and into an `importmap` in `index.html`, so `index.js` imports the libraries by bare specifier with no version information.

## Changes

`index.html` gains an importmap:

```html
<script type="importmap">
{
  "imports": {
    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
  }
}
</script>
```

`index.js` now imports by bare specifier:

```diff
-} from 'https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js';
+} from '@babylonjs/lite';
-import HavokPhysics from 'https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js';
+import HavokPhysics from '@babylonjs/havok';
```

Applied across all 11 Havok examples: balls, box, coins, cone, domino, eraser, football, gltf, marbles, minimum, shogi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)