### PR TITLE
Match Babylon.js Lite camera framing to the Babylon.js samples

### DIFF
--- a/examples/babylonjs-lite/havok/balls/index.js
+++ b/examples/babylonjs-lite/havok/balls/index.js
@@ -33,7 +33,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
-    const camera = createArcRotateCamera(0.86, 1.37, 40, { x: 0, y: 5 * PHYSICS_SCALE, z: 0 });
+    // Match the Babylon.js sample's effective view: it overrides the ArcRotateCamera ctor with
+    // camera.setPosition(0, 2, -30) looking at the origin -> alpha -PI/2, beta ~1.50, radius ~30.07.
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.504, 30.07, { x: 0, y: 0, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);
 

--- a/examples/babylonjs-lite/havok/box/index.js
+++ b/examples/babylonjs-lite/havok/box/index.js
@@ -58,7 +58,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
-    const camera = createArcRotateCamera(-2.2, 1.0, 50, { x: 0, y: 15 * PHYSICS_SCALE, z: 0 });
+    // Match the Babylon.js sample's effective view: it overrides the ArcRotateCamera ctor with
+    // camera.setPosition(0, 3, -30) looking at the origin -> alpha -PI/2, beta ~1.47, radius ~30.15.
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.471, 30.15, { x: 0, y: 0, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);
 

--- a/examples/babylonjs-lite/havok/domino/index.js
+++ b/examples/babylonjs-lite/havok/domino/index.js
@@ -53,7 +53,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
-    const camera = createArcRotateCamera(-2.2, 1.0, 50, { x: 0, y: 0, z: 0 });
+    // Match the Babylon.js sample's effective view: it overrides the ArcRotateCamera ctor with
+    // camera.setPosition(0, 10, -30) looking at the origin -> alpha -PI/2, beta ~1.25, radius ~31.62.
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.249, 31.62, { x: 0, y: 0, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);
 

--- a/examples/babylonjs-lite/havok/football/index.js
+++ b/examples/babylonjs-lite/havok/football/index.js
@@ -58,7 +58,9 @@ async function main() {
     const scene = createSceneContext(engine);
     scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
 
-    const camera = createArcRotateCamera(-2.2, 1.0, 50, { x: 0, y: 20 * PHYSICS_SCALE, z: 0 });
+    // Match the Babylon.js sample's effective view: it overrides the ArcRotateCamera ctor with
+    // camera.setPosition(0, 2, -30) looking at the origin -> alpha -PI/2, beta ~1.50, radius ~30.07.
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.504, 30.07, { x: 0, y: 0, z: 0 });
     scene.camera = camera;
     attachControl(camera, canvas, scene);
 


### PR DESCRIPTION
## Summary

The Babylon.js `balls` / `box` / `domino` / `football` samples create an `ArcRotateCamera` and then immediately override its pose with `camera.setPosition(...)`, which recomputes `alpha` / `beta` / `radius`. The Babylon.js Lite versions had copied the **overridden** constructor values, so they were framed farther out / at a different angle than the Babylon.js samples (objects appeared smaller, more of the scene visible).

This sets each Lite camera to the Babylon.js **effective** view (derived from the `setPosition` target, looking at the origin):

| sample | Babylon.js `setPosition` | → Lite camera (alpha, beta, radius, target) |
|---|---|---|
| balls | `(0, 2, -30)` | `(-PI/2, 1.504, 30.07, origin)` |
| box | `(0, 3, -30)` | `(-PI/2, 1.471, 30.15, origin)` |
| domino | `(0, 10, -30)` | `(-PI/2, 1.249, 31.62, origin)` |
| football | `(0, 2, -30)` | `(-PI/2, 1.504, 30.07, origin)` |

## Verification

Rendered the Babylon.js and Lite versions side by side at the same window size. Before, the Lite scenes were zoomed out relative to the Babylon.js scenes; after, the framing (zoom + angle) matches.

(Babylon.js via headless WebGL2; Lite via headed Chrome on the real GPU.)

`eraser` and `shogi` already match (`setPosition(0,0,40)` → radius 40, beta PI/2, origin — the Lite versions already use those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)