### PR TITLE
Match Babylon.js Lite minimum sample look to the Babylon.js sample

### DIFF
--- a/examples/babylonjs-lite/havok/minimum/index.js
+++ b/examples/babylonjs-lite/havok/minimum/index.js
@@ -31,10 +31,14 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
-    // ArcRotateCamera — positioned behind and above the scene
-    const camera = createArcRotateCamera(-Math.PI / 2, 1.0, 25, { x: 0, y: 2, z: 0 });
+    // ArcRotateCamera framed like the Babylon.js sample (camera.setPosition(0, 2, -20) looking at
+    // the origin): a near-horizontal view, alpha -PI/2, beta ~1.47, radius ~20.1, target (0,0,0).
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.471, 20.1, { x: 0, y: 0, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);
+
+    // White background, matching the Babylon.js sample (scene.clearColor = Color3(1,1,1)).
+    scene.clearColor = { r: 1, g: 1, b: 1, a: 1 };
 
     // Hemispheric light
     const light = createHemisphericLight([0, 1, 0]);


### PR DESCRIPTION
## Summary

Aligns the **Babylon.js Lite** `havok/minimum` sample's look with the **Babylon.js** sample, as part of keeping each Lite sample visually matched to its Babylon.js counterpart.

`examples/babylonjs-lite/havok/minimum/index.js`:
- **White background** — `scene.clearColor = (1,1,1)`, matching the Babylon.js sample's `scene.clearColor = Color3(1,1,1)` (the Lite version previously used the dark default background)
- **Camera reframed** to the Babylon.js effective view (`camera.setPosition(0, 2, -20)` looking at the origin): `alpha -PI/2, beta ~1.47, radius ~20.1, target (0,0,0)` — a near-horizontal view (the Lite version was higher / more top-down)

## Verification

Rendered both versions and compared side by side — the Lite version now shows the same white background, frog-textured box + ground, and near-horizontal framing as the Babylon.js version. (Babylon.js via headless WebGL2; Lite via **headed Chrome on the real GPU**, since headless WebGPU canvas capture is not available.)

This is the first of a series aligning the remaining Lite samples to their Babylon.js counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)