### PR TITLE
Bump Babylon Lite to 1.8.0 in all examples

### DIFF
--- a/examples/babylon-lite/havok/balls/index.html
+++ b/examples/babylon-lite/havok/balls/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/box/index.html
+++ b/examples/babylon-lite/havok/box/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/coins/index.html
+++ b/examples/babylon-lite/havok/coins/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/cone/index.html
+++ b/examples/babylon-lite/havok/cone/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/domino/index.html
+++ b/examples/babylon-lite/havok/domino/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/eraser/index.html
+++ b/examples/babylon-lite/havok/eraser/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/football/index.html
+++ b/examples/babylon-lite/havok/football/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf/index.html
+++ b/examples/babylon-lite/havok/gltf/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Basic_Shapes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Filtering/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_JointTypes/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Friction/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Materials_Restitution/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Motion_Properties/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
+++ b/examples/babylon-lite/havok/gltf_physics_Triggers/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/marbles/index.html
+++ b/examples/babylon-lite/havok/marbles/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/minimum/index.html
+++ b/examples/babylon-lite/havok/minimum/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/havok/shogi/index.html
+++ b/examples/babylon-lite/havok/shogi/index.html
@@ -11,7 +11,7 @@
 <script type="importmap">
 {
   "imports": {
-    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "@babylonjs/lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
Update the Babylon.js Lite CDN import across all 18 `examples/babylon-lite/havok/*` examples from `@babylonjs/lite@1.7.0?bundle` to `@babylonjs/lite@1.8.0?bundle`.

Only the version pin in each `importmap` changed; the `@babylonjs/havok` import is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)