### PR TITLE
Switch Babylon Lite examples to esm.sh and bump to 1.4.0

### DIFF
--- a/examples/babylon-lite/havok/balls/index.html
+++ b/examples/babylon-lite/havok/balls/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/box/index.html
+++ b/examples/babylon-lite/havok/box/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/coins/index.html
+++ b/examples/babylon-lite/havok/coins/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/coins/index.js
+++ b/examples/babylon-lite/havok/coins/index.js
@@ -12,7 +12,7 @@ import HavokPhysics from '@babylonjs/havok';
 const BASE_URL = 'https://cx20.github.io/gltf-test';
 const DUCK_URL = BASE_URL + '/sampleModels/Duck/glTF/Duck.gltf';
 const ENV_URL = BASE_URL + '/textures/env/papermillSpecularHDR.env';
-const BRDF_URL = 'https://cdn.jsdelivr.net/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
+const BRDF_URL = 'https://esm.sh/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;
 const COIN_INTERVAL = 3; // place a coin on every 3rd duck index, matching the Babylon.js sample

--- a/examples/babylon-lite/havok/cone/index.html
+++ b/examples/babylon-lite/havok/cone/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/domino/index.html
+++ b/examples/babylon-lite/havok/domino/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/eraser/index.html
+++ b/examples/babylon-lite/havok/eraser/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/football/index.html
+++ b/examples/babylon-lite/havok/football/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf/index.html
+++ b/examples/babylon-lite/havok/gltf/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/marbles/index.html
+++ b/examples/babylon-lite/havok/marbles/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/marbles/index.js
+++ b/examples/babylon-lite/havok/marbles/index.js
@@ -11,7 +11,7 @@ import HavokPhysics from '@babylonjs/havok';
 const BASE_URL = 'https://cx20.github.io/gltf-test';
 const MODEL_URL = BASE_URL + '/tutorialModels/IridescenceMetallicSpheres/glTF/IridescenceMetallicSpheres.gltf';
 const ENV_URL = BASE_URL + '/textures/env/papermillSpecularHDR.env';
-const BRDF_URL = 'https://cdn.jsdelivr.net/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
+const BRDF_URL = 'https://esm.sh/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
 const PHYSICS_SCALE = 1 / 10;
 const PHYSICS_FPS = 60;
 

--- a/examples/babylon-lite/havok/minimum/index.html
+++ b/examples/babylon-lite/havok/minimum/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/shogi/index.html
+++ b/examples/babylon-lite/havok/shogi/index.html
@@ -11,8 +11,8 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>

--- a/examples/babylon-lite/havok/shogi/index.js
+++ b/examples/babylon-lite/havok/shogi/index.js
@@ -16,7 +16,7 @@ const PIECE_COUNT = 300;
 // PBR materials need IBL textures + a BRDF LUT; loadEnvironment supplies both (and enables the
 // tone mapping that gives the gamma-correct look). No skyboxUrl, so the background stays clearColor.
 const ENV_URL = 'https://cx20.github.io/gltf-test/textures/env/papermillSpecularHDR.env';
-const BRDF_URL = 'https://cdn.jsdelivr.net/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
+const BRDF_URL = 'https://esm.sh/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png';
 // Full box-collider extents, identical to the other Havok shogi samples' shape sizes.
 const SHOGI_PHYSICS_SIZE = [1.6, 1.92, 0.448];
 const GROUND_PHYSICS_SIZE = [13, 0.1, 13];


### PR DESCRIPTION
## Summary

- Bump `@babylonjs/lite` from `1.3.0` to `1.4.0` in all Babylon Lite Havok examples.
- Serve all Babylon Lite example dependencies from `esm.sh` instead of `cdn.jsdelivr.net`.

## Why

The console reported an outdated version (`Babylon Lite v0.1.0`). jsDelivr resolved the bare `@babylonjs/lite` specifier to `dist/index.js`, a legacy bundle whose hardcoded `VERSION` was still `0.1.0`. `esm.sh` honors the package `exports` map and loads `lib/index.js`, which logs the correct version.

## Changes (under `examples/babylon-lite/havok`)

| Dependency | Before | After |
| --- | --- | --- |
| `@babylonjs/lite` | `cdn.jsdelivr.net/npm/@babylonjs/lite@1.3.0/index.js` | `esm.sh/@babylonjs/lite@1.4.0` |
| `@babylonjs/havok` | `cdn.jsdelivr.net/npm/...HavokPhysics_es.js` | `esm.sh/...HavokPhysics_es.js` |
| `brdf-lut.png` | `cdn.jsdelivr.net/gh/...` | `esm.sh/gh/...` |

## Verification

- Confirmed in-browser that examples render and physics run correctly.
- Havok WASM resolves via esm.sh (`/es2022/HavokPhysics.wasm` -> 301 -> `/lib/esm/HavokPhysics.wasm`, `application/wasm`).
- `brdf-lut.png` served by esm.sh as `image/png`.
- Console now prints the correct Babylon Lite version.

Note: examples outside `examples/babylon-lite` still use `cdn.jsdelivr.net` and are intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)