### PR TITLE
Bump Rhodonite to v0.19.9 in all examples

### DIFF
--- a/examples/rhodonite/havok/balls/index.html
+++ b/examples/rhodonite/havok/balls/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/box/index.html
+++ b/examples/rhodonite/havok/box/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/coins/index.html
+++ b/examples/rhodonite/havok/coins/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/cone/index.html
+++ b/examples/rhodonite/havok/cone/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/domino/index.html
+++ b/examples/rhodonite/havok/domino/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/eraser/index.html
+++ b/examples/rhodonite/havok/eraser/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/football/index.html
+++ b/examples/rhodonite/havok/football/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf/index.html
+++ b/examples/rhodonite/havok/gltf/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Basic_Shapes/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Basic_Shapes/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Filtering/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Filtering/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_JointTypes/index.html
+++ b/examples/rhodonite/havok/gltf_physics_JointTypes/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Materials_Friction/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Materials_Friction/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Materials_Restitution/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Materials_Restitution/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Motion_Properties/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Motion_Properties/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/gltf_physics_Triggers/index.html
+++ b/examples/rhodonite/havok/gltf_physics_Triggers/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/marbles/index.html
+++ b/examples/rhodonite/havok/marbles/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/minimum/index.html
+++ b/examples/rhodonite/havok/minimum/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/havok/shogi/index.html
+++ b/examples/rhodonite/havok/shogi/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/balls/index.html
+++ b/examples/rhodonite/oimo/balls/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/box/index.html
+++ b/examples/rhodonite/oimo/box/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/domino/index.html
+++ b/examples/rhodonite/oimo/domino/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/football/index.html
+++ b/examples/rhodonite/oimo/football/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/marbles/index.html
+++ b/examples/rhodonite/oimo/marbles/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/minimum/index.html
+++ b/examples/rhodonite/oimo/minimum/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>

--- a/examples/rhodonite/oimo/shogi/index.html
+++ b/examples/rhodonite/oimo/shogi/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
     "imports": {
-        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.8/esm/index.js"
+        "rhodonite": "https://cx20.github.io/gltf-test/libs/rhodonite/v0.19.9/esm/index.js"
     }
 }
 </script>


### PR DESCRIPTION
## Summary
Update the Rhodonite ESM CDN URL from `v0.19.8` to `v0.19.9` across all Rhodonite examples.

- `examples/rhodonite/havok/` — 18 files
- `examples/rhodonite/oimo/` — 7 files

25 files changed, one URL replacement each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)