### PR TITLE
Make Babylon.js Lite camera auto-rotation frame-rate independent

### DIFF
--- a/examples/babylonjs-lite/havok/balls/index.js
+++ b/examples/babylonjs-lite/havok/balls/index.js
@@ -159,6 +159,7 @@ async function main() {
     setShadowTaskCasterMeshes(shadowGenerator, objects.map((o) => o.mesh));
 
     // Recycle balls that fall below the floor
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
         for (const obj of objects) {
             if (obj.mesh.position.y < -100 * PHYSICS_SCALE) {
@@ -169,8 +170,12 @@ async function main() {
                 setPhysicsBodyAngularVelocity(world, obj.body, { x: 0, y: 0, z: 0 });
             }
         }
-        // Slow ~0.2 rad/s rotation to match the WebGL/WebGPU samples.
-        camera.alpha += 0.2 / 60;
+        // Slow ~0.2 rad/s rotation to match the WebGL/WebGPU samples. Framerate-independent
+        // via the Babylon.js getAnimationRatio() equivalent (= deltaMs / (1000/60)).
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += (0.2 / 60) * animationRatio;
     });
 
     const viewer = createPhysicsViewer(scene, world);

--- a/examples/babylonjs-lite/havok/box/index.js
+++ b/examples/babylonjs-lite/havok/box/index.js
@@ -131,6 +131,7 @@ async function main() {
     }
 
     // Recycle boxes that fall below the floor
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
         for (const obj of objects) {
             if (obj.mesh.position.y < -100 * PHYSICS_SCALE) {
@@ -141,7 +142,12 @@ async function main() {
                 setPhysicsBodyAngularVelocity(world, obj.body, { x: 0, y: 0, z: 0 });
             }
         }
-        camera.alpha += Math.PI / 180.0;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio()
+        // (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += (Math.PI / 180.0) * animationRatio;
     });
 
     const viewer = createPhysicsViewer(scene, world);

--- a/examples/babylonjs-lite/havok/cone/index.js
+++ b/examples/babylonjs-lite/havok/cone/index.js
@@ -155,6 +155,7 @@ async function main() {
     setShadowTaskCasterMeshes(shadowGenerator, casterMeshes);
 
     // Recycle cones that fall below the floor.
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
         for (const cone of cones) {
             if (cone.mesh.position.y < -100 * SCALE) {
@@ -167,7 +168,12 @@ async function main() {
                 setPhysicsBodyAngularVelocity(world, cone.body, { x: 0, y: 0, z: 0 });
             }
         }
-        camera.alpha -= 0.003;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio()
+        // (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha -= 0.003 * animationRatio;
     });
 
     const viewer = createPhysicsViewer(scene, world);

--- a/examples/babylonjs-lite/havok/domino/index.js
+++ b/examples/babylonjs-lite/havok/domino/index.js
@@ -88,7 +88,15 @@ async function main() {
         }
     });
 
-    onBeforeRender(scene, () => { camera.alpha += Math.PI * 0.5 / 180.0; });
+    // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio()
+    // (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+    let lastFrameTime = 0;
+    onBeforeRender(scene, () => {
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += (Math.PI * 0.5 / 180.0) * animationRatio;
+    });
 
     const hknp = await HavokPhysics();
     const world = createHavokWorld(scene, hknp, { x: 0, y: -9.8, z: 0 });

--- a/examples/babylonjs-lite/havok/football/index.js
+++ b/examples/babylonjs-lite/havok/football/index.js
@@ -135,6 +135,7 @@ async function main() {
     }
 
     // Recycle balls that fall below the floor
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
         for (const obj of objects) {
             if (obj.mesh.position.y < -100 * PHYSICS_SCALE) {
@@ -145,7 +146,12 @@ async function main() {
                 setPhysicsBodyAngularVelocity(world, obj.body, { x: 0, y: 0, z: 0 });
             }
         }
-        camera.alpha += Math.PI / 180.0;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio()
+        // (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += (Math.PI / 180.0) * animationRatio;
     });
 
     const viewer = createPhysicsViewer(scene, world);

