### PR TITLE
Match Babylon.js Lite gltf_physics background to the Babylon.js samples

### DIFF
--- a/examples/babylonjs-lite/havok/gltf_physics_Basic_Shapes/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Basic_Shapes/index.js
@@ -157,6 +157,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.3, 16, { x: 0, y: 2.4, z: 2.2 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);

--- a/examples/babylonjs-lite/havok/gltf_physics_Filtering/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Filtering/index.js
@@ -158,6 +158,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.2, 13, { x: 0, y: 2.6, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);

--- a/examples/babylonjs-lite/havok/gltf_physics_JointTypes/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_JointTypes/index.js
@@ -167,6 +167,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.3, 11, { x: 0, y: 2.6, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);

--- a/examples/babylonjs-lite/havok/gltf_physics_Materials_Friction/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Materials_Friction/index.js
@@ -144,6 +144,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     // View the front of the scene (azimuth rotated 180 deg from the Babylon.js example so the
     // sloped floor's top faces the camera): ArcRotate at alpha +PI/2, beta PI/2.2.
     const camera = createArcRotateCamera(Math.PI / 2, Math.PI / 2.2, 11, { x: 0, y: 2.6, z: -2.4 });

--- a/examples/babylonjs-lite/havok/gltf_physics_Materials_Restitution/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Materials_Restitution/index.js
@@ -145,6 +145,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     // View the front of the scene (azimuth rotated 180 deg, matching the Materials Friction view).
     const camera = createArcRotateCamera(Math.PI / 2, 1.15, 4.5, { x: 0, y: 0.6, z: 0 });
     scene.camera = camera;

--- a/examples/babylonjs-lite/havok/gltf_physics_Motion_Properties/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Motion_Properties/index.js
@@ -165,6 +165,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     // Azimuth chosen so the scene faces the camera the way the Babylon.js (full) example does.
     const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.2, 13, { x: 0, y: 2.6, z: 0 });
     scene.camera = camera;

--- a/examples/babylonjs-lite/havok/gltf_physics_Triggers/index.js
+++ b/examples/babylonjs-lite/havok/gltf_physics_Triggers/index.js
@@ -177,6 +177,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
+    // Light background, matching the Babylon.js sample (scene.clearColor = (0.97, 0.97, 0.98)).
+    scene.clearColor = { r: 0.97, g: 0.97, b: 0.98, a: 1.0 };
+
     const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.4, 6, { x: 0, y: 0.8, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);


### PR DESCRIPTION
## Summary

The Babylon.js `gltf_physics` samples use a **light background** (`scene.clearColor = Color4(0.97, 0.97, 0.98, 1.0)`), but the Babylon.js Lite versions left the **dark default** background, so the two looked clearly different.

This sets the same light `clearColor` on all seven Lite `gltf_physics` samples:

`Basic_Shapes`, `Filtering`, `JointTypes`, `Materials_Friction`, `Materials_Restitution`, `Motion_Properties`, `Triggers`.

## Verification

Rendered the Babylon.js and Lite versions side by side. Before, the Lite scenes had a dark navy background while the Babylon.js scenes were near-white; after, both show the same light background.

(Babylon.js via headless WebGL2; Lite via headed Chrome on the real GPU, since headless WebGPU canvas capture is not available.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)