### PR TITLE
Use esm.sh ?bundle for Babylon Lite import

### DIFF
--- a/examples/babylon-lite/havok/balls/index.html
+++ b/examples/babylon-lite/havok/balls/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/box/index.html
+++ b/examples/babylon-lite/havok/box/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/coins/index.html
+++ b/examples/babylon-lite/havok/coins/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/cone/index.html
+++ b/examples/babylon-lite/havok/cone/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/domino/index.html
+++ b/examples/babylon-lite/havok/domino/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/eraser/index.html
+++ b/examples/babylon-lite/havok/eraser/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/football/index.html
+++ b/examples/babylon-lite/havok/football/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf/index.html
+++ b/examples/babylon-lite/havok/gltf/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/marbles/index.html
+++ b/examples/babylon-lite/havok/marbles/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/minimum/index.html
+++ b/examples/babylon-lite/havok/minimum/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/shogi/index.html
+++ b/examples/babylon-lite/havok/shogi/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.6.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
## Summary

Append `?bundle` to the `@babylonjs/lite` esm.sh import in all Babylon Lite Havok examples, so esm.sh inlines internal modules into a single file (`lite.bundle.mjs`).

- Before: `https://esm.sh/@babylonjs/lite@1.6.0`
- After: `https://esm.sh/@babylonjs/lite@1.6.0?bundle`

## Why

Without bundling, esm.sh code-splits Babylon Lite. Animation handlers that Babylon Lite registers through dynamic `import()` side effects then land in a separate chunk and never reach the loader instance, so some animations (e.g. `KHR_animation_pointer`) fail to play. `?bundle` keeps the handler in the same instance.

Ref: https://github.com/cx20/gltf-test/pull/954

## Verification

- Confirmed esm.sh resolves `@babylonjs/lite@1.6.0?bundle` to `/es2022/lite.bundle.mjs` (HTTP 200).
- 18 files updated; no remaining non-bundled `lite@1.6.0` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)