--- a/examples/babylonjs-lite/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Basic_Shapes/index.js
@@ -170,6 +170,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -179,7 +180,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0012 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_Filtering/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Filtering/index.js
@@ -171,6 +171,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -180,7 +181,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0012 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_JointTypes/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_JointTypes/index.js
@@ -180,6 +180,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -189,7 +190,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0012 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Materials_Friction/index.js
@@ -159,6 +159,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -168,7 +169,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0015 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Materials_Restitution/index.js
@@ -159,6 +159,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -168,7 +169,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0015 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Motion_Properties/index.js
@@ -179,6 +179,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
     onBeforeRender(scene, () => {
         frameCount++;
@@ -188,7 +189,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0012 * animationRatio;
     });
 
     const hknp = await HavokPhysics();

--- a/examples/babylonjs-lite/havok/gltf_physics_Triggers/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Triggers/index.js
@@ -190,6 +190,7 @@ async function main() {
 
     const fpsEl = document.getElementById('fps');
     let lastTime = performance.now();
+    let lastFrameTime = 0;
     let frameCount = 0;
 
     const hknp = await HavokPhysics();
@@ -308,7 +309,10 @@ async function main() {
             frameCount = 0;
             lastTime = now;
         }
-        camera.alpha += 0.0012;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio().
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += 0.0012 * animationRatio;
 
         for (const trigger of triggers) {
             let active = false;

--- a/examples/babylonjs-lite/havok/marbles/index.js
+++ b/examples/babylonjs-lite/havok/marbles/index.js
@@ -170,6 +170,7 @@ async function main() {
     }
 
     // Recycle spheres that fall away.
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
         for (const s of spheres) {
             if (s.anchor.position.y < -100 * PHYSICS_SCALE) {
@@ -180,7 +181,12 @@ async function main() {
                 setPhysicsBodyAngularVelocity(world, s.body, { x: 0, y: 0, z: 0 });
             }
         }
-        camera.alpha -= 0.005;
+        // Framerate-independent spin to match the Babylon.js sample's getAnimationRatio()
+        // (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha -= 0.005 * animationRatio;
     });
 
     const viewer = createPhysicsViewer(scene, world);

--- a/examples/babylonjs-lite/havok/minimum/index.js
+++ b/examples/babylonjs-lite/havok/minimum/index.js
@@ -72,9 +72,14 @@ async function main() {
         }
     });
 
-    // Camera auto-rotation (1 degree per frame at 60 fps)
+    // Camera auto-rotation: 1 degree per frame at 60 fps, framerate-independent to match the
+    // Babylon.js sample's getAnimationRatio() (= deltaMs / (1000/60), i.e. 1.0 at 60 FPS).
+    let lastFrameTime = 0;
     onBeforeRender(scene, () => {
-        camera.alpha += Math.PI / 180.0 / 60.0;
+        const now = performance.now();
+        const animationRatio = lastFrameTime ? (now - lastFrameTime) / (1000 / 60) : 1;
+        lastFrameTime = now;
+        camera.alpha += (Math.PI / 180.0) * animationRatio;
     });
 
     // Havok physics — WASM loads automatically from the same CDN path


### PR DESCRIPTION
## Summary

Makes the auto-rotating camera in the **Babylon.js Lite** Havok samples frame-rate independent, matching the Babylon.js samples.

The Babylon.js samples scale their per-frame camera spin by `scene.getAnimationRatio()`, so the rotation speed stays constant regardless of display refresh rate. The Lite build does not expose `getAnimationRatio()`, so the Lite samples advanced the camera by a fixed amount **per frame** and spun ~2x faster on 120 Hz displays.

This derives the same ratio from the measured frame delta (`deltaMs / (1000/60)`, i.e. `1.0` at 60 FPS) and scales the spin by it.

## Also fixes two spin values to match the Babylon.js samples

- `minimum`: was `Math.PI/180/60` (~1°/s) → `Math.PI/180` per ratio (~60°/s)
- `gltf_physics` Materials Friction / Restitution: `0.0012` → `0.0015`

## Affected samples (14)

`balls`, `box`, `cone`, `domino`, `football`, `marbles`, `minimum`, and `gltf_physics` `Basic_Shapes` / `Filtering` / `JointTypes` / `Materials_Friction` / `Materials_Restitution` / `Motion_Properties` / `Triggers`.

Samples with a static camera (`coins`, `eraser`, `shogi`) are unchanged, matching their Babylon.js counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)