### PR TITLE
Fix Babylon.js Lite domino ball size to match the Babylon.js sample

### DIFF
--- a/examples/babylonjs-lite/havok/domino/index.js
+++ b/examples/babylonjs-lite/havok/domino/index.js
@@ -143,7 +143,9 @@ async function main() {
     ballMat.diffuseTexture = footballTex;
     ballMat.emissiveColor = [1, 1, 1];
     for (let y = 0; y < 16; y++) {
-        const ball = createSphere(engine, BALL_SIZE * PHYSICS_SCALE);
+        // createSphere expects an options object; passing a bare number left diameter at its
+        // default of 1 (~2/3 the intended size). Match the Babylon.js sample's diameter 1.5.
+        const ball = createSphere(engine, { diameter: BALL_SIZE * PHYSICS_SCALE, segments: 16 });
         const x1 = -105 * PHYSICS_SCALE;
         const y1 = (10 + Math.random()) * PHYSICS_SCALE;
         const z1 = (-150 + y * BALL_SIZE * 1.2) * PHYSICS_SCALE;


### PR DESCRIPTION
## Summary

In the Babylon.js Lite `domino` sample the soccer balls were roughly **half the size** of the Babylon.js sample's.

Cause: Lite's `createSphere(engine, options)` expects an **options object** (`{ diameter, segments }`), but the domino sample passed a **bare number**:

```js
const ball = createSphere(engine, BALL_SIZE * PHYSICS_SCALE); // wrong
```

So `options.diameter` was `undefined` and `createSphereData` fell back to its default `diameter ?? 1` → a diameter-1 ball instead of the intended 1.5 (~2/3 the size). Every other Lite sample (`balls`, `football`, `gltf_physics_*`) already passes an object.

Fix:

```js
const ball = createSphere(engine, { diameter: BALL_SIZE * PHYSICS_SCALE, segments: 16 }); // diameter 1.5
```

This matches the Babylon.js sample's `Mesh.CreateSphere(name, 16, BALL_SIZE * PHYSICS_SCALE)`. The `SPHERE` physics aggregate derives its radius from the mesh, so the collider is corrected along with the visual.

## Verification

Rendered both versions side by side at the same window size; the Lite balls are now the same size as the Babylon.js balls. (Babylon.js via headless WebGL2; Lite via headed Chrome on the real GPU.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)