### PR TITLE
Bump Babylon.js Lite to 1.3.0 in all examples

### DIFF
--- a/examples/babylon-lite/havok/balls/index.html
+++ b/examples/babylon-lite/havok/balls/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/box/index.html
+++ b/examples/babylon-lite/havok/box/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/coins/index.html
+++ b/examples/babylon-lite/havok/coins/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/cone/index.html
+++ b/examples/babylon-lite/havok/cone/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/domino/index.html
+++ b/examples/babylon-lite/havok/domino/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/eraser/index.html
+++ b/examples/babylon-lite/havok/eraser/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/football/index.html
+++ b/examples/babylon-lite/havok/football/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf/index.html
+++ b/examples/babylon-lite/havok/gltf/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/marbles/index.html
+++ b/examples/babylon-lite/havok/marbles/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/minimum/index.html
+++ b/examples/babylon-lite/havok/minimum/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/shogi/index.html
+++ b/examples/babylon-lite/havok/shogi/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js",
+    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
     "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
## Summary
Update the `@babylonjs/lite` CDN import map entry from `1.2.0` to `1.3.0` across all 18 babylonjs-lite Havok examples.

## Changes
- `examples/babylonjs-lite/havok/*/index.html`: `@babylonjs/lite@1.2.0` → `@babylonjs/lite@1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